### PR TITLE
Fix Unit test cases

### DIFF
--- a/ScipDotnet.Tests/Position.cs
+++ b/ScipDotnet.Tests/Position.cs
@@ -1,5 +1,3 @@
-using Scip;
-
 namespace ScipDotnet.Tests;
 
 public record Position(int Line, int Character) : IComparable<Position>

--- a/ScipDotnet.Tests/SnapshotTests.cs
+++ b/ScipDotnet.Tests/SnapshotTests.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Text;
 using DiffPlex.DiffBuilder;
 using DiffPlex.DiffBuilder.Model;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Scip;
 using Index = Scip.Index;
 

--- a/snapshots/input/syntax/Main/Expressions.cs
+++ b/snapshots/input/syntax/Main/Expressions.cs
@@ -243,7 +243,7 @@ public class Expressions
     {
         var a = (string x) => x + 1;
         var b = (Lambda a, Lambda b) => { return a.func(b); };
-        var c = string (Lambda a, Lambda _) => { return a; };
+        var c = string (Lambda a, Lambda _) => { return "hi"; };
     }
 
     void TupleExpressions()

--- a/snapshots/input/syntax/Main/Interfaces.cs
+++ b/snapshots/input/syntax/Main/Interfaces.cs
@@ -58,7 +58,7 @@ public class Interfaces
 
     public interface IGetNext<T> where T : IGetNext<T>
     {
-        static T operator ++(IGetNext<T> other)
+        static IGetNext<T> operator ++(IGetNext<T> other)
         {
             throw new NotImplementedException();
         }

--- a/snapshots/input/syntax/Main/Statements.cs
+++ b/snapshots/input/syntax/Main/Statements.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Net;
 
 namespace Main;
 

--- a/snapshots/output-net6.0/syntax/Main/Expressions.cs
+++ b/snapshots/output-net6.0/syntax/Main/Expressions.cs
@@ -614,7 +614,7 @@
 //                                                 ^ reference local 50
 //                                                   ^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#func().
 //                                                        ^ reference local 51
-          var c = string (Lambda a, Lambda _) => { return a; };
+          var c = string (Lambda a, Lambda _) => { return "hi"; };
 //            ^ definition local 52
 //              documentation ```cs\nFunc<Lambda, Lambda, string>? c\n```
 //                        ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#
@@ -623,7 +623,6 @@
 //                                  ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#
 //                                         ^ definition local 55
 //                                           documentation ```cs\nLambda _\n```
-//                                                        ^ reference local 54
       }
 
       void TupleExpressions()

--- a/snapshots/output-net6.0/syntax/Main/Interfaces.cs
+++ b/snapshots/output-net6.0/syntax/Main/Interfaces.cs
@@ -116,11 +116,11 @@
 //                                       ^ reference scip-dotnet nuget . . Main/Interfaces#IGetNext#[T]
 //                                                    ^ reference scip-dotnet nuget . . Main/Interfaces#IGetNext#[T]
       {
-          static T operator ++(IGetNext<T> other)
-//               ^ reference scip-dotnet nuget . . Main/Interfaces#IGetNext#[T]
-//                                      ^ reference scip-dotnet nuget . . Main/Interfaces#IGetNext#[T]
-//                                         ^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IGetNext#op_Increment().(other)
-//                                               documentation ```cs\nIGetNext<T> other\n```
+          static IGetNext<T> operator ++(IGetNext<T> other)
+//                        ^ reference scip-dotnet nuget . . Main/Interfaces#IGetNext#[T]
+//                                                ^ reference scip-dotnet nuget . . Main/Interfaces#IGetNext#[T]
+//                                                   ^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IGetNext#op_Increment().(other)
+//                                                         documentation ```cs\nIGetNext<T> other\n```
           {
               throw new NotImplementedException();
           }

--- a/snapshots/output-net6.0/syntax/Main/Statements.cs
+++ b/snapshots/output-net6.0/syntax/Main/Statements.cs
@@ -1,5 +1,4 @@
   using System.Diagnostics.CodeAnalysis;
-  using System.Net;
 
   namespace Main;
 //          ^^^^ reference scip-dotnet nuget . . Main/

--- a/snapshots/output-net7.0/syntax/Main/Expressions.cs
+++ b/snapshots/output-net7.0/syntax/Main/Expressions.cs
@@ -624,7 +624,7 @@
 //                                                 ^ reference local 50
 //                                                   ^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#func().
 //                                                        ^ reference local 51
-          var c = string (Lambda a, Lambda _) => { return a; };
+          var c = string (Lambda a, Lambda _) => { return "hi"; };
 //            ^ definition local 52
 //              documentation ```cs\nFunc<Lambda, Lambda, string>? c\n```
 //                        ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#
@@ -633,7 +633,6 @@
 //                                  ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#
 //                                         ^ definition local 55
 //                                           documentation ```cs\nLambda _\n```
-//                                                        ^ reference local 54
       }
 
       void TupleExpressions()

--- a/snapshots/output-net7.0/syntax/Main/Interfaces.cs
+++ b/snapshots/output-net7.0/syntax/Main/Interfaces.cs
@@ -122,11 +122,11 @@
 //                                       ^ reference scip-dotnet nuget . . Main/Interfaces#IGetNext#[T]
 //                                                    ^ reference scip-dotnet nuget . . Main/Interfaces#IGetNext#[T]
       {
-          static T operator ++(IGetNext<T> other)
-//               ^ reference scip-dotnet nuget . . Main/Interfaces#IGetNext#[T]
-//                                      ^ reference scip-dotnet nuget . . Main/Interfaces#IGetNext#[T]
-//                                         ^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IGetNext#op_Increment().(other)
-//                                               documentation ```cs\nIGetNext<T> other\n```
+          static IGetNext<T> operator ++(IGetNext<T> other)
+//                        ^ reference scip-dotnet nuget . . Main/Interfaces#IGetNext#[T]
+//                                                ^ reference scip-dotnet nuget . . Main/Interfaces#IGetNext#[T]
+//                                                   ^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IGetNext#op_Increment().(other)
+//                                                         documentation ```cs\nIGetNext<T> other\n```
           {
               throw new NotImplementedException();
 //                      ^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/NotImplementedException#

--- a/snapshots/output-net7.0/syntax/Main/Statements.cs
+++ b/snapshots/output-net7.0/syntax/Main/Statements.cs
@@ -2,9 +2,6 @@
 //      ^^^^^^ reference scip-dotnet nuget . . System/
 //             ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
 //                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
-  using System.Net;
-//      ^^^^^^ reference scip-dotnet nuget . . System/
-//             ^^^ reference scip-dotnet nuget . . Net/
 
   namespace Main;
 //          ^^^^ reference scip-dotnet nuget . . Main/


### PR DESCRIPTION
The syntax.sln had two compiler errors. I have fixed them and updated the expected output of the UTs.