### PR TITLE
Add Visual Basic support

### DIFF
--- a/ScipDotnet.Tests/SnapshotTests.cs
+++ b/ScipDotnet.Tests/SnapshotTests.cs
@@ -214,6 +214,7 @@ public class SnapshotTests
 
     private string FormatDocument(Index index, Document document)
     {
+        var commentChar = document.Language == "C#" ? "//" : "'";
         var sb = new StringBuilder();
         var inputPath = new Uri(index.Metadata.ProjectRoot + "/" + document.RelativePath).LocalPath;
         var occurrences = document.Occurrences.ToList();
@@ -237,7 +238,11 @@ public class SnapshotTests
                 var role = isDefinition ? "definition" : "reference";
                 var length = range.End.Character - range.Start.Character;
                 var indent = new String(' ', range.Start.Character);
-                sb.Append("//")
+                if (document.Language == "Visual Basic")
+                {
+                    indent+=" ";
+                }
+                sb.Append(commentChar)
                     .Append(indent)
                     .Append(new String('^', length))
                     .Append(' ')
@@ -248,7 +253,7 @@ public class SnapshotTests
                 if (isDefinition)
                 {
                     var info = symtab.GetValueOrDefault(occurrence.Symbol, new SymbolInformation());
-                    var prefix = "//" + indent + new String(' ', length + 1);
+                    var prefix = commentChar + indent + new String(' ', length + 1);
                     foreach (var documentation in info.Documentation)
                     {
                         sb.Append(prefix).Append("documentation ").AppendLine(documentation.Replace("\n", "\\n"));

--- a/ScipDotnet.Tests/SnapshotTests.cs
+++ b/ScipDotnet.Tests/SnapshotTests.cs
@@ -240,7 +240,7 @@ public class SnapshotTests
                 var indent = new String(' ', range.Start.Character);
                 if (document.Language == "Visual Basic")
                 {
-                    indent+=" ";
+                    indent += " ";
                 }
                 sb.Append(commentChar)
                     .Append(indent)

--- a/ScipDotnet.Tests/SnapshotTests.cs
+++ b/ScipDotnet.Tests/SnapshotTests.cs
@@ -277,8 +277,6 @@ public class SnapshotTests
         return sb.ToString();
     }
 
-    private static int CompareOccurrences(Occurrence a, Occurrence b)
-    {
-        return Range.FromOccurrence(a).CompareTo(Range.FromOccurrence(b));
-    }
+    private static int CompareOccurrences(Occurrence a, Occurrence b) =>
+        Range.FromOccurrence(a).CompareTo(Range.FromOccurrence(b));
 }

--- a/ScipDotnet/IndexCommandHandler.cs
+++ b/ScipDotnet/IndexCommandHandler.cs
@@ -47,7 +47,7 @@ public static class IndexCommandHandler
     private static async Task ScipIndex(IHost host, IndexCommandOptions options)
     {
         var stopwatch = Stopwatch.StartNew();
-        var indexer = host.Services.GetRequiredService<ScipIndexer>();
+        var indexer = host.Services.GetRequiredService<ScipProjectIndexer>();
         var index = new Scip.Index
         {
             Metadata = new Metadata

--- a/ScipDotnet/IndexCommandHandler.cs
+++ b/ScipDotnet/IndexCommandHandler.cs
@@ -74,7 +74,7 @@ public static class IndexCommandHandler
     private static string FixThisProblem(string examplePath)
     {
         return
-            "To fix this problem, pass the path of a solution (.sln) or project (.csproj) file to the `scip-dotnet index` command. " +
+            "To fix this problem, pass the path of a solution (.sln) or project (.csproj/.vbrpoj) file to the `scip-dotnet index` command. " +
             $"For example, run: scip-dotnet index {examplePath}";
     }
 
@@ -82,7 +82,8 @@ public static class IndexCommandHandler
     {
         var paths = Directory.GetFiles(workingDirectory.FullName).Where(file =>
             string.Equals(Path.GetExtension(file), ".sln", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(Path.GetExtension(file), ".csproj", StringComparison.OrdinalIgnoreCase)
+            string.Equals(Path.GetExtension(file), ".csproj", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(Path.GetExtension(file), ".vbproj", StringComparison.OrdinalIgnoreCase)
         ).ToList();
 
         if (paths.Count != 0)
@@ -91,7 +92,7 @@ public static class IndexCommandHandler
         }
 
         logger.LogError(
-            "No solution (.sln) or .csproj file detected in the working directory '{WorkingDirectory}'. {FixThis}",
+            "No solution (.sln) or .csproj/.vbproj file detected in the working directory '{WorkingDirectory}'. {FixThis}",
             workingDirectory.FullName, FixThisProblem("SOLUTION_FILE"));
         return new List<FileInfo>();
     }

--- a/ScipDotnet/IndexCommandHandler.cs
+++ b/ScipDotnet/IndexCommandHandler.cs
@@ -39,10 +39,8 @@ public static class IndexCommandHandler
         return 0;
     }
 
-    private static FileInfo OutputFile(FileInfo workingDirectory, string output)
-    {
-        return Path.IsPathRooted(output) ? new FileInfo(output) : new FileInfo(Path.Join(workingDirectory.FullName, output));
-    }
+    private static FileInfo OutputFile(FileInfo workingDirectory, string output) =>
+        Path.IsPathRooted(output) ? new FileInfo(output) : new FileInfo(Path.Join(workingDirectory.FullName, output));
 
     private static async Task ScipIndex(IHost host, IndexCommandOptions options)
     {
@@ -71,12 +69,9 @@ public static class IndexCommandHandler
             stopwatch.Elapsed.ToFriendlyString());
     }
 
-    private static string FixThisProblem(string examplePath)
-    {
-        return
-            "To fix this problem, pass the path of a solution (.sln) or project (.csproj/.vbrpoj) file to the `scip-dotnet index` command. " +
-            $"For example, run: scip-dotnet index {examplePath}";
-    }
+    private static string FixThisProblem(string examplePath) =>
+        "To fix this problem, pass the path of a solution (.sln) or project (.csproj/.vbrpoj) file to the `scip-dotnet index` command. " +
+        $"For example, run: scip-dotnet index {examplePath}";
 
     private static List<FileInfo> FindSolutionOrProjectFile(FileInfo workingDirectory, ILogger logger)
     {

--- a/ScipDotnet/Program.cs
+++ b/ScipDotnet/Program.cs
@@ -19,7 +19,7 @@ public static class Program
     {
         var indexCommand = new Command("index", "Index a solution file")
         {
-            new Argument<FileInfo>("projects", "Path to the .sln (solution) or .csproj file")
+            new Argument<FileInfo>("projects", "Path to the .sln (solution) or .csproj/.vbproj file")
                 { Arity = ArgumentArity.ZeroOrMore },
             new Option<string>("--output", () => "index.scip",
                 "Path to the output SCIP index file"),
@@ -43,7 +43,7 @@ public static class Program
         indexCommand.Handler = CommandHandler.Create(IndexCommandHandler.Process);
         var rootCommand =
             new RootCommand(
-                "SCIP indexer for the C# programming language. Built with the Roslyn .NET compiler. Supports MSBuild.")
+                "SCIP indexer for the C# and Visual basic programming languages. Built with the Roslyn .NET compiler. Supports MSBuild.")
             {
                 indexCommand,
             };

--- a/ScipDotnet/Program.cs
+++ b/ScipDotnet/Program.cs
@@ -60,7 +60,7 @@ public static class Program
                 host.ConfigureServices((_, collection) =>
                     collection
                         .AddSingleton(_ => CreateWorkspace())
-                        .AddTransient<ScipIndexer>()
+                        .AddTransient<ScipProjectIndexer>()
                         .AddTransient(services => (Workspace)services.GetRequiredService<MSBuildWorkspace>())
                 );
             })

--- a/ScipDotnet/ScipCSharpSyntaxWalker.cs
+++ b/ScipDotnet/ScipCSharpSyntaxWalker.cs
@@ -1,9 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.Extensions.Logging;
-using Scip;
-using Document = Scip.Document;
 
 namespace ScipDotnet;
 
@@ -12,75 +9,20 @@ namespace ScipDotnet;
 /// </summary>
 public class ScipCSharpSyntaxWalker : CSharpSyntaxWalker
 {
-    private readonly Document _doc;
     private readonly SemanticModel _semanticModel;
-    private readonly IndexCommandOptions _options;
-    private int _localCounter;
-    private readonly Dictionary<ISymbol, ScipSymbol> _globals;
-    private readonly Dictionary<ISymbol, ScipSymbol> _locals = new(SymbolEqualityComparer.Default);
+    private readonly ScipSymbolFormatter _scipSymbolFormatter;
 
-    // Custom formatting options to render symbol documentation. Feel free to tweak these parameters.
-    // The options were derived by multiple rounds of experimentation with the goal of striking a
-    // balance between showing detailed/accurate information without using too verbose syntax.
-    private readonly SymbolDisplayFormat _format = new(
-        globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.OmittedAsContaining,
-        typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameOnly,
-        genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters |
-                         SymbolDisplayGenericsOptions.IncludeVariance |
-                         SymbolDisplayGenericsOptions.IncludeTypeConstraints,
-        memberOptions: SymbolDisplayMemberOptions.IncludeAccessibility |
-                       SymbolDisplayMemberOptions.IncludeModifiers |
-                       SymbolDisplayMemberOptions.IncludeParameters |
-                       SymbolDisplayMemberOptions.IncludeRef |
-                       SymbolDisplayMemberOptions.IncludeType |
-                       SymbolDisplayMemberOptions.IncludeConstantValue |
-                       SymbolDisplayMemberOptions.IncludeContainingType |
-                       SymbolDisplayMemberOptions.IncludeExplicitInterface,
-        delegateStyle: SymbolDisplayDelegateStyle.NameAndSignature,
-        extensionMethodStyle: SymbolDisplayExtensionMethodStyle.InstanceMethod,
-        parameterOptions: SymbolDisplayParameterOptions.IncludeType |
-                          SymbolDisplayParameterOptions.IncludeName |
-                          SymbolDisplayParameterOptions.IncludeDefaultValue |
-                          SymbolDisplayParameterOptions.IncludeExtensionThis |
-                          SymbolDisplayParameterOptions.IncludeOptionalBrackets |
-                          SymbolDisplayParameterOptions.IncludeParamsRefOut,
-        propertyStyle: SymbolDisplayPropertyStyle.ShowReadWriteDescriptor,
-        localOptions: SymbolDisplayLocalOptions.IncludeType |
-                      SymbolDisplayLocalOptions.IncludeRef |
-                      SymbolDisplayLocalOptions.IncludeConstantValue,
-        kindOptions: SymbolDisplayKindOptions.IncludeTypeKeyword |
-                     SymbolDisplayKindOptions.IncludeMemberKeyword |
-                     SymbolDisplayKindOptions.IncludeNamespaceKeyword,
-        miscellaneousOptions: SymbolDisplayMiscellaneousOptions.AllowDefaultLiteral |
-                              SymbolDisplayMiscellaneousOptions.UseSpecialTypes |
-                              SymbolDisplayMiscellaneousOptions.UseAsterisksInMultiDimensionalArrays |
-                              SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier |
-                              SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers
-    );
-
-    public ScipCSharpSyntaxWalker(
-        Document doc,
-        SemanticModel semanticModel,
-        IndexCommandOptions options,
-        Dictionary<ISymbol, ScipSymbol> globals,
-        SyntaxWalkerDepth depth = SyntaxWalkerDepth.Node
-    ) : base(depth)
+    public ScipCSharpSyntaxWalker(ScipSymbolFormatter scipSymbolFormatter, SemanticModel semanticModel, SyntaxWalkerDepth depth = SyntaxWalkerDepth.Node) : base(depth)
     {
-        _doc = doc;
+        _scipSymbolFormatter = scipSymbolFormatter;
         _semanticModel = semanticModel;
-        _options = options;
-        _globals = globals;
     }
-
-    //-------------------------
-    // Overridden visit methods
-    //-------------------------
 
     public override void VisitIdentifierName(IdentifierNameSyntax node)
     {
         if (!node.IsVar)
         {
-            VisitOccurrence(_semanticModel.GetSymbolInfo(node).Symbol, node.GetLocation(), false);
+            _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetSymbolInfo(node).Symbol, node.GetLocation(), false);
         }
 
         base.VisitIdentifierName(node);
@@ -88,406 +30,93 @@ public class ScipCSharpSyntaxWalker : CSharpSyntaxWalker
 
     public override void VisitClassDeclaration(ClassDeclarationSyntax node)
     {
-        VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitClassDeclaration(node);
     }
 
     public override void VisitRecordDeclaration(RecordDeclarationSyntax node)
     {
-        VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitRecordDeclaration(node);
     }
 
     public override void VisitEnumDeclaration(EnumDeclarationSyntax node)
     {
-        VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitEnumDeclaration(node);
     }
 
     public override void VisitCatchDeclaration(CatchDeclarationSyntax node)
     {
-        VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitCatchDeclaration(node);
     }
 
     public override void VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
     {
-        VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitConstructorDeclaration(node);
     }
 
     public override void VisitDelegateDeclaration(DelegateDeclarationSyntax node)
     {
-        VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitDelegateDeclaration(node);
     }
 
     public override void VisitDestructorDeclaration(DestructorDeclarationSyntax node)
     {
-        VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitDestructorDeclaration(node);
     }
 
     public override void VisitEventDeclaration(EventDeclarationSyntax node)
     {
-        VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitEventDeclaration(node);
     }
 
     public override void VisitInterfaceDeclaration(InterfaceDeclarationSyntax node)
     {
-        VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitInterfaceDeclaration(node);
     }
 
     public override void VisitPropertyDeclaration(PropertyDeclarationSyntax node)
     {
-        VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitPropertyDeclaration(node);
     }
 
     public override void VisitStructDeclaration(StructDeclarationSyntax node)
     {
-        VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitStructDeclaration(node);
     }
 
 
     public override void VisitVariableDeclarator(VariableDeclaratorSyntax node)
     {
-        VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitVariableDeclarator(node);
     }
 
 
     public override void VisitEnumMemberDeclaration(EnumMemberDeclarationSyntax node)
     {
-        VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitEnumMemberDeclaration(node);
     }
 
     public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
     {
-        VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitMethodDeclaration(node);
     }
 
     public override void VisitParameter(ParameterSyntax node)
     {
-        VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitParameter(node);
-    }
-
-    //------------------
-    // Symbol formatting
-    //------------------
-
-
-    private ScipSymbol CreateScipSymbol(ISymbol? sym)
-    {
-        if (sym == null)
-        {
-            return ScipSymbol.Empty;
-        }
-
-        var fromCache = _globals.GetValueOrDefault(sym, ScipSymbol.Empty);
-        if (fromCache != ScipSymbol.Empty)
-        {
-            return fromCache;
-        }
-
-        if (IsLocalSymbol(sym))
-        {
-            return CreateLocalScipSymbol(sym);
-        }
-
-        var owner = sym.Kind == SymbolKind.Namespace
-            ? CreateScipPackageSymbol(sym)
-            : CreateScipSymbol(sym.ContainingSymbol);
-
-        if (owner.IsLocal())
-        {
-            return CreateLocalScipSymbol(sym);
-        }
-
-
-        var result = ScipSymbol.Global(owner, new SymbolDescriptor
-        {
-            Name = sym.Name,
-            Suffix = SymbolSuffix(sym),
-            Disambiguator = MethodDisambiguator(sym)
-        });
-        _globals.TryAdd(sym, result);
-        return result;
-    }
-
-
-    private ScipSymbol CreateLocalScipSymbol(ISymbol sym)
-    {
-        var local = _locals.GetValueOrDefault(sym, ScipSymbol.Empty);
-        if (local != ScipSymbol.Empty)
-        {
-            return local;
-        }
-
-        var localResult = ScipSymbol.Local(_localCounter++);
-        _locals.TryAdd(sym, localResult);
-        return localResult;
-    }
-
-    private ScipSymbol CreateScipPackageSymbol(ISymbol sym)
-    {
-        if (sym.ContainingAssembly == null)
-        {
-            return ScipSymbol.IndexLocalPackage;
-        }
-
-        if (!_options.AllowGlobalSymbolDefinitions && sym.Locations.Any(location => location.IsInSource))
-        {
-            // Emit index-local symbols to avoid exporting public symbols into the global scope (all repos in the world).
-            // We have no guarantee that a random csproj file from any random repository is publishing to NuGet.
-            // Use the command-line flag --allow-global-symbol-definitions to disable this behavior.
-            return ScipSymbol.IndexLocalPackage;
-        }
-
-
-        return ScipSymbol.Package(
-            sym.ContainingAssembly.Identity.Name,
-            sym.ContainingAssembly.Identity.Version.ToString());
-    }
-
-    private SymbolDescriptor.Types.Suffix SymbolSuffix(ISymbol sym)
-    {
-        switch (sym.Kind)
-        {
-            case SymbolKind.Namespace:
-                return SymbolDescriptor.Types.Suffix.Package;
-            case SymbolKind.NamedType:
-            case SymbolKind.FunctionPointerType:
-            case SymbolKind.ErrorType:
-            case SymbolKind.PointerType:
-            case SymbolKind.ArrayType:
-            case SymbolKind.DynamicType:
-            case SymbolKind.Alias:
-            case SymbolKind.Event:
-                return SymbolDescriptor.Types.Suffix.Type;
-            case SymbolKind.Property:
-            case SymbolKind.Field:
-            case SymbolKind.Assembly:
-            case SymbolKind.Label:
-            case SymbolKind.NetModule:
-            case SymbolKind.RangeVariable:
-            case SymbolKind.Preprocessing:
-            case SymbolKind.Discard:
-                return SymbolDescriptor.Types.Suffix.Term;
-            case SymbolKind.Method:
-                return SymbolDescriptor.Types.Suffix.Method;
-            case SymbolKind.Parameter:
-                return SymbolDescriptor.Types.Suffix.Parameter;
-            case SymbolKind.TypeParameter:
-                return SymbolDescriptor.Types.Suffix.TypeParameter;
-            case SymbolKind.Local:
-                return SymbolDescriptor.Types.Suffix.Local;
-            default:
-                _options.Logger.LogWarning("unknown symbol kind {SymKind}", sym.Kind);
-                return SymbolDescriptor.Types.Suffix.Meta;
-        }
-    }
-
-    private static string MethodDisambiguator(ISymbol sym)
-    {
-        if (sym is not IMethodSymbol)
-        {
-            return "";
-        }
-
-        var overloadCount = 0;
-        foreach (var member in sym.ContainingType.GetMembers())
-        {
-            if (member.Equals(sym, SymbolEqualityComparer.Default))
-            {
-                return overloadCount == 0 ? "" : $"+{overloadCount}";
-            }
-
-            if (member.Name.Equals(sym.Name))
-            {
-                overloadCount++;
-            }
-        }
-
-        return "";
-    }
-
-    private readonly string[] _isIgnoredRelationshipSymbol =
-    {
-        " System/Object#",
-        " System/Enum#",
-        " System/ValueType#",
-    };
-
-    // Returns true if this symbol should not be emitted as a SymbolInformation relationship symbol.
-    // The reason we ignore these symbols is because they appear automatically for a large number of
-    // symbols putting pressure on our backend to index the inverted index. It's not particularly useful anyways
-    // to query all the implementations of something like System/Object#.
-    private bool IsIgnoredRelationshipSymbol(string symbol)
-    {
-        return _isIgnoredRelationshipSymbol.Any(symbol.EndsWith);
-    }
-
-
-    private void VisitOccurrence(ISymbol? symbol, Location location, bool isDefinition)
-    {
-        if (symbol == null)
-        {
-            return;
-        }
-
-        var symbolRole = 0;
-        if (isDefinition)
-        {
-            symbolRole |= (int)SymbolRole.Definition;
-        }
-
-        var scipSymbol = CreateScipSymbol(symbol).Value;
-        var occurrence = new Occurrence
-        {
-            Symbol = scipSymbol,
-            SymbolRoles = symbolRole
-        };
-        _doc.Occurrences.Add(occurrence);
-        foreach (var range in LocationToRange(location))
-        {
-            occurrence.Range.Add(range);
-        }
-
-        if (!isDefinition) return;
-
-        // Emit SymbolInformation for this definition occurrence.
-        var info = new SymbolInformation { Symbol = scipSymbol };
-        _doc.Symbols.Add(info);
-
-        var symbolSignature = symbol.ToDisplayString(_format);
-        if (symbolSignature.Length > 0)
-        {
-            info.Documentation.Add("```cs\n" + symbolSignature + "\n```");
-        }
-
-        var symbolDocumentation = symbol.GetDocumentationCommentXml();
-        if (symbolDocumentation?.Length > 0)
-        {
-            info.Documentation.Add(symbolDocumentation);
-        }
-
-        switch (symbol)
-        {
-            case INamedTypeSymbol namedTypeSymbol:
-                {
-                    var baseType = namedTypeSymbol.BaseType;
-                    while (baseType != null)
-                    {
-                        var baseTypeSymbol = CreateScipSymbol(baseType).Value;
-                        if (IsIgnoredRelationshipSymbol(baseTypeSymbol))
-                        {
-                            break;
-                        }
-
-                        info.Relationships.Add(new Relationship
-                        {
-                            Symbol = baseTypeSymbol,
-                            IsImplementation = true
-                        });
-                        baseType = baseType.BaseType;
-                    }
-
-                    foreach (var interfaceSymbol in namedTypeSymbol.AllInterfaces)
-                    {
-                        var interfaceSymbolSymbol = CreateScipSymbol(interfaceSymbol).Value;
-                        if (IsIgnoredRelationshipSymbol(interfaceSymbolSymbol))
-                        {
-                            continue;
-                        }
-
-                        info.Relationships.Add(new Relationship
-                        {
-                            Symbol = interfaceSymbolSymbol,
-                            IsImplementation = true
-                        });
-                    }
-
-                    break;
-                }
-            case IMethodSymbol methodSymbol:
-                {
-                    var overriddenMethod = methodSymbol.OverriddenMethod;
-                    while (overriddenMethod != null)
-                    {
-                        info.Relationships.Add(new Relationship
-                        {
-                            Symbol = CreateScipSymbol(overriddenMethod).Value,
-                            IsImplementation = true,
-                            IsReference = true
-                        });
-                        overriddenMethod = overriddenMethod.OverriddenMethod;
-                    }
-
-                    foreach (var interfaceMethod in InterfaceImplementations(methodSymbol))
-                    {
-                        info.Relationships.Add(new Relationship
-                        {
-                            Symbol = CreateScipSymbol(interfaceMethod).Value,
-                            IsImplementation = true,
-                            IsReference = true
-                        });
-                    }
-
-                    break;
-                }
-        }
-    }
-
-
-    // Returns explicitly and implicitly implemented interface methods by the given symbol method.
-    // The Roslyn API has a `ExplicitInterfaceImplementations` that does not return implicitly implemented
-    // methods.
-    private IEnumerable<ISymbol> InterfaceImplementations(IMethodSymbol symbol)
-    {
-        foreach (var interfaceSymbol in symbol.ContainingType.AllInterfaces)
-        {
-            foreach (var interfaceMember in interfaceSymbol.GetMembers())
-            {
-                var implementation = symbol.ContainingType.FindImplementationForInterfaceMember(interfaceMember);
-                if (implementation != null && symbol.Equals(implementation, SymbolEqualityComparer.Default))
-                {
-                    yield return interfaceMember;
-                }
-            }
-        }
-    }
-
-
-    // Converts a Roslyn location into a SCIP range.
-    private static IEnumerable<int> LocationToRange(Location location)
-    {
-        var span = location.GetMappedLineSpan();
-        if (span.StartLinePosition.Line == span.EndLinePosition.Line)
-        {
-            return new[]
-                { span.StartLinePosition.Line, span.StartLinePosition.Character, span.EndLinePosition.Character };
-        }
-
-        return new[]
-        {
-            span.StartLinePosition.Line, span.StartLinePosition.Character, span.EndLinePosition.Line,
-            span.EndLinePosition.Character
-        };
-    }
-
-    private static bool IsLocalSymbol(ISymbol sym)
-    {
-        return sym.Kind == SymbolKind.Local ||
-               // Anonymous classes/methods have empty names and can not be accessed outside their file.
-               // The "global namespace" (parent of all namespaces) also has an empty name and should not
-               // be treated as a local variable.
-               (sym.Name.Equals("") && sym.Kind != SymbolKind.Namespace);
     }
 }

--- a/ScipDotnet/ScipCSharpSyntaxWalker.cs
+++ b/ScipDotnet/ScipCSharpSyntaxWalker.cs
@@ -10,11 +10,11 @@ namespace ScipDotnet;
 public class ScipCSharpSyntaxWalker : CSharpSyntaxWalker
 {
     private readonly SemanticModel _semanticModel;
-    private readonly ScipSymbolFormatter _scipSymbolFormatter;
+    private readonly ScipDocumentIndexer _scipDocumentIndexer;
 
-    public ScipCSharpSyntaxWalker(ScipSymbolFormatter scipSymbolFormatter, SemanticModel semanticModel, SyntaxWalkerDepth depth = SyntaxWalkerDepth.Node) : base(depth)
+    public ScipCSharpSyntaxWalker(ScipDocumentIndexer scipSymbolFormatter, SemanticModel semanticModel, SyntaxWalkerDepth depth = SyntaxWalkerDepth.Node) : base(depth)
     {
-        _scipSymbolFormatter = scipSymbolFormatter;
+        _scipDocumentIndexer = scipSymbolFormatter;
         _semanticModel = semanticModel;
     }
 
@@ -22,7 +22,7 @@ public class ScipCSharpSyntaxWalker : CSharpSyntaxWalker
     {
         if (!node.IsVar)
         {
-            _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetSymbolInfo(node).Symbol, node.GetLocation(), false);
+            _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetSymbolInfo(node).Symbol, node.GetLocation(), false);
         }
 
         base.VisitIdentifierName(node);
@@ -30,93 +30,93 @@ public class ScipCSharpSyntaxWalker : CSharpSyntaxWalker
 
     public override void VisitClassDeclaration(ClassDeclarationSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitClassDeclaration(node);
     }
 
     public override void VisitRecordDeclaration(RecordDeclarationSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitRecordDeclaration(node);
     }
 
     public override void VisitEnumDeclaration(EnumDeclarationSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitEnumDeclaration(node);
     }
 
     public override void VisitCatchDeclaration(CatchDeclarationSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitCatchDeclaration(node);
     }
 
     public override void VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitConstructorDeclaration(node);
     }
 
     public override void VisitDelegateDeclaration(DelegateDeclarationSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitDelegateDeclaration(node);
     }
 
     public override void VisitDestructorDeclaration(DestructorDeclarationSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitDestructorDeclaration(node);
     }
 
     public override void VisitEventDeclaration(EventDeclarationSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitEventDeclaration(node);
     }
 
     public override void VisitInterfaceDeclaration(InterfaceDeclarationSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitInterfaceDeclaration(node);
     }
 
     public override void VisitPropertyDeclaration(PropertyDeclarationSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitPropertyDeclaration(node);
     }
 
     public override void VisitStructDeclaration(StructDeclarationSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitStructDeclaration(node);
     }
 
 
     public override void VisitVariableDeclarator(VariableDeclaratorSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitVariableDeclarator(node);
     }
 
 
     public override void VisitEnumMemberDeclaration(EnumMemberDeclarationSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitEnumMemberDeclaration(node);
     }
 
     public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitMethodDeclaration(node);
     }
 
     public override void VisitParameter(ParameterSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitParameter(node);
     }
 }

--- a/ScipDotnet/ScipDocumentIndexer.cs
+++ b/ScipDotnet/ScipDocumentIndexer.cs
@@ -94,7 +94,6 @@ public class ScipDocumentIndexer
             return CreateLocalScipSymbol(sym);
         }
 
-
         var result = ScipSymbol.Global(owner, new SymbolDescriptor
         {
             Name = sym.Name,
@@ -133,7 +132,6 @@ public class ScipDocumentIndexer
             // Use the command-line flag --allow-global-symbol-definitions to disable this behavior.
             return ScipSymbol.IndexLocalPackage;
         }
-
 
         return ScipSymbol.Package(
             sym.ContainingAssembly.Identity.Name,

--- a/ScipDotnet/ScipDocumentIndexer.cs
+++ b/ScipDotnet/ScipDocumentIndexer.cs
@@ -8,14 +8,14 @@ namespace ScipDotnet;
 /// <summary>
 /// Creates SCIP <code>Document</code> based on provided symbols.
 /// </summary>
-public class ScipSymbolFormatter
+public class ScipDocumentIndexer
 {
     private readonly Document _doc;
     private readonly IndexCommandOptions _options;
     private int _localCounter;
     private readonly Dictionary<ISymbol, ScipSymbol> _globals;
     private readonly Dictionary<ISymbol, ScipSymbol> _locals = new(SymbolEqualityComparer.Default);
-    private readonly string _languagePrefix;
+    private readonly string _markdownCodeFenceLanguage;
 
     // Custom formatting options to render symbol documentation. Feel free to tweak these parameters.
     // The options were derived by multiple rounds of experimentation with the goal of striking a
@@ -56,7 +56,7 @@ public class ScipSymbolFormatter
                               SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers
     );
 
-    public ScipSymbolFormatter(
+    public ScipDocumentIndexer(
         Document doc,
         IndexCommandOptions options,
         Dictionary<ISymbol, ScipSymbol> globals)
@@ -64,7 +64,7 @@ public class ScipSymbolFormatter
         _doc = doc;
         _options = options;
         _globals = globals;
-        _languagePrefix = _doc.Language == "C#" ? "cs" : "vb";
+        _markdownCodeFenceLanguage = _doc.Language == "C#" ? "cs" : "vb";
     }
 
     private ScipSymbol CreateScipSymbol(ISymbol? sym)
@@ -252,7 +252,7 @@ public class ScipSymbolFormatter
         var symbolSignature = symbol.ToDisplayString(_format);
         if (symbolSignature.Length > 0)
         {
-            info.Documentation.Add($"```{_languagePrefix}\n{symbolSignature}\n```");
+            info.Documentation.Add($"```{_markdownCodeFenceLanguage}\n{symbolSignature}\n```");
         }
 
         var symbolDocumentation = symbol.GetDocumentationCommentXml();
@@ -313,7 +313,7 @@ public class ScipSymbolFormatter
                         overriddenMethod = overriddenMethod.OverriddenMethod;
                     }
 
-                    foreach (var interfaceMethod in ScipSymbolFormatter.InterfaceImplementations(methodSymbol))
+                    foreach (var interfaceMethod in ScipDocumentIndexer.InterfaceImplementations(methodSymbol))
                     {
                         info.Relationships.Add(new Relationship
                         {

--- a/ScipDotnet/ScipProjectIndexer.cs
+++ b/ScipDotnet/ScipProjectIndexer.cs
@@ -11,14 +11,14 @@ namespace ScipDotnet;
 /// <summary>
 /// Orchestrates Roslyn and MSBuild APIs to SCIP index a given project.
 /// </summary>
-public class ScipIndexer
+public class ScipProjectIndexer
 {
     private const int DotnetRestoreTimeout = 3000;
+    public ScipProjectIndexer(ILogger<ScipProjectIndexer> logger) => 
 
-    public ScipIndexer(ILogger<ScipIndexer> logger) => 
         Logger = logger;
 
-    private ILogger<ScipIndexer> Logger { get; }
+    private ILogger<ScipProjectIndexer> Logger { get; }
 
     private static void Restore(IndexCommandOptions options, FileInfo project)
     {
@@ -120,14 +120,14 @@ public class ScipIndexer
         }
         else
         {
-            var symbolFormatter = new ScipSymbolFormatter(doc, options, globals);
+            var symbolFormatter = new ScipDocumentIndexer(doc, options, globals);
             var root = await document.GetSyntaxRootAsync();
             if (language == "C#")
             {
                 var walker = new ScipCSharpSyntaxWalker(symbolFormatter, semanticModel);
                 walker.Visit(root);
             }
-            else
+            else if (language == "Visual Basic")
             {
                 var walker = new ScipVisualBasicSyntaxWalker(symbolFormatter, semanticModel);
                 walker.Visit(root);

--- a/ScipDotnet/ScipProjectIndexer.cs
+++ b/ScipDotnet/ScipProjectIndexer.cs
@@ -14,7 +14,7 @@ namespace ScipDotnet;
 public class ScipProjectIndexer
 {
     private const int DotnetRestoreTimeout = 3000;
-    public ScipProjectIndexer(ILogger<ScipProjectIndexer> logger) => 
+    public ScipProjectIndexer(ILogger<ScipProjectIndexer> logger) =>
 
         Logger = logger;
 

--- a/ScipDotnet/ScipProjectIndexer.cs
+++ b/ScipDotnet/ScipProjectIndexer.cs
@@ -55,7 +55,7 @@ public class ScipProjectIndexer
                                                                HashSet<ProjectId> indexedProjects)
     {
         Restore(options, rootProject);
-        IEnumerable<Project> projects = string.Equals(rootProject.Extension, ".csproj")
+        IEnumerable<Project> projects = string.Equals(rootProject.Extension, ".csproj") || string.Equals(rootProject.Extension, ".vbproj")
             ? new[]
             {
                 await host.Services.GetRequiredService<MSBuildWorkspace>()

--- a/ScipDotnet/ScipProjectIndexer.cs
+++ b/ScipDotnet/ScipProjectIndexer.cs
@@ -14,8 +14,8 @@ namespace ScipDotnet;
 public class ScipProjectIndexer
 {
     private const int DotnetRestoreTimeout = 3000;
-    public ScipProjectIndexer(ILogger<ScipProjectIndexer> logger) =>
 
+    public ScipProjectIndexer(ILogger<ScipProjectIndexer> logger) =>
         Logger = logger;
 
     private ILogger<ScipProjectIndexer> Logger { get; }

--- a/ScipDotnet/ScipSymbol.cs
+++ b/ScipDotnet/ScipSymbol.cs
@@ -10,43 +10,31 @@ public class ScipSymbol
 {
     public string Value { get; }
 
-    private ScipSymbol(string value)
-    {
+    private ScipSymbol(string value) => 
         Value = value;
-    }
 
-    public bool IsLocal()
-    {
-        return Value.StartsWith("local ");
-    }
+    public bool IsLocal() =>
+        Value.StartsWith("local ");
 
-    public static ScipSymbol Global(ScipSymbol owner, SymbolDescriptor descriptor)
-    {
-        return new ScipSymbol(owner.Value + DescriptorString(descriptor));
-    }
+    public static ScipSymbol Global(ScipSymbol owner, SymbolDescriptor descriptor) =>
+        new(owner.Value + DescriptorString(descriptor));
 
-
-    public static ScipSymbol Local(int counter)
-    {
-        return new ScipSymbol("local " + counter);
-    }
+    public static ScipSymbol Local(int counter) =>
+        new("local " + counter);
 
     public static readonly ScipSymbol Empty = new("");
     public static readonly ScipSymbol IndexLocalPackage = Package(".", ".");
 
-    public static ScipSymbol Package(string name, string version)
-    {
-        return new ScipSymbol(
+    public static ScipSymbol Package(string name, string version) => 
+        new(
             "scip-dotnet nuget " +
             // SCIP package names and versions should use double-space to escape space characters.
             name.Replace(" ", "  ") + " " +
             version.Replace(" ", "  ") + " "
         );
-    }
 
-    private static string DescriptorString(SymbolDescriptor desc)
-    {
-        return desc.Suffix switch
+    private static string DescriptorString(SymbolDescriptor desc) => 
+        desc.Suffix switch
         {
             SymbolDescriptor.Types.Suffix.Package => EscapedName(desc) + '/',
             SymbolDescriptor.Types.Suffix.Type => EscapedName(desc) + '#',
@@ -58,7 +46,6 @@ public class ScipSymbol
             SymbolDescriptor.Types.Suffix.Local => "local" + EscapedName(desc),
             _ => throw new ArgumentException("unexpected descriptor suffix: " + desc.Suffix)
         };
-    }
 
     private static string EscapedName(SymbolDescriptor desc)
     {
@@ -75,8 +62,6 @@ public class ScipSymbol
         return "`" + desc.Name.Replace("`", "``") + "`";
     }
 
-    private static bool IsSimpleIdentifier(string name)
-    {
-        return Regex.IsMatch(name, @"^[\w$+-]+$", RegexOptions.IgnoreCase);
-    }
+    private static bool IsSimpleIdentifier(string name) =>
+        Regex.IsMatch(name, @"^[\w$+-]+$", RegexOptions.IgnoreCase);
 }

--- a/ScipDotnet/ScipSymbol.cs
+++ b/ScipDotnet/ScipSymbol.cs
@@ -10,7 +10,7 @@ public class ScipSymbol
 {
     public string Value { get; }
 
-    private ScipSymbol(string value) => 
+    private ScipSymbol(string value) =>
         Value = value;
 
     public bool IsLocal() =>
@@ -25,7 +25,7 @@ public class ScipSymbol
     public static readonly ScipSymbol Empty = new("");
     public static readonly ScipSymbol IndexLocalPackage = Package(".", ".");
 
-    public static ScipSymbol Package(string name, string version) => 
+    public static ScipSymbol Package(string name, string version) =>
         new(
             "scip-dotnet nuget " +
             // SCIP package names and versions should use double-space to escape space characters.
@@ -33,7 +33,7 @@ public class ScipSymbol
             version.Replace(" ", "  ") + " "
         );
 
-    private static string DescriptorString(SymbolDescriptor desc) => 
+    private static string DescriptorString(SymbolDescriptor desc) =>
         desc.Suffix switch
         {
             SymbolDescriptor.Types.Suffix.Package => EscapedName(desc) + '/',

--- a/ScipDotnet/ScipSymbolFormatter.cs
+++ b/ScipDotnet/ScipSymbolFormatter.cs
@@ -1,0 +1,376 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+using Scip;
+using Document = Scip.Document;
+
+namespace ScipDotnet;
+
+/// <summary>
+/// Creates SCIP <code>Document</code> based on provided symbols.
+/// </summary>
+public class ScipSymbolFormatter
+{
+    private readonly Document _doc;
+    private readonly IndexCommandOptions _options;
+    private int _localCounter;
+    private readonly Dictionary<ISymbol, ScipSymbol> _globals;
+    private readonly Dictionary<ISymbol, ScipSymbol> _locals = new(SymbolEqualityComparer.Default);
+    private readonly string _languagePrefix;
+
+    // Custom formatting options to render symbol documentation. Feel free to tweak these parameters.
+    // The options were derived by multiple rounds of experimentation with the goal of striking a
+    // balance between showing detailed/accurate information without using too verbose syntax.
+    private readonly SymbolDisplayFormat _format = new(
+        globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.OmittedAsContaining,
+        typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameOnly,
+        genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters |
+                         SymbolDisplayGenericsOptions.IncludeVariance |
+                         SymbolDisplayGenericsOptions.IncludeTypeConstraints,
+        memberOptions: SymbolDisplayMemberOptions.IncludeAccessibility |
+                       SymbolDisplayMemberOptions.IncludeModifiers |
+                       SymbolDisplayMemberOptions.IncludeParameters |
+                       SymbolDisplayMemberOptions.IncludeRef |
+                       SymbolDisplayMemberOptions.IncludeType |
+                       SymbolDisplayMemberOptions.IncludeConstantValue |
+                       SymbolDisplayMemberOptions.IncludeContainingType |
+                       SymbolDisplayMemberOptions.IncludeExplicitInterface,
+        delegateStyle: SymbolDisplayDelegateStyle.NameAndSignature,
+        extensionMethodStyle: SymbolDisplayExtensionMethodStyle.InstanceMethod,
+        parameterOptions: SymbolDisplayParameterOptions.IncludeType |
+                          SymbolDisplayParameterOptions.IncludeName |
+                          SymbolDisplayParameterOptions.IncludeDefaultValue |
+                          SymbolDisplayParameterOptions.IncludeExtensionThis |
+                          SymbolDisplayParameterOptions.IncludeOptionalBrackets |
+                          SymbolDisplayParameterOptions.IncludeParamsRefOut,
+        propertyStyle: SymbolDisplayPropertyStyle.ShowReadWriteDescriptor,
+        localOptions: SymbolDisplayLocalOptions.IncludeType |
+                      SymbolDisplayLocalOptions.IncludeRef |
+                      SymbolDisplayLocalOptions.IncludeConstantValue,
+        kindOptions: SymbolDisplayKindOptions.IncludeTypeKeyword |
+                     SymbolDisplayKindOptions.IncludeMemberKeyword |
+                     SymbolDisplayKindOptions.IncludeNamespaceKeyword,
+        miscellaneousOptions: SymbolDisplayMiscellaneousOptions.AllowDefaultLiteral |
+                              SymbolDisplayMiscellaneousOptions.UseSpecialTypes |
+                              SymbolDisplayMiscellaneousOptions.UseAsterisksInMultiDimensionalArrays |
+                              SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier |
+                              SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers
+    );
+
+    public ScipSymbolFormatter(
+        Document doc,
+        IndexCommandOptions options,
+        Dictionary<ISymbol, ScipSymbol> globals)
+    {
+        _doc = doc;
+        _options = options;
+        _globals = globals;
+        _languagePrefix = _doc.Language == "C#" ? "cs" : "vb";
+    }
+
+    private ScipSymbol CreateScipSymbol(ISymbol? sym)
+    {
+        if (sym == null)
+        {
+            return ScipSymbol.Empty;
+        }
+
+        var fromCache = _globals.GetValueOrDefault(sym, ScipSymbol.Empty);
+        if (fromCache != ScipSymbol.Empty)
+        {
+            return fromCache;
+        }
+
+        if (IsLocalSymbol(sym))
+        {
+            return CreateLocalScipSymbol(sym);
+        }
+
+        var owner = sym.Kind == SymbolKind.Namespace
+            ? CreateScipPackageSymbol(sym)
+            : CreateScipSymbol(sym.ContainingSymbol);
+
+        if (owner.IsLocal())
+        {
+            return CreateLocalScipSymbol(sym);
+        }
+
+
+        var result = ScipSymbol.Global(owner, new SymbolDescriptor
+        {
+            Name = sym.Name,
+            Suffix = SymbolSuffix(sym),
+            Disambiguator = MethodDisambiguator(sym)
+        });
+        _globals.TryAdd(sym, result);
+        return result;
+    }
+
+
+    private ScipSymbol CreateLocalScipSymbol(ISymbol sym)
+    {
+        var local = _locals.GetValueOrDefault(sym, ScipSymbol.Empty);
+        if (local != ScipSymbol.Empty)
+        {
+            return local;
+        }
+
+        var localResult = ScipSymbol.Local(_localCounter++);
+        _locals.TryAdd(sym, localResult);
+        return localResult;
+    }
+
+    private ScipSymbol CreateScipPackageSymbol(ISymbol sym)
+    {
+        if (sym.ContainingAssembly == null)
+        {
+            return ScipSymbol.IndexLocalPackage;
+        }
+
+        if (!_options.AllowGlobalSymbolDefinitions && sym.Locations.Any(location => location.IsInSource))
+        {
+            // Emit index-local symbols to avoid exporting public symbols into the global scope (all repos in the world).
+            // We have no guarantee that a random csproj file from any random repository is publishing to NuGet.
+            // Use the command-line flag --allow-global-symbol-definitions to disable this behavior.
+            return ScipSymbol.IndexLocalPackage;
+        }
+
+
+        return ScipSymbol.Package(
+            sym.ContainingAssembly.Identity.Name,
+            sym.ContainingAssembly.Identity.Version.ToString());
+    }
+
+    private SymbolDescriptor.Types.Suffix SymbolSuffix(ISymbol sym)
+    {
+        switch (sym.Kind)
+        {
+            case SymbolKind.Namespace:
+                return SymbolDescriptor.Types.Suffix.Package;
+            case SymbolKind.NamedType:
+            case SymbolKind.FunctionPointerType:
+            case SymbolKind.ErrorType:
+            case SymbolKind.PointerType:
+            case SymbolKind.ArrayType:
+            case SymbolKind.DynamicType:
+            case SymbolKind.Alias:
+            case SymbolKind.Event:
+                return SymbolDescriptor.Types.Suffix.Type;
+            case SymbolKind.Property:
+            case SymbolKind.Field:
+            case SymbolKind.Assembly:
+            case SymbolKind.Label:
+            case SymbolKind.NetModule:
+            case SymbolKind.RangeVariable:
+            case SymbolKind.Preprocessing:
+            case SymbolKind.Discard:
+                return SymbolDescriptor.Types.Suffix.Term;
+            case SymbolKind.Method:
+                return SymbolDescriptor.Types.Suffix.Method;
+            case SymbolKind.Parameter:
+                return SymbolDescriptor.Types.Suffix.Parameter;
+            case SymbolKind.TypeParameter:
+                return SymbolDescriptor.Types.Suffix.TypeParameter;
+            case SymbolKind.Local:
+                return SymbolDescriptor.Types.Suffix.Local;
+            default:
+                _options.Logger.LogWarning("unknown symbol kind {SymKind}", sym.Kind);
+                return SymbolDescriptor.Types.Suffix.Meta;
+        }
+    }
+
+    private static string MethodDisambiguator(ISymbol sym)
+    {
+        if (sym is not IMethodSymbol)
+        {
+            return "";
+        }
+
+        var overloadCount = 0;
+        foreach (var member in sym.ContainingType.GetMembers())
+        {
+            if (member.Equals(sym, SymbolEqualityComparer.Default))
+            {
+                return overloadCount == 0 ? "" : $"+{overloadCount}";
+            }
+
+            if (member.Name.Equals(sym.Name))
+            {
+                overloadCount++;
+            }
+        }
+
+        return "";
+    }
+
+    private readonly string[] _isIgnoredRelationshipSymbol =
+    {
+    " System/Object#",
+    " System/Enum#",
+    " System/ValueType#",
+};
+
+    // Returns true if this symbol should not be emitted as a SymbolInformation relationship symbol.
+    // The reason we ignore these symbols is because they appear automatically for a large number of
+    // symbols putting pressure on our backend to index the inverted index. It's not particularly useful anyways
+    // to query all the implementations of something like System/Object#.
+    private bool IsIgnoredRelationshipSymbol(string symbol)
+    {
+        return _isIgnoredRelationshipSymbol.Any(symbol.EndsWith);
+    }
+
+    public void VisitOccurrence(ISymbol? symbol, Location location, bool isDefinition)
+    {
+        if (symbol == null)
+        {
+            return;
+        }
+
+        var symbolRole = 0;
+        if (isDefinition)
+        {
+            symbolRole |= (int)SymbolRole.Definition;
+        }
+
+        var scipSymbol = CreateScipSymbol(symbol).Value;
+        var occurrence = new Occurrence
+        {
+            Symbol = scipSymbol,
+            SymbolRoles = symbolRole
+        };
+        _doc.Occurrences.Add(occurrence);
+        foreach (var range in LocationToRange(location))
+        {
+            occurrence.Range.Add(range);
+        }
+
+        if (!isDefinition) return;
+
+        // Emit SymbolInformation for this definition occurrence.
+        var info = new SymbolInformation { Symbol = scipSymbol };
+        _doc.Symbols.Add(info);
+
+        var symbolSignature = symbol.ToDisplayString(_format);
+        if (symbolSignature.Length > 0)
+        {
+            info.Documentation.Add($"```{_languagePrefix}\n{symbolSignature}\n```");
+        }
+
+        var symbolDocumentation = symbol.GetDocumentationCommentXml();
+        if (symbolDocumentation?.Length > 0)
+        {
+            info.Documentation.Add(symbolDocumentation);
+        }
+
+        switch (symbol)
+        {
+            case INamedTypeSymbol namedTypeSymbol:
+                {
+                    var baseType = namedTypeSymbol.BaseType;
+                    while (baseType != null)
+                    {
+                        var baseTypeSymbol = CreateScipSymbol(baseType).Value;
+                        if (IsIgnoredRelationshipSymbol(baseTypeSymbol))
+                        {
+                            break;
+                        }
+
+                        info.Relationships.Add(new Relationship
+                        {
+                            Symbol = baseTypeSymbol,
+                            IsImplementation = true
+                        });
+                        baseType = baseType.BaseType;
+                    }
+
+                    foreach (var interfaceSymbol in namedTypeSymbol.AllInterfaces)
+                    {
+                        var interfaceSymbolSymbol = CreateScipSymbol(interfaceSymbol).Value;
+                        if (IsIgnoredRelationshipSymbol(interfaceSymbolSymbol))
+                        {
+                            continue;
+                        }
+
+                        info.Relationships.Add(new Relationship
+                        {
+                            Symbol = interfaceSymbolSymbol,
+                            IsImplementation = true
+                        });
+                    }
+
+                    break;
+                }
+            case IMethodSymbol methodSymbol:
+                {
+                    var overriddenMethod = methodSymbol.OverriddenMethod;
+                    while (overriddenMethod != null)
+                    {
+                        info.Relationships.Add(new Relationship
+                        {
+                            Symbol = CreateScipSymbol(overriddenMethod).Value,
+                            IsImplementation = true,
+                            IsReference = true
+                        });
+                        overriddenMethod = overriddenMethod.OverriddenMethod;
+                    }
+
+                    foreach (var interfaceMethod in ScipSymbolFormatter.InterfaceImplementations(methodSymbol))
+                    {
+                        info.Relationships.Add(new Relationship
+                        {
+                            Symbol = CreateScipSymbol(interfaceMethod).Value,
+                            IsImplementation = true,
+                            IsReference = true
+                        });
+                    }
+
+                    break;
+                }
+        }
+    }
+
+
+    // Returns explicitly and implicitly implemented interface methods by the given symbol method.
+    // The Roslyn API has a `ExplicitInterfaceImplementations` that does not return implicitly implemented
+    // methods.
+    private static IEnumerable<ISymbol> InterfaceImplementations(IMethodSymbol symbol)
+    {
+        foreach (var interfaceSymbol in symbol.ContainingType.AllInterfaces)
+        {
+            foreach (var interfaceMember in interfaceSymbol.GetMembers())
+            {
+                var implementation = symbol.ContainingType.FindImplementationForInterfaceMember(interfaceMember);
+                if (implementation != null && symbol.Equals(implementation, SymbolEqualityComparer.Default))
+                {
+                    yield return interfaceMember;
+                }
+            }
+        }
+    }
+
+
+    // Converts a Roslyn location into a SCIP range.
+    private static IEnumerable<int> LocationToRange(Location location)
+    {
+        var span = location.GetMappedLineSpan();
+        if (span.StartLinePosition.Line == span.EndLinePosition.Line)
+        {
+            return new[]
+                { span.StartLinePosition.Line, span.StartLinePosition.Character, span.EndLinePosition.Character };
+        }
+
+        return new[]
+        {
+        span.StartLinePosition.Line, span.StartLinePosition.Character, span.EndLinePosition.Line,
+        span.EndLinePosition.Character
+    };
+    }
+
+    private static bool IsLocalSymbol(ISymbol sym)
+    {
+        return sym.Kind == SymbolKind.Local ||
+               // Anonymous classes/methods have empty names and can not be accessed outside their file.
+               // The "global namespace" (parent of all namespaces) also has an empty name and should not
+               // be treated as a local variable.
+               (sym.Name.Equals("") && sym.Kind != SymbolKind.Namespace);
+    }
+}

--- a/ScipDotnet/ScipVisualBasicSyntaxWalker.cs
+++ b/ScipDotnet/ScipVisualBasicSyntaxWalker.cs
@@ -1,0 +1,120 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.VisualBasic;
+using Microsoft.CodeAnalysis.VisualBasic.Syntax;
+using System.Diagnostics;
+
+namespace ScipDotnet;
+
+/// <summary>
+/// Walks a single VisualBasic syntax tree and produces a SCIP <code>Document</code>.
+/// </summary>
+public class ScipVisualBasicSyntaxWalker : VisualBasicSyntaxWalker
+{
+    private readonly SemanticModel _semanticModel;
+    private readonly ScipSymbolFormatter _scipSymbolFormatter;
+
+    public ScipVisualBasicSyntaxWalker(ScipSymbolFormatter scipSymbolFormatter, SemanticModel semanticModel, SyntaxWalkerDepth depth = SyntaxWalkerDepth.Node) : base(depth)
+    {
+        _scipSymbolFormatter = scipSymbolFormatter;
+        _semanticModel = semanticModel;
+    }
+
+    public override void VisitIdentifierName(IdentifierNameSyntax node)
+    {
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetSymbolInfo(node).Symbol, node.GetLocation(), false);
+        base.VisitIdentifierName(node);
+    }
+
+    public override void VisitClassStatement(ClassStatementSyntax node)
+    {
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        base.VisitClassStatement(node);
+    }
+
+    public override void VisitModuleStatement(ModuleStatementSyntax node)
+    {
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        base.VisitModuleStatement(node);
+    }
+
+    public override void VisitEnumStatement(EnumStatementSyntax node)
+    {
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        base.VisitEnumStatement(node);
+    }
+
+    public override void VisitCatchStatement(CatchStatementSyntax node)
+    {
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.IdentifierName.Identifier.GetLocation(), true);
+        base.VisitCatchStatement(node);
+    }
+
+    public override void VisitSubNewStatement(SubNewStatementSyntax node)
+    {
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.NewKeyword.GetLocation(), true);
+        base.VisitSubNewStatement(node);
+    }
+
+    public override void VisitDelegateStatement(DelegateStatementSyntax node)
+    {
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        base.VisitDelegateStatement(node);
+    }
+
+    public override void VisitEventStatement(EventStatementSyntax node)
+    {
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        base.VisitEventStatement(node);
+    }
+
+    public override void VisitInterfaceStatement(InterfaceStatementSyntax node)
+    {
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        base.VisitInterfaceStatement(node);
+    }
+
+    public override void VisitPropertyStatement(PropertyStatementSyntax node)
+    {
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        base.VisitPropertyStatement(node);
+    }
+
+    public override void VisitStructureStatement(StructureStatementSyntax node)
+    {
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        base.VisitStructureStatement(node);
+    }
+
+    public override void VisitVariableDeclarator(VariableDeclaratorSyntax node)
+    {
+        foreach (var identifiers in node.Names)
+        {
+            _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(identifiers), identifiers.Identifier.GetLocation(), true);
+        }
+       base.VisitVariableDeclarator(node);
+    }
+
+    public override void VisitEnumMemberDeclaration(EnumMemberDeclarationSyntax node)
+    {
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        base.VisitEnumMemberDeclaration(node);
+    }
+
+    public override void VisitMethodStatement(MethodStatementSyntax node)
+    {
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        base.VisitMethodStatement(node);
+    }
+
+    public override void VisitParameter(ParameterSyntax node)
+    {
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        base.VisitParameter(node);
+    }
+
+    public override void VisitTypeParameter(TypeParameterSyntax node)
+    {
+        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        base.VisitTypeParameter(node);
+    }
+}

--- a/ScipDotnet/ScipVisualBasicSyntaxWalker.cs
+++ b/ScipDotnet/ScipVisualBasicSyntaxWalker.cs
@@ -91,7 +91,7 @@ public class ScipVisualBasicSyntaxWalker : VisualBasicSyntaxWalker
         {
             _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(identifiers), identifiers.Identifier.GetLocation(), true);
         }
-       base.VisitVariableDeclarator(node);
+        base.VisitVariableDeclarator(node);
     }
 
     public override void VisitEnumMemberDeclaration(EnumMemberDeclarationSyntax node)

--- a/ScipDotnet/ScipVisualBasicSyntaxWalker.cs
+++ b/ScipDotnet/ScipVisualBasicSyntaxWalker.cs
@@ -11,77 +11,77 @@ namespace ScipDotnet;
 public class ScipVisualBasicSyntaxWalker : VisualBasicSyntaxWalker
 {
     private readonly SemanticModel _semanticModel;
-    private readonly ScipSymbolFormatter _scipSymbolFormatter;
+    private readonly ScipDocumentIndexer _scipDocumentIndexer;
 
-    public ScipVisualBasicSyntaxWalker(ScipSymbolFormatter scipSymbolFormatter, SemanticModel semanticModel, SyntaxWalkerDepth depth = SyntaxWalkerDepth.Node) : base(depth)
+    public ScipVisualBasicSyntaxWalker(ScipDocumentIndexer scipSymbolFormatter, SemanticModel semanticModel, SyntaxWalkerDepth depth = SyntaxWalkerDepth.Node) : base(depth)
     {
-        _scipSymbolFormatter = scipSymbolFormatter;
+        _scipDocumentIndexer = scipSymbolFormatter;
         _semanticModel = semanticModel;
     }
 
     public override void VisitIdentifierName(IdentifierNameSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetSymbolInfo(node).Symbol, node.GetLocation(), false);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetSymbolInfo(node).Symbol, node.GetLocation(), false);
         base.VisitIdentifierName(node);
     }
 
     public override void VisitClassStatement(ClassStatementSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitClassStatement(node);
     }
 
     public override void VisitModuleStatement(ModuleStatementSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitModuleStatement(node);
     }
 
     public override void VisitEnumStatement(EnumStatementSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitEnumStatement(node);
     }
 
     public override void VisitCatchStatement(CatchStatementSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.IdentifierName.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.IdentifierName.Identifier.GetLocation(), true);
         base.VisitCatchStatement(node);
     }
 
     public override void VisitSubNewStatement(SubNewStatementSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.NewKeyword.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.NewKeyword.GetLocation(), true);
         base.VisitSubNewStatement(node);
     }
 
     public override void VisitDelegateStatement(DelegateStatementSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitDelegateStatement(node);
     }
 
     public override void VisitEventStatement(EventStatementSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitEventStatement(node);
     }
 
     public override void VisitInterfaceStatement(InterfaceStatementSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitInterfaceStatement(node);
     }
 
     public override void VisitPropertyStatement(PropertyStatementSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitPropertyStatement(node);
     }
 
     public override void VisitStructureStatement(StructureStatementSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitStructureStatement(node);
     }
 
@@ -89,32 +89,32 @@ public class ScipVisualBasicSyntaxWalker : VisualBasicSyntaxWalker
     {
         foreach (var identifiers in node.Names)
         {
-            _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(identifiers), identifiers.Identifier.GetLocation(), true);
+            _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(identifiers), identifiers.Identifier.GetLocation(), true);
         }
        base.VisitVariableDeclarator(node);
     }
 
     public override void VisitEnumMemberDeclaration(EnumMemberDeclarationSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitEnumMemberDeclaration(node);
     }
 
     public override void VisitMethodStatement(MethodStatementSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitMethodStatement(node);
     }
 
     public override void VisitParameter(ParameterSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitParameter(node);
     }
 
     public override void VisitTypeParameter(TypeParameterSyntax node)
     {
-        _scipSymbolFormatter.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
+        _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetDeclaredSymbol(node), node.Identifier.GetLocation(), true);
         base.VisitTypeParameter(node);
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # scip-dotnet
 
-SCIP indexer for the C# programming language.
+SCIP indexer for the C# and Visual basic programming languages.
 
 ## Getting started
 

--- a/snapshots/input/syntax/Main/Classes.cs
+++ b/snapshots/input/syntax/Main/Classes.cs
@@ -21,7 +21,6 @@ public class Classes
         Console.WriteLine(42);
     }
 
-
     public class ObjectClass : object, SomeInterface
     {
     }

--- a/snapshots/input/syntax/VBMain/Classes.vb
+++ b/snapshots/input/syntax/VBMain/Classes.vb
@@ -1,0 +1,80 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+
+Namespace VBMain
+    <SuppressMessage("ReSharper", "all")>
+    Public Class Classes
+
+        Public Name As String
+        Public Const IntConstant As Integer = 1
+        Public Const StringConstant As String = "hello"
+
+        Public Sub New(ByVal name As Integer)
+            Me.Name = "name"
+        End Sub
+
+        Public Sub New(ByVal name As String)
+            Me.Name = name
+        End Sub
+
+        Protected Overrides Sub Finalize()
+            Console.WriteLine(42)
+        End Sub
+
+        Public Class ObjectClass
+            Inherits Object
+            Implements SomeInterface
+        End Class
+
+        Public Partial Class PartialClass
+        End Class
+
+        Class TypeParameterClass(Of T)
+        End Class
+
+        Friend Class InternalMultipleTypeParametersClass(Of T1, T2)
+        End Class
+        
+        Interface ICovariantContravariant(Of In T1, Out T2)
+        Sub Method1(ByVal t1 As T1)
+
+        Function Method2() As T2
+
+        End Interface
+
+        Public Class StructConstraintClass(Of T As Structure)
+        End Class
+
+        Public Class ClassConstraintClass(Of T As Class)
+        End Class
+
+        Public Class NewConstraintClass(Of T As New)
+        End Class
+
+        Public Class TypeParameterConstraintClass(Of T As SomeInterface)
+        End Class
+
+        Private Class MultipleTypeParameterConstraintsClass(Of T1 As {SomeInterface, SomeInterface2, New}, T2 As SomeInterface2)
+        End Class
+
+        Class IndexClass
+            Private a As Boolean
+
+            Default Public Property Item(ByVal index As Integer) As Boolean
+                Get
+                    Return a
+                End Get
+                Set(ByVal value As Boolean)
+                    a = value
+                End Set
+            End Property
+        End Class
+
+    Interface SomeInterface
+    End Interface
+
+    Friend Interface SomeInterface2
+    End Interface
+
+    End Class
+
+End Namespace

--- a/snapshots/input/syntax/VBMain/Classes.vb
+++ b/snapshots/input/syntax/VBMain/Classes.vb
@@ -33,11 +33,11 @@ Namespace VBMain
 
         Friend Class InternalMultipleTypeParametersClass(Of T1, T2)
         End Class
-        
-        Interface ICovariantContravariant(Of In T1, Out T2)
-        Sub Method1(ByVal t1 As T1)
 
-        Function Method2() As T2
+        Interface ICovariantContravariant(Of In T1, Out T2)
+            Sub Method1(ByVal t1 As T1)
+
+            Function Method2() As T2
 
         End Interface
 
@@ -69,11 +69,11 @@ Namespace VBMain
             End Property
         End Class
 
-    Interface SomeInterface
-    End Interface
+        Interface SomeInterface
+        End Interface
 
-    Friend Interface SomeInterface2
-    End Interface
+        Friend Interface SomeInterface2
+        End Interface
 
     End Class
 

--- a/snapshots/input/syntax/VBMain/Enums.vb
+++ b/snapshots/input/syntax/VBMain/Enums.vb
@@ -1,0 +1,16 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+
+Namespace VBMain
+    <SuppressMessage("ReSharper", "all")>
+    Public Class Enums
+        Enum EnumWithIntValues
+            Ten = 10
+            Twenty = 20
+        End Enum
+
+        Enum EnumWithByteValues
+            Five = &H05
+            Fifteen = &H0F
+        End Enum
+    End Class
+End Namespace

--- a/snapshots/input/syntax/VBMain/Enums.vb
+++ b/snapshots/input/syntax/VBMain/Enums.vb
@@ -9,8 +9,8 @@ Namespace VBMain
         End Enum
 
         Enum EnumWithByteValues
-            Five = &H05
-            Fifteen = &H0F
+            Five = &H5
+            Fifteen = &HF
         End Enum
     End Class
 End Namespace

--- a/snapshots/input/syntax/VBMain/Events.vb
+++ b/snapshots/input/syntax/VBMain/Events.vb
@@ -1,0 +1,34 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+
+Namespace VBMain
+    <SuppressMessage("ReSharper", "all")>
+    Public Class Events
+        Private EventHandlerList As New ArrayList
+
+        Public Event Event1 As EventHandler(Of Integer)
+
+        Public Custom Event Event2 As EventHandler
+
+            AddHandler(ByVal value As EventHandler)
+                EventHandlerList.Add(value)
+            End AddHandler
+            
+            RemoveHandler(ByVal value As EventHandler)
+                EventHandlerList.Remove(value)
+            End RemoveHandler
+            
+            RaiseEvent(ByVal sender As Object, ByVal e As EventArgs)
+            
+                For Each handler As EventHandler In EventHandlerList
+                    If handler IsNot Nothing Then
+                    handler.BeginInvoke(sender, e, Nothing, Nothing)
+                    End If
+                Next
+            End RaiseEvent
+        End Event
+
+        Private Sub Event1Handler() Handles Me.Event1
+            Throw New NotImplementedException()
+        End Sub
+    End Class
+End Namespace

--- a/snapshots/input/syntax/VBMain/Events.vb
+++ b/snapshots/input/syntax/VBMain/Events.vb
@@ -12,16 +12,15 @@ Namespace VBMain
             AddHandler(ByVal value As EventHandler)
                 EventHandlerList.Add(value)
             End AddHandler
-            
+
             RemoveHandler(ByVal value As EventHandler)
                 EventHandlerList.Remove(value)
             End RemoveHandler
-            
+
             RaiseEvent(ByVal sender As Object, ByVal e As EventArgs)
-            
                 For Each handler As EventHandler In EventHandlerList
                     If handler IsNot Nothing Then
-                    handler.BeginInvoke(sender, e, Nothing, Nothing)
+                        handler.BeginInvoke(sender, e, Nothing, Nothing)
                     End If
                 Next
             End RaiseEvent

--- a/snapshots/input/syntax/VBMain/Expressions.vb
+++ b/snapshots/input/syntax/VBMain/Expressions.vb
@@ -1,0 +1,244 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+
+Namespace VBMain
+    <SuppressMessage("ReSharper", "all")>
+    Public Class Expressions
+
+        Private Sub AssignmentToPrefixUnaryExpressions()
+            Dim A = 42
+            Dim B = 42
+            A = +A
+            A = -A
+            A = Not A
+            b = A
+            Dim C = True
+            C = Not C
+        End Sub
+
+        Private Sub AssignmentToPrefixBinaryExpressions()
+            Dim A = 42
+            A = A + A
+            A = A - A
+            A = A * A
+            A = A / A
+            A = A \ A
+            A = A ^ A
+            A = A Mod A
+            A = A And A
+            A = A Or A
+            A = A Xor A
+            A = A << A
+            A = A >> A
+        End Sub
+
+        Private Sub AssignmentToBinaryEqualityExpression()
+            Dim A = True
+            Dim B = True
+            Dim C = 42
+            Dim D = 42
+            A = A = B
+            A = A <> B
+            A = C < D
+            A = C <= D
+            A = C > D
+            A = C >= D
+        End Sub
+
+         Private Sub AssignmentToBinaryExpression()
+            Dim A = 42
+            A += A
+            A -= A
+            A *= A
+            A /= A
+            A \= A
+            A &= A
+            A <<= A
+            A >>= A
+            A ^= A
+        End Sub
+
+         Structure Struct
+            Public [Property] As Integer
+         End Structure
+
+        Structure IndexedClass
+            Public [Property] As Integer
+
+            Default Public Property Item(ByVal index As Integer) As Integer
+                Get
+                    Return [Property]
+                End Get
+                Set(ByVal value As Integer)
+                    [Property] = value
+                End Set
+            End Property
+        End Structure
+
+        Private Sub AssignmentToLeftValueTypes()
+            Dim E As (A As Integer, B As Integer) = (1, 2) 
+            Dim A = 1
+            Dim C = New Struct With {
+                .[Property] = 42
+            }
+            C.[Property] = 1
+            Dim D = New IndexedClass()
+            d(E.B) = 1
+            Dim X = New IndexedClass With {
+                .[Property] = 1
+            }
+            E.A = 1
+        End Sub
+
+        Private Sub TernaryExpression()
+            Dim X = True
+            Dim Y = If(x, "foo", "bar")
+            Dim Z As Object = True
+            Dim T = If(TypeOf z Is Boolean, 42, 41)
+        End Sub
+
+        Class Cast
+            Public Nested As Cast
+            Public Nested2 As Cast2
+
+            Public Function Plus(ByVal other As Cast) As Cast
+                Nested = other
+                Return Me
+            End Function
+
+            Public Class Cast2
+            End Class
+        End Class
+
+        Private Function CastExpressions() As Integer
+            Dim A As Object = New Cast()
+            Dim B As Object = New Cast()
+            Dim C As Cast = (CType(A, Cast)).Plus(CType(B, Cast))
+            Dim D As Cast = CType(New Object() {A, B}(0), Cast)
+            Dim E = CType((C.nested.nested2), Cast.Cast2)
+            Dim F = CType((1), Int32)
+            Dim G = CType((1), Int32)
+            Dim H = CType(((1)), Int32)
+            Return F + G + H
+        End Function
+
+        Private Function AnonymousObject() As Object
+            Dim X = New With {Key .Helper = ""}
+            Dim Y = New With {x}
+            Return Y.X.Helper
+        End Function
+
+        Class ObjectCreationClass
+            Public Field As D
+
+            Public Sub New(ByVal field As D)
+                Me.Field = field
+            End Sub
+
+            Public Class D
+                Public Sub New(ByVal a As Integer, ByVal b As String)
+                End Sub
+            End Class
+        End Class
+
+        Private Sub ObjectCreation()
+            Dim A = New ObjectCreationClass.D(1, "hi")
+            Dim B = New ObjectCreationClass(A) With {
+                .Field = A
+            }
+            B = New ObjectCreationClass(A)
+        End Sub
+
+        Class NamedParametersClass
+            Public A As Integer
+            Public B As String
+
+            Public Sub New(ByVal a As Integer, ByVal b As String)
+                Me.A = a
+                Me.B = b
+            End Sub
+
+            Public Sub Update(ByVal a As Integer, ByVal b As String)
+                Me.A = a
+                Me.B = b
+            End Sub
+        End Class
+
+        Private Function NamedParameters() As NamedParametersClass
+            Dim A = New NamedParametersClass(B:="hi", A:=1)
+            A.Update(B:="foo", A:=42)
+            Return A
+        End Function
+
+        Private Function AnonymousFunction() As Func(Of Integer, Integer)
+            Dim d = Function(ByVal __ As Integer, ByVal ___ As Integer) 42
+            Return Function(ByVal a As Integer) a + d.Invoke(a, a)
+        End Function
+
+        Class Lambda
+            Public Function func(ByVal x As Lambda) As String
+                Return ""
+            End Function
+        End Class
+
+        Private Sub LambdaExpressions()
+            Dim a = Function(ByVal x As String) x & 1
+            Dim b = Function(ByVal aa As Lambda, ByVal bb As Lambda) aa.func(bb)
+            Dim c = Function(aaa As Lambda, __ As Lambda)
+                        If True Then
+                            Return "hi"
+                        End If
+                    End Function
+        End Sub
+
+        Private Sub TupleExpression()
+            Dim A = (1, 2, "")
+        End Sub 
+
+        Private Sub ArrayCreation()
+            Dim a = {
+            {1, 1},
+            {2, 2},
+            {3, 3}}
+            Dim d = New Integer(2) {1, 2, 3}
+            Dim e = New Byte(,) {
+            {1, 2},
+            {2, 3}}
+            Dim f = New Integer(2, 1) {
+            {1, 1},
+            {2, 2},
+            {3, 3}}
+
+            Dim numbers(4) As Integer
+            Dim numbers2 = New Integer() {1, 2, 4, 8}
+            ReDim Preserve numbers(15)
+            ReDim numbers(15)
+            Dim matrix(5, 5) As Double
+            Dim matrix2 = New Integer(,) {{1, 2, 3}, {2, 3, 4}, {3, 4, 5}, {4, 5, 6}}
+            Dim sales()() As Double = New Double(11)() {}
+        End Sub
+
+         Private Sub [TypeOf]()
+            Dim a = GetType(Integer)
+            Dim b = GetType(List(Of String).Enumerator)
+            Dim c = GetType(Dictionary(Of,))
+            Dim d = GetType(Tuple(Of,,,))
+        End Sub
+
+        Private Sub SelectCase()
+            Dim Some = 42
+            Select Case Some
+                Case 1
+                    Debug.WriteLine("One")
+                Case 2
+                    Debug.WriteLine("One")
+                Case Else
+                    Debug.WriteLine("More")
+            End Select
+        End Sub
+
+        Private Sub Dictionary()
+            Dim A = New Dictionary(Of String, Integer) From {{ 1, "Test1" }, { 2, "Test1" }}
+        End Sub
+
+    End Class
+End Namespace

--- a/snapshots/input/syntax/VBMain/Expressions.vb
+++ b/snapshots/input/syntax/VBMain/Expressions.vb
@@ -10,7 +10,7 @@ Namespace VBMain
             A = +A
             A = -A
             A = Not A
-            b = A
+            B = A
             Dim C = True
             C = Not C
         End Sub
@@ -44,7 +44,7 @@ Namespace VBMain
             A = C >= D
         End Sub
 
-         Private Sub AssignmentToBinaryExpression()
+        Private Sub AssignmentToBinaryExpression()
             Dim A = 42
             A += A
             A -= A
@@ -57,9 +57,9 @@ Namespace VBMain
             A ^= A
         End Sub
 
-         Structure Struct
+        Structure Struct
             Public [Property] As Integer
-         End Structure
+        End Structure
 
         Structure IndexedClass
             Public [Property] As Integer
@@ -75,14 +75,14 @@ Namespace VBMain
         End Structure
 
         Private Sub AssignmentToLeftValueTypes()
-            Dim E As (A As Integer, B As Integer) = (1, 2) 
+            Dim E As (A As Integer, B As Integer) = (1, 2)
             Dim A = 1
             Dim C = New Struct With {
                 .[Property] = 42
             }
             C.[Property] = 1
             Dim D = New IndexedClass()
-            d(E.B) = 1
+            D(E.B) = 1
             Dim X = New IndexedClass With {
                 .[Property] = 1
             }
@@ -91,9 +91,9 @@ Namespace VBMain
 
         Private Sub TernaryExpression()
             Dim X = True
-            Dim Y = If(x, "foo", "bar")
+            Dim Y = If(X, "foo", "bar")
             Dim Z As Object = True
-            Dim T = If(TypeOf z Is Boolean, 42, 41)
+            Dim T = If(TypeOf Z Is Boolean, 42, 41)
         End Sub
 
         Class Cast
@@ -114,7 +114,7 @@ Namespace VBMain
             Dim B As Object = New Cast()
             Dim C As Cast = (CType(A, Cast)).Plus(CType(B, Cast))
             Dim D As Cast = CType(New Object() {A, B}(0), Cast)
-            Dim E = CType((C.nested.nested2), Cast.Cast2)
+            Dim E = CType((C.Nested.Nested2), Cast.Cast2)
             Dim F = CType((1), Int32)
             Dim G = CType((1), Int32)
             Dim H = CType(((1)), Int32)
@@ -123,8 +123,8 @@ Namespace VBMain
 
         Private Function AnonymousObject() As Object
             Dim X = New With {Key .Helper = ""}
-            Dim Y = New With {x}
-            Return Y.X.Helper
+            Dim Y = New With {X}
+            Return Y.x.Helper
         End Function
 
         Class ObjectCreationClass
@@ -164,8 +164,8 @@ Namespace VBMain
         End Class
 
         Private Function NamedParameters() As NamedParametersClass
-            Dim A = New NamedParametersClass(B:="hi", A:=1)
-            A.Update(B:="foo", A:=42)
+            Dim A = New NamedParametersClass(b:="hi", a:=1)
+            A.Update(b:="foo", a:=42)
             Return A
         End Function
 
@@ -192,7 +192,7 @@ Namespace VBMain
 
         Private Sub TupleExpression()
             Dim A = (1, 2, "")
-        End Sub 
+        End Sub
 
         Private Sub ArrayCreation()
             Dim a = {
@@ -217,7 +217,7 @@ Namespace VBMain
             Dim sales()() As Double = New Double(11)() {}
         End Sub
 
-         Private Sub [TypeOf]()
+        Private Sub [TypeOf]()
             Dim a = GetType(Integer)
             Dim b = GetType(List(Of String).Enumerator)
             Dim c = GetType(Dictionary(Of,))
@@ -237,7 +237,7 @@ Namespace VBMain
         End Sub
 
         Private Sub Dictionary()
-            Dim A = New Dictionary(Of String, Integer) From {{ 1, "Test1" }, { 2, "Test1" }}
+            Dim A = New Dictionary(Of String, Integer) From {{1, "Test1"}, {2, "Test1"}}
         End Sub
 
     End Class

--- a/snapshots/input/syntax/VBMain/Fields.vb
+++ b/snapshots/input/syntax/VBMain/Fields.vb
@@ -1,0 +1,19 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+
+Namespace VBMain
+    <SuppressMessage("ReSharper", "all")>
+    Public Class Fields
+        Class Fields1
+            Private ReadOnly Property1 As Integer
+            Private Property2, Property3 As Int64
+            Private Property4 As Tuple(Of Char, Nullable(Of Integer))
+
+            Public Sub New(ByVal field2 As Long, ByVal field3 As Long, ByVal field4 As Tuple(Of Char, Integer?), ByVal field1 As Integer)
+                Property2 = field2
+                Property3 = field3
+                Property4 = field4
+                Property1 = field1
+            End Sub
+        End Class
+    End Class
+End Namespace

--- a/snapshots/input/syntax/VBMain/GlobalAttributes.vb
+++ b/snapshots/input/syntax/VBMain/GlobalAttributes.vb
@@ -1,0 +1,39 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+
+Namespace VBMain
+    <SuppressMessage("ReSharper", "all")>
+    <AttributeUsage(AttributeTargets.[Class], AllowMultiple:=True, Inherited:=True)>
+    Public Class GlobalAttributes
+        Inherits Attribute
+
+        Class AuthorAttribute
+            Inherits Attribute
+
+            Public Sub New(ByVal name As String)
+            End Sub
+        End Class
+
+        <Author("PropertyAttribute")>
+        Public Z As Integer
+
+        <Author("MethodAttribute")>
+        Private Function Method1() As Integer
+            Return 0
+        End Function
+
+        <Author("EnumAttribute")>
+        Enum A
+            B
+            C
+        End Enum
+
+        <Author("EventAttribute")>
+        Public Event SomeEvent As EventHandler
+
+        <Author("TypeParameterAttribute")>
+        Public Class InnerClass(Of T)
+            Private Sub Method(Of T2)()
+            End Sub
+        End Class
+    End Class
+End Namespace

--- a/snapshots/input/syntax/VBMain/Identifiers.vb
+++ b/snapshots/input/syntax/VBMain/Identifiers.vb
@@ -1,0 +1,18 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+
+Namespace VBMain
+    <SuppressMessage("ReSharper", "all")>
+    Public Class Identifiers
+        Private Sub SpecialNames()
+            Dim [const] = 42
+            Dim var As Integer = [const]
+            Dim under_score = 0
+            Dim with1number = 0
+            Dim varæble = 0
+            Dim Переменная = 0
+            Dim first‿letter = 0
+            Dim ග්රහලෝකය = 0
+            Dim _كوكبxxx = 0
+        End Sub
+    End Class
+End Namespace

--- a/snapshots/input/syntax/VBMain/Interfaces.vb
+++ b/snapshots/input/syntax/VBMain/Interfaces.vb
@@ -1,0 +1,41 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+
+Namespace VBMain
+    <SuppressMessage("ReSharper", "all")>
+    Public Class Interfaces
+        Interface IOne
+        End Interface
+
+        Interface ITwo
+        End Interface
+
+        Interface IThree
+        End Interface
+
+        Interface IProperties
+            ReadOnly Property [Get] As Byte
+            WriteOnly Property [Set] As Char
+            Property GetSet As UInteger
+            Property SetGet As Long
+        End Interface
+
+        Interface IMethods
+            Sub [Nothing]()
+            Function Output() As Integer
+            Sub Input(ByVal a As String)
+            Function InputOutput(ByVal a As String) As Integer
+        End Interface
+
+        Interface IEvent
+             Event SomeEvent As EventHandler(Of Integer)
+        End Interface
+
+        Interface IIndex
+            Default Property Item(ByVal index As Integer) As Boolean
+        End Interface
+
+        Private Interface IInherit
+            Inherits IOne, ITwo
+        End Interface
+    End Class
+End Namespace

--- a/snapshots/input/syntax/VBMain/Interfaces.vb
+++ b/snapshots/input/syntax/VBMain/Interfaces.vb
@@ -27,7 +27,7 @@ Namespace VBMain
         End Interface
 
         Interface IEvent
-             Event SomeEvent As EventHandler(Of Integer)
+            Event SomeEvent As EventHandler(Of Integer)
         End Interface
 
         Interface IIndex

--- a/snapshots/input/syntax/VBMain/Literals.vb
+++ b/snapshots/input/syntax/VBMain/Literals.vb
@@ -1,0 +1,14 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+
+Namespace VBMain
+    <SuppressMessage("ReSharper", "all")>
+    Public Class Literals
+        Private Function Interpolation() As String
+            Dim a = 1
+            Dim b = 2
+            Dim c = 3
+            Dim d = 3
+            Return $"a={a} b={b} c={c} d={d}"
+        End Function
+    End Class
+End Namespace

--- a/snapshots/input/syntax/VBMain/Methods.vb
+++ b/snapshots/input/syntax/VBMain/Methods.vb
@@ -1,0 +1,87 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+
+Namespace VBMain
+    <SuppressMessage("ReSharper", "all")>
+    Public Class Methods
+        Private Function SingleParameter(ByVal b As Integer) As Integer
+            Return b
+        End Function
+
+        Private Function TwoParameters(ByVal a As Integer, ByVal b As Integer) As Integer
+            Return a + b
+        End Function
+
+        Private Function Overload1(ByVal a As Integer) As Integer
+            Return a
+        End Function
+
+        Private Function Overload1(ByVal a As Integer, ByVal b As Integer) As Integer
+            Return a + b
+        End Function
+
+        Private Function Generic(Of T)(ByVal param As T) As T
+            Return param
+        End Function
+
+        Private Function GenericConstraint(Of T As New)(ByVal param As T) As T
+            Return param
+        End Function
+
+        Private Sub DefaultParameter(ByVal Optional a As Integer = 5)
+        End Sub
+
+        Private Function DefaultParameterOverload(ByVal Optional a As Integer = 5) As Integer
+            Return DefaultParameterOverload(a, a)
+        End Function
+
+        Private Function DefaultParameterOverload(ByVal a As Integer, ByVal b As Integer) As Integer
+            Return DefaultParameterOverload()
+        End Function
+
+        Interface IHello
+            Function Hello() As String
+        End Interface
+
+        Class ImplementsHello
+            Implements IHello
+
+            Private Function Hello() As String Implements IHello.Hello
+                Throw New NotImplementedException()
+            End Function
+
+        End Class
+
+        Class InheritedOverloads1
+            Public Sub Method()
+            End Sub
+        End Class
+
+        Class InheritedOverloads2
+            Inherits InheritedOverloads1
+
+            Public Function Method(ByVal parameter As Integer) As Integer
+                Return parameter
+            End Function
+        End Class
+
+        Class InheritedOverloads3
+            Inherits InheritedOverloads2
+
+            Public Function Method(ByVal parameter As String) As String
+                Return parameter
+            End Function
+        End Class
+
+        Public Shared Sub InheritedOverloads()
+            Dim a as InheritedOverloads1 = New InheritedOverloads1
+            a.Method()
+            Dim b as InheritedOverloads2 = New InheritedOverloads2
+            DirectCast(b, InheritedOverloads1).Method()
+            b.Method(42)
+            Dim c as InheritedOverloads3 = New InheritedOverloads3
+            DirectCast(c, InheritedOverloads1).Method()
+            DirectCast(c, InheritedOverloads2).Method(42)
+            c.Method("42")
+        End Sub
+    End Class
+End Namespace

--- a/snapshots/input/syntax/VBMain/Methods.vb
+++ b/snapshots/input/syntax/VBMain/Methods.vb
@@ -73,12 +73,12 @@ Namespace VBMain
         End Class
 
         Public Shared Sub InheritedOverloads()
-            Dim a as InheritedOverloads1 = New InheritedOverloads1
+            Dim a As InheritedOverloads1 = New InheritedOverloads1
             a.Method()
-            Dim b as InheritedOverloads2 = New InheritedOverloads2
+            Dim b As InheritedOverloads2 = New InheritedOverloads2
             DirectCast(b, InheritedOverloads1).Method()
             b.Method(42)
-            Dim c as InheritedOverloads3 = New InheritedOverloads3
+            Dim c As InheritedOverloads3 = New InheritedOverloads3
             DirectCast(c, InheritedOverloads1).Method()
             DirectCast(c, InheritedOverloads2).Method(42)
             c.Method("42")

--- a/snapshots/input/syntax/VBMain/Modules.vb
+++ b/snapshots/input/syntax/VBMain/Modules.vb
@@ -1,0 +1,14 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+
+Namespace VBMain
+    <SuppressMessage("ReSharper", "all")>
+    Public Module Modules
+        Private Function [Function](ByVal b As Integer) As Integer
+            Return b
+        End Function
+
+        Private Sub [Sub](ByVal Optional a As Integer = 5)
+        End Sub
+
+    End Module
+End Namespace

--- a/snapshots/input/syntax/VBMain/Operators.vb
+++ b/snapshots/input/syntax/VBMain/Operators.vb
@@ -1,0 +1,50 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+
+Namespace VBMain
+    <SuppressMessage("ReSharper", "all")>
+    Public Class Operators
+        Public Class PlusMinus
+            Public Shared Operator +(A As PlusMinus)
+                Return 0
+            End Operator
+
+            Public Shared Operator +(A As PlusMinus, B As PlusMinus)
+                Return 0
+            End Operator
+
+            Public Shared Operator -(A As PlusMinus)
+                Return 0
+            End Operator
+        End Class
+
+        Public Class TrueFalse
+            Public Shared Operator IsTrue(A As TrueFalse) As Boolean
+                Return True
+            End Operator
+
+            Public Shared Operator IsFalse(A As TrueFalse) As Boolean
+                Return False
+            End Operator
+
+            Public Shared Operator =(A As TrueFalse, B As TrueFalse) As Boolean
+                Return True
+            End Operator
+
+            Public Shared Operator <>(A As TrueFalse, B As TrueFalse) As Boolean
+                Return True
+            End Operator
+
+            Public Overrides Function Equals(obj As Object) As Boolean
+                If ReferenceEquals(Nothing, obj) Then Return False
+                If ReferenceEquals(Me, obj) Then Return True
+                If obj.GetType() <> Me.GetType() Then Return False
+                Return Equals(CType(obj, TrueFalse))
+            End Function
+
+            Public Overrides Function GetHashCode() As Integer
+                Throw New NotImplementedException()
+            End Function
+
+        End Class
+    End Class
+End Namespace

--- a/snapshots/input/syntax/VBMain/Packages.vb
+++ b/snapshots/input/syntax/VBMain/Packages.vb
@@ -1,0 +1,12 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+Imports DiffPlex.DiffBuilder
+Imports DiffPlex.DiffBuilder.Model
+
+Namespace VBMain
+    <SuppressMessage("ReSharper", "all")>
+    Public Class Packages
+        Private Function Diff() As DiffPaneModel
+            Return InlineDiffBuilder.Diff("a", "b")
+        End Function
+    End Class
+End Namespace

--- a/snapshots/input/syntax/VBMain/Preprocessors.vb
+++ b/snapshots/input/syntax/VBMain/Preprocessors.vb
@@ -1,0 +1,19 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+
+Namespace VBMain
+    <SuppressMessage("ReSharper", "all")>
+    Public Class Preprocessors
+        Private Function OperatingSystem() As String
+#if WIN32
+            Dim Os As String = "Win32"
+#warning This class is bad.
+#error Okay, just stop.
+#elif MACOS
+            Dim Os As String = "MacOS"
+#else
+            Dim Os As String = "Unknown"
+#End If
+            Return Os
+        End Function
+    End Class
+End Namespace

--- a/snapshots/input/syntax/VBMain/Preprocessors.vb
+++ b/snapshots/input/syntax/VBMain/Preprocessors.vb
@@ -4,13 +4,13 @@ Namespace VBMain
     <SuppressMessage("ReSharper", "all")>
     Public Class Preprocessors
         Private Function OperatingSystem() As String
-#if WIN32
+#If WIN32 Then
             Dim Os As String = "Win32"
 #warning This class is bad.
 #error Okay, just stop.
 #elif MACOS
             Dim Os As String = "MacOS"
-#else
+#Else
             Dim Os As String = "Unknown"
 #End If
             Return Os

--- a/snapshots/input/syntax/VBMain/Program.vb
+++ b/snapshots/input/syntax/VBMain/Program.vb
@@ -1,6 +1,6 @@
 Module Program
     Sub Main(args As String())
-        
+
         Console.WriteLine("Hello, World!")
     End Sub
 End Module

--- a/snapshots/input/syntax/VBMain/Program.vb
+++ b/snapshots/input/syntax/VBMain/Program.vb
@@ -1,0 +1,6 @@
+Module Program
+    Sub Main(args As String())
+        
+        Console.WriteLine("Hello, World!")
+    End Sub
+End Module

--- a/snapshots/input/syntax/VBMain/Properties.vb
+++ b/snapshots/input/syntax/VBMain/Properties.vb
@@ -1,0 +1,17 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+
+Namespace VBMain
+    <SuppressMessage("ReSharper", "all")>
+    Public Class Properties
+        Private ReadOnly Property [Get] As Byte
+
+        Private WriteOnly Property [Set] As Char
+            Set(ByVal value As Char)
+                Throw New NotImplementedException()
+            End Set
+        End Property
+
+        Private Property GetSet As UInteger
+        Private Property SetGet As Long
+    End Class
+End Namespace

--- a/snapshots/input/syntax/VBMain/QuerySyntax.vb
+++ b/snapshots/input/syntax/VBMain/QuerySyntax.vb
@@ -1,0 +1,38 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+
+Namespace VBMain
+    <SuppressMessage("ReSharper", "all")>
+    Public Class QuerySyntax
+        Private sourceA As List(Of IGeneric) = New List(Of IGeneric)()
+        Private sourceB As List(Of IGeneric) = New List(Of IGeneric)()
+
+        Interface IGeneric
+            Function Method() As String
+        End Interface
+
+        Private Sub [Select]()
+            Dim x = From a In sourceA Select a.Method()
+        End Sub
+
+        Private Sub Projection()
+            Dim x = From a In sourceA Select New With {Key.Name = a.Method()}
+            Dim b = From a In x Select a.Name
+        End Sub
+
+        Private Sub Where()
+            Dim x = From a In sourceA Where a.Method().StartsWith("a") Select a
+        End Sub
+
+        Private Sub [Let]()
+            Dim x = From a In sourceA Let z = New With { Key.A = a.Method(), Key.B = a.Method() } Select z
+        End Sub
+
+        Private Sub Join()
+            Dim x = From a In sourceA Join b In sourceB On a.Method() Equals b.Method() Select New With { Key.A = a.Method(), Key.B = b.Method() }
+        End Sub
+
+        Private Sub MultipleFrom()
+            Dim x = From a In sourceA From b In sourceB Where a.Method() = b.Method() Select New With { Key.A = a.Method(), Key.B = b.Method() }
+        End Sub
+    End Class
+End Namespace

--- a/snapshots/input/syntax/VBMain/QuerySyntax.vb
+++ b/snapshots/input/syntax/VBMain/QuerySyntax.vb
@@ -15,7 +15,7 @@ Namespace VBMain
         End Sub
 
         Private Sub Projection()
-            Dim x = From a In sourceA Select New With {Key.Name = a.Method()}
+            Dim x = From a In sourceA Select New With {Key .Name = a.Method()}
             Dim b = From a In x Select a.Name
         End Sub
 
@@ -24,15 +24,15 @@ Namespace VBMain
         End Sub
 
         Private Sub [Let]()
-            Dim x = From a In sourceA Let z = New With { Key.A = a.Method(), Key.B = a.Method() } Select z
+            Dim x = From a In sourceA Let z = New With {Key .A = a.Method(), Key .B = a.Method()} Select z
         End Sub
 
         Private Sub Join()
-            Dim x = From a In sourceA Join b In sourceB On a.Method() Equals b.Method() Select New With { Key.A = a.Method(), Key.B = b.Method() }
+            Dim x = From a In sourceA Join b In sourceB On a.Method() Equals b.Method() Select New With {Key .A = a.Method(), Key .B = b.Method()}
         End Sub
 
         Private Sub MultipleFrom()
-            Dim x = From a In sourceA From b In sourceB Where a.Method() = b.Method() Select New With { Key.A = a.Method(), Key.B = b.Method() }
+            Dim x = From a In sourceA From b In sourceB Where a.Method() = b.Method() Select New With {Key .A = a.Method(), Key .B = b.Method()}
         End Sub
     End Class
 End Namespace

--- a/snapshots/input/syntax/VBMain/Statements.vb
+++ b/snapshots/input/syntax/VBMain/Statements.vb
@@ -1,0 +1,69 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+Imports System.IO
+
+Namespace VBMain
+    <SuppressMessage("ReSharper", "all")>
+    Public Class Statements
+        Private Sub [Try]()
+            Try
+                File.ReadLines("asd")
+            Catch err As Exception
+                Console.WriteLine(err)
+            End Try
+        End Sub
+
+        Private Function [Default]() As (A as String, B as Boolean)
+            Dim C As (A As String, B As Boolean) = ("42", 42)
+            Return C
+        End Function
+
+       Public class Inferred
+            Property F1 As Int32
+            Property F2 As Int32
+       End Class
+
+        Private Sub InferredTuples()
+            Dim List = New List(Of Inferred)()
+            Dim Result = List.Select(Function(c) (c.F1, c.F2)).Where(Function(t) t.F2 = 1)
+        End Sub
+
+        Private Function MultipleInitializers() As Integer
+            Dim a As Integer = 1, b As Integer = 2
+            Return a + b
+        End Function
+
+        Class MyDisposable
+            Implements IDisposable
+
+            Private Sub Dispose() Implements IDisposable.Dispose
+                Throw New NotImplementedException()
+            End Sub
+        End Class
+
+        Private Function [Using]() As MyDisposable
+            Dim b = New MyDisposable()
+
+            Using a = b
+                Return a
+            End Using
+        End Function
+
+        Private Function MultipleUsing() As Long
+            Using a As Stream = File.OpenRead("a"), b As Stream = File.OpenRead("a")
+                Return a.Length + b.Length
+            End Using
+        End Function
+
+        Private Function Foreach() As Integer
+        Dim y = New Integer() {1}
+            Dim z = 0
+
+            For Each x As Integer In y
+                z += x
+            Next
+
+            Return z
+        End Function
+
+    End Class
+End Namespace

--- a/snapshots/input/syntax/VBMain/Statements.vb
+++ b/snapshots/input/syntax/VBMain/Statements.vb
@@ -12,15 +12,15 @@ Namespace VBMain
             End Try
         End Sub
 
-        Private Function [Default]() As (A as String, B as Boolean)
+        Private Function [Default]() As (A As String, B As Boolean)
             Dim C As (A As String, B As Boolean) = ("42", 42)
             Return C
         End Function
 
-       Public class Inferred
+        Public Class Inferred
             Property F1 As Int32
             Property F2 As Int32
-       End Class
+        End Class
 
         Private Sub InferredTuples()
             Dim List = New List(Of Inferred)()
@@ -55,7 +55,7 @@ Namespace VBMain
         End Function
 
         Private Function Foreach() As Integer
-        Dim y = New Integer() {1}
+            Dim y = New Integer() {1}
             Dim z = 0
 
             For Each x As Integer In y

--- a/snapshots/input/syntax/VBMain/Structs.vb
+++ b/snapshots/input/syntax/VBMain/Structs.vb
@@ -1,0 +1,14 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+
+Namespace VBMain
+    <SuppressMessage("ReSharper", "all")>
+    Public Class Structs
+        Structure BasicStruct
+            Public Property1 As Integer
+
+            Public Sub New(ByVal field1 As Integer)
+                Property1 = field1
+            End Sub
+        End Structure
+    End Class
+End Namespace

--- a/snapshots/input/syntax/VBMain/VBMain.vbproj
+++ b/snapshots/input/syntax/VBMain/VBMain.vbproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>VBMain</RootNamespace>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DiffPlex" Version="1.7.1" />
+  </ItemGroup>
+
+</Project>

--- a/snapshots/input/syntax/syntax.sln
+++ b/snapshots/input/syntax/syntax.sln
@@ -3,20 +3,26 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Main", "Main\Main.csproj", "{07578BF0-FBDF-4ADC-BEC2-F12082258C53}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Main", "Main\Main.csproj", "{07578BF0-FBDF-4ADC-BEC2-F12082258C53}"
+EndProject
+Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "VBMain", "VBMain\VBMain.vbproj", "{AF2AE8A3-AFB7-41DE-BDC9-2BD40A0684A8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{07578BF0-FBDF-4ADC-BEC2-F12082258C53}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{07578BF0-FBDF-4ADC-BEC2-F12082258C53}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{07578BF0-FBDF-4ADC-BEC2-F12082258C53}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{07578BF0-FBDF-4ADC-BEC2-F12082258C53}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AF2AE8A3-AFB7-41DE-BDC9-2BD40A0684A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AF2AE8A3-AFB7-41DE-BDC9-2BD40A0684A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AF2AE8A3-AFB7-41DE-BDC9-2BD40A0684A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AF2AE8A3-AFB7-41DE-BDC9-2BD40A0684A8}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/snapshots/output-net6.0/syntax/Main/Classes.cs
+++ b/snapshots/output-net6.0/syntax/Main/Classes.cs
@@ -43,7 +43,6 @@
           Console.WriteLine(42);
       }
 
-
       public class ObjectClass : object, SomeInterface
 //                 ^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#ObjectClass#
 //                             documentation ```cs\nclass ObjectClass\n```

--- a/snapshots/output-net6.0/syntax/VBMain/Classes.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Classes.vb
@@ -1,0 +1,175 @@
+  Imports System.Diagnostics.CodeAnalysis
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+      Public Class Classes
+'                  ^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#
+'                          documentation ```vb\nClass Classes\n```
+
+          Public Name As String
+'                ^^^^ definition scip-dotnet nuget . . VBMain/Classes#Name.
+'                     documentation ```vb\nPublic Classes.Name As String\n```
+          Public Const IntConstant As Integer = 1
+'                      ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#IntConstant.
+'                                  documentation ```vb\nPublic Const Classes.IntConstant As Integer = 1\n```
+          Public Const StringConstant As String = "hello"
+'                      ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#StringConstant.
+'                                     documentation ```vb\nPublic Const Classes.StringConstant As String = "hello"\n```
+
+          Public Sub New(ByVal name As Integer)
+'                    ^^^ definition scip-dotnet nuget . . VBMain/Classes#`.ctor`().
+'                        documentation ```vb\nPublic Sub Classes.New(name As Integer)\n```
+'                              ^^^^ definition scip-dotnet nuget . . VBMain/Classes#`.ctor`().(name)
+'                                   documentation ```vb\nname As Integer\n```
+              Me.Name = "name"
+'                ^^^^ reference scip-dotnet nuget . . VBMain/Classes#Name.
+          End Sub
+
+          Public Sub New(ByVal name As String)
+'                    ^^^ definition scip-dotnet nuget . . VBMain/Classes#`.ctor`(+1).
+'                        documentation ```vb\nPublic Sub Classes.New(name As String)\n```
+'                              ^^^^ definition scip-dotnet nuget . . VBMain/Classes#`.ctor`(+1).(name)
+'                                   documentation ```vb\nname As String\n```
+              Me.Name = name
+'                ^^^^ reference scip-dotnet nuget . . VBMain/Classes#Name.
+'                       ^^^^ reference scip-dotnet nuget . . VBMain/Classes#`.ctor`(+1).(name)
+          End Sub
+
+          Protected Overrides Sub Finalize()
+'                                 ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#Finalize().
+'                                          documentation ```vb\nProtected Overrides Sub Classes.Finalize()\n```
+              Console.WriteLine(42)
+          End Sub
+
+          Public Class ObjectClass
+'                      ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ObjectClass#
+'                                  documentation ```vb\nClass ObjectClass\n```
+'                                  relationship implementation scip-dotnet nuget . . VBMain/Classes#SomeInterface#
+              Inherits Object
+              Implements SomeInterface
+'                        ^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Classes#SomeInterface#
+          End Class
+
+          Public Partial Class PartialClass
+'                              ^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#PartialClass#
+'                                           documentation ```vb\nClass PartialClass\n```
+          End Class
+
+          Class TypeParameterClass(Of T)
+'               ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#TypeParameterClass#
+'                                  documentation ```vb\nClass TypeParameterClass(Of T)\n```
+'                                     ^ definition scip-dotnet nuget . . VBMain/Classes#TypeParameterClass#[T]
+'                                       documentation ```vb\nT\n```
+          End Class
+
+          Friend Class InternalMultipleTypeParametersClass(Of T1, T2)
+'                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#InternalMultipleTypeParametersClass#
+'                                                          documentation ```vb\nClass InternalMultipleTypeParametersClass(Of T1, T2)\n```
+'                                                             ^^ definition scip-dotnet nuget . . VBMain/Classes#InternalMultipleTypeParametersClass#[T1]
+'                                                                documentation ```vb\nT1\n```
+'                                                                 ^^ definition scip-dotnet nuget . . VBMain/Classes#InternalMultipleTypeParametersClass#[T2]
+'                                                                    documentation ```vb\nT2\n```
+          End Class
+          
+          Interface ICovariantContravariant(Of In T1, Out T2)
+'                   ^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#
+'                                           documentation ```vb\nInterface ICovariantContravariant(Of In T1, Out T2)\n```
+'                                                 ^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T1]
+'                                                    documentation ```vb\nIn T1\n```
+'                                                         ^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T2]
+'                                                            documentation ```vb\nOut T2\n```
+          Sub Method1(ByVal t1 As T1)
+'             ^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method1().
+'                     documentation ```vb\nSub ICovariantContravariant(Of In T1, Out T2).Method1(t1 As T1)\n```
+'                           ^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method1().(t1)
+'                              documentation ```vb\nt1 As T1\n```
+'                                 ^^ reference scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T1]
+
+          Function Method2() As T2
+'                  ^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method2().
+'                          documentation ```vb\nFunction ICovariantContravariant(Of In T1, Out T2).Method2() As T2\n```
+'                               ^^ reference scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T2]
+
+          End Interface
+
+          Public Class StructConstraintClass(Of T As Structure)
+'                      ^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#StructConstraintClass#
+'                                            documentation ```vb\nClass StructConstraintClass(Of T As Structure)\n```
+'                                               ^ definition scip-dotnet nuget . . VBMain/Classes#StructConstraintClass#[T]
+'                                                 documentation ```vb\nT\n```
+          End Class
+
+          Public Class ClassConstraintClass(Of T As Class)
+'                      ^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ClassConstraintClass#
+'                                           documentation ```vb\nClass ClassConstraintClass(Of T As Class)\n```
+'                                              ^ definition scip-dotnet nuget . . VBMain/Classes#ClassConstraintClass#[T]
+'                                                documentation ```vb\nT\n```
+          End Class
+
+          Public Class NewConstraintClass(Of T As New)
+'                      ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#NewConstraintClass#
+'                                         documentation ```vb\nClass NewConstraintClass(Of T As New)\n```
+'                                            ^ definition scip-dotnet nuget . . VBMain/Classes#NewConstraintClass#[T]
+'                                              documentation ```vb\nT\n```
+          End Class
+
+          Public Class TypeParameterConstraintClass(Of T As SomeInterface)
+'                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#TypeParameterConstraintClass#
+'                                                   documentation ```vb\nClass TypeParameterConstraintClass(Of T As SomeInterface)\n```
+'                                                      ^ definition scip-dotnet nuget . . VBMain/Classes#TypeParameterConstraintClass#[T]
+'                                                        documentation ```vb\nT\n```
+'                                                           ^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Classes#SomeInterface#
+          End Class
+
+          Private Class MultipleTypeParameterConstraintsClass(Of T1 As {SomeInterface, SomeInterface2, New}, T2 As SomeInterface2)
+'                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#MultipleTypeParameterConstraintsClass#
+'                                                             documentation ```vb\nClass MultipleTypeParameterConstraintsClass(Of T1 As {SomeInterface, SomeInterface2, New}, T2 As SomeInterface2)\n```
+'                                                                ^^ definition scip-dotnet nuget . . VBMain/Classes#MultipleTypeParameterConstraintsClass#[T1]
+'                                                                   documentation ```vb\nT1\n```
+'                                                                       ^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Classes#SomeInterface#
+'                                                                                      ^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Classes#SomeInterface2#
+'                                                                                                            ^^ definition scip-dotnet nuget . . VBMain/Classes#MultipleTypeParameterConstraintsClass#[T2]
+'                                                                                                               documentation ```vb\nT2\n```
+'                                                                                                                  ^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Classes#SomeInterface2#
+          End Class
+
+          Class IndexClass
+'               ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#IndexClass#
+'                          documentation ```vb\nClass IndexClass\n```
+              Private a As Boolean
+'                     ^ definition scip-dotnet nuget . . VBMain/Classes#IndexClass#a.
+'                       documentation ```vb\nPrivate IndexClass.a As Boolean\n```
+
+              Default Public Property Item(ByVal index As Integer) As Boolean
+'                                     ^^^^ definition scip-dotnet nuget . . VBMain/Classes#IndexClass#Item.
+'                                          documentation ```vb\nPublic Default Property IndexClass.Item(index As Integer) As Boolean\n```
+'                                                ^^^^^ definition scip-dotnet nuget . . VBMain/Classes#IndexClass#Item.(index)
+'                                                      documentation ```vb\nindex As Integer\n```
+                  Get
+                      Return a
+'                            ^ reference scip-dotnet nuget . . VBMain/Classes#IndexClass#a.
+                  End Get
+                  Set(ByVal value As Boolean)
+'                           ^^^^^ definition scip-dotnet nuget . . VBMain/Classes#IndexClass#set_Item().(value)
+'                                 documentation ```vb\nvalue As Boolean\n```
+                      a = value
+'                     ^ reference scip-dotnet nuget . . VBMain/Classes#IndexClass#a.
+'                         ^^^^^ reference scip-dotnet nuget . . VBMain/Classes#IndexClass#set_Item().(value)
+                  End Set
+              End Property
+          End Class
+
+      Interface SomeInterface
+'               ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#SomeInterface#
+'                             documentation ```vb\nInterface SomeInterface\n```
+      End Interface
+
+      Friend Interface SomeInterface2
+'                      ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#SomeInterface2#
+'                                     documentation ```vb\nInterface SomeInterface2\n```
+      End Interface
+
+      End Class
+
+  End Namespace

--- a/snapshots/output-net6.0/syntax/VBMain/Classes.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Classes.vb
@@ -71,7 +71,7 @@
 '                                                                 ^^ definition scip-dotnet nuget . . VBMain/Classes#InternalMultipleTypeParametersClass#[T2]
 '                                                                    documentation ```vb\nT2\n```
           End Class
-          
+
           Interface ICovariantContravariant(Of In T1, Out T2)
 '                   ^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#
 '                                           documentation ```vb\nInterface ICovariantContravariant(Of In T1, Out T2)\n```
@@ -79,17 +79,17 @@
 '                                                    documentation ```vb\nIn T1\n```
 '                                                         ^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T2]
 '                                                            documentation ```vb\nOut T2\n```
-          Sub Method1(ByVal t1 As T1)
-'             ^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method1().
-'                     documentation ```vb\nSub ICovariantContravariant(Of In T1, Out T2).Method1(t1 As T1)\n```
-'                           ^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method1().(t1)
-'                              documentation ```vb\nt1 As T1\n```
-'                                 ^^ reference scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T1]
+              Sub Method1(ByVal t1 As T1)
+'                 ^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method1().
+'                         documentation ```vb\nSub ICovariantContravariant(Of In T1, Out T2).Method1(t1 As T1)\n```
+'                               ^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method1().(t1)
+'                                  documentation ```vb\nt1 As T1\n```
+'                                     ^^ reference scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T1]
 
-          Function Method2() As T2
-'                  ^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method2().
-'                          documentation ```vb\nFunction ICovariantContravariant(Of In T1, Out T2).Method2() As T2\n```
-'                               ^^ reference scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T2]
+              Function Method2() As T2
+'                      ^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method2().
+'                              documentation ```vb\nFunction ICovariantContravariant(Of In T1, Out T2).Method2() As T2\n```
+'                                   ^^ reference scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T2]
 
           End Interface
 
@@ -160,15 +160,15 @@
               End Property
           End Class
 
-      Interface SomeInterface
-'               ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#SomeInterface#
-'                             documentation ```vb\nInterface SomeInterface\n```
-      End Interface
+          Interface SomeInterface
+'                   ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#SomeInterface#
+'                                 documentation ```vb\nInterface SomeInterface\n```
+          End Interface
 
-      Friend Interface SomeInterface2
-'                      ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#SomeInterface2#
-'                                     documentation ```vb\nInterface SomeInterface2\n```
-      End Interface
+          Friend Interface SomeInterface2
+'                          ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#SomeInterface2#
+'                                         documentation ```vb\nInterface SomeInterface2\n```
+          End Interface
 
       End Class
 

--- a/snapshots/output-net6.0/syntax/VBMain/Enums.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Enums.vb
@@ -1,0 +1,31 @@
+  Imports System.Diagnostics.CodeAnalysis
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+      Public Class Enums
+'                  ^^^^^ definition scip-dotnet nuget . . VBMain/Enums#
+'                        documentation ```vb\nClass Enums\n```
+          Enum EnumWithIntValues
+'              ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Enums#EnumWithIntValues#
+'                                documentation ```vb\nEnum EnumWithIntValues\n```
+              Ten = 10
+'             ^^^ definition scip-dotnet nuget . . VBMain/Enums#EnumWithIntValues#Ten.
+'                 documentation ```vb\nEnumWithIntValues.Ten = 10\n```
+              Twenty = 20
+'             ^^^^^^ definition scip-dotnet nuget . . VBMain/Enums#EnumWithIntValues#Twenty.
+'                    documentation ```vb\nEnumWithIntValues.Twenty = 20\n```
+          End Enum
+
+          Enum EnumWithByteValues
+'              ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Enums#EnumWithByteValues#
+'                                 documentation ```vb\nEnum EnumWithByteValues\n```
+              Five = &H05
+'             ^^^^ definition scip-dotnet nuget . . VBMain/Enums#EnumWithByteValues#Five.
+'                  documentation ```vb\nEnumWithByteValues.Five = 5\n```
+              Fifteen = &H0F
+'             ^^^^^^^ definition scip-dotnet nuget . . VBMain/Enums#EnumWithByteValues#Fifteen.
+'                     documentation ```vb\nEnumWithByteValues.Fifteen = 15\n```
+          End Enum
+      End Class
+  End Namespace

--- a/snapshots/output-net6.0/syntax/VBMain/Enums.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Enums.vb
@@ -20,10 +20,10 @@
           Enum EnumWithByteValues
 '              ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Enums#EnumWithByteValues#
 '                                 documentation ```vb\nEnum EnumWithByteValues\n```
-              Five = &H05
+              Five = &H5
 '             ^^^^ definition scip-dotnet nuget . . VBMain/Enums#EnumWithByteValues#Five.
 '                  documentation ```vb\nEnumWithByteValues.Five = 5\n```
-              Fifteen = &H0F
+              Fifteen = &HF
 '             ^^^^^^^ definition scip-dotnet nuget . . VBMain/Enums#EnumWithByteValues#Fifteen.
 '                     documentation ```vb\nEnumWithByteValues.Fifteen = 15\n```
           End Enum

--- a/snapshots/output-net6.0/syntax/VBMain/Events.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Events.vb
@@ -25,7 +25,7 @@
 '                 ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Events#EventHandlerList.
 '                                      ^^^^^ reference scip-dotnet nuget . . VBMain/Events#add_Event2().(value)
               End AddHandler
-              
+
               RemoveHandler(ByVal value As EventHandler)
 '                                 ^^^^^ definition scip-dotnet nuget . . VBMain/Events#remove_Event2().(value)
 '                                       documentation ```vb\nvalue As EventHandler\n```
@@ -33,23 +33,22 @@
 '                 ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Events#EventHandlerList.
 '                                         ^^^^^ reference scip-dotnet nuget . . VBMain/Events#remove_Event2().(value)
               End RemoveHandler
-              
+
               RaiseEvent(ByVal sender As Object, ByVal e As EventArgs)
 '                              ^^^^^^ definition scip-dotnet nuget . . VBMain/Events#raise_Event2().(sender)
 '                                     documentation ```vb\nsender As Object\n```
 '                                                      ^ definition scip-dotnet nuget . . VBMain/Events#raise_Event2().(e)
 '                                                        documentation ```vb\ne As EventArgs\n```
-              
                   For Each handler As EventHandler In EventHandlerList
 '                          ^^^^^^^ definition local 0
 '                                  documentation ```vb\nhandler As EventHandler\n```
 '                                                     ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Events#EventHandlerList.
                       If handler IsNot Nothing Then
 '                        ^^^^^^^ reference local 0
-                      handler.BeginInvoke(sender, e, Nothing, Nothing)
-'                     ^^^^^^^ reference local 0
-'                                         ^^^^^^ reference scip-dotnet nuget . . VBMain/Events#raise_Event2().(sender)
-'                                                 ^ reference scip-dotnet nuget . . VBMain/Events#raise_Event2().(e)
+                          handler.BeginInvoke(sender, e, Nothing, Nothing)
+'                         ^^^^^^^ reference local 0
+'                                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Events#raise_Event2().(sender)
+'                                                     ^ reference scip-dotnet nuget . . VBMain/Events#raise_Event2().(e)
                       End If
                   Next
               End RaiseEvent

--- a/snapshots/output-net6.0/syntax/VBMain/Events.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Events.vb
@@ -1,0 +1,65 @@
+  Imports System.Diagnostics.CodeAnalysis
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+      Public Class Events
+'                  ^^^^^^ definition scip-dotnet nuget . . VBMain/Events#
+'                         documentation ```vb\nClass Events\n```
+          Private EventHandlerList As New ArrayList
+'                 ^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Events#EventHandlerList.
+'                                  documentation ```vb\nPrivate Events.EventHandlerList As ArrayList\n```
+
+          Public Event Event1 As EventHandler(Of Integer)
+'                      ^^^^^^ definition scip-dotnet nuget . . VBMain/Events#Event1#
+'                             documentation ```vb\nPublic Event Events.Event1 As EventHandler\n```
+
+          Public Custom Event Event2 As EventHandler
+'                             ^^^^^^ definition scip-dotnet nuget . . VBMain/Events#Event2#
+'                                    documentation ```vb\nPublic Event Events.Event2 As EventHandler\n```
+
+              AddHandler(ByVal value As EventHandler)
+'                              ^^^^^ definition scip-dotnet nuget . . VBMain/Events#add_Event2().(value)
+'                                    documentation ```vb\nvalue As EventHandler\n```
+                  EventHandlerList.Add(value)
+'                 ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Events#EventHandlerList.
+'                                      ^^^^^ reference scip-dotnet nuget . . VBMain/Events#add_Event2().(value)
+              End AddHandler
+              
+              RemoveHandler(ByVal value As EventHandler)
+'                                 ^^^^^ definition scip-dotnet nuget . . VBMain/Events#remove_Event2().(value)
+'                                       documentation ```vb\nvalue As EventHandler\n```
+                  EventHandlerList.Remove(value)
+'                 ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Events#EventHandlerList.
+'                                         ^^^^^ reference scip-dotnet nuget . . VBMain/Events#remove_Event2().(value)
+              End RemoveHandler
+              
+              RaiseEvent(ByVal sender As Object, ByVal e As EventArgs)
+'                              ^^^^^^ definition scip-dotnet nuget . . VBMain/Events#raise_Event2().(sender)
+'                                     documentation ```vb\nsender As Object\n```
+'                                                      ^ definition scip-dotnet nuget . . VBMain/Events#raise_Event2().(e)
+'                                                        documentation ```vb\ne As EventArgs\n```
+              
+                  For Each handler As EventHandler In EventHandlerList
+'                          ^^^^^^^ definition local 0
+'                                  documentation ```vb\nhandler As EventHandler\n```
+'                                                     ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Events#EventHandlerList.
+                      If handler IsNot Nothing Then
+'                        ^^^^^^^ reference local 0
+                      handler.BeginInvoke(sender, e, Nothing, Nothing)
+'                     ^^^^^^^ reference local 0
+'                                         ^^^^^^ reference scip-dotnet nuget . . VBMain/Events#raise_Event2().(sender)
+'                                                 ^ reference scip-dotnet nuget . . VBMain/Events#raise_Event2().(e)
+                      End If
+                  Next
+              End RaiseEvent
+          End Event
+
+          Private Sub Event1Handler() Handles Me.Event1
+'                     ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Events#Event1Handler().
+'                                   documentation ```vb\nPrivate Sub Events.Event1Handler()\n```
+'                                                ^^^^^^ reference scip-dotnet nuget . . VBMain/Events#Event1#
+              Throw New NotImplementedException()
+          End Sub
+      End Class
+  End Namespace

--- a/snapshots/output-net6.0/syntax/VBMain/Expressions.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Expressions.vb
@@ -25,7 +25,7 @@
               A = Not A
 '             ^ reference local 0
 '                     ^ reference local 0
-              b = A
+              B = A
 '             ^ reference local 1
 '                 ^ reference local 0
               Dim C = True
@@ -133,9 +133,9 @@
 '                      ^ reference local 7
           End Sub
 
-           Private Sub AssignmentToBinaryExpression()
-'                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AssignmentToBinaryExpression().
-'                                                   documentation ```vb\nPrivate Sub Expressions.AssignmentToBinaryExpression()\n```
+          Private Sub AssignmentToBinaryExpression()
+'                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AssignmentToBinaryExpression().
+'                                                  documentation ```vb\nPrivate Sub Expressions.AssignmentToBinaryExpression()\n```
               Dim A = 42
 '                 ^ definition local 8
 '                   documentation ```vb\nA As Integer\n```
@@ -168,13 +168,13 @@
 '                  ^ reference local 8
           End Sub
 
-           Structure Struct
-'                    ^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Struct#
-'                           documentation ```vb\nStructure Struct\n```
+          Structure Struct
+'                   ^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Struct#
+'                          documentation ```vb\nStructure Struct\n```
               Public [Property] As Integer
 '                    ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Struct#Property.
 '                               documentation ```vb\nPublic Struct.Property As Integer\n```
-           End Structure
+          End Structure
 
           Structure IndexedClass
 '                   ^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#IndexedClass#
@@ -205,7 +205,7 @@
           Private Sub AssignmentToLeftValueTypes()
 '                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AssignmentToLeftValueTypes().
 '                                                documentation ```vb\nPrivate Sub Expressions.AssignmentToLeftValueTypes()\n```
-              Dim E As (A As Integer, B As Integer) = (1, 2) 
+              Dim E As (A As Integer, B As Integer) = (1, 2)
 '                 ^ definition local 9
 '                   documentation ```vb\nE As (A As Integer, B As Integer)\n```
               Dim A = 1
@@ -225,7 +225,7 @@
 '                 ^ definition local 12
 '                   documentation ```vb\nD As Structure IndexedClass\n```
 '                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#
-              d(E.B) = 1
+              D(E.B) = 1
 '             ^ reference local 12
 '               ^ reference local 9
 '                 ^ reference local 14
@@ -247,14 +247,14 @@
               Dim X = True
 '                 ^ definition local 17
 '                   documentation ```vb\nX As Boolean\n```
-              Dim Y = If(x, "foo", "bar")
+              Dim Y = If(X, "foo", "bar")
 '                 ^ definition local 18
 '                   documentation ```vb\nY As Object\n```
 '                        ^ reference local 17
               Dim Z As Object = True
 '                 ^ definition local 19
 '                   documentation ```vb\nZ As Object\n```
-              Dim T = If(TypeOf z Is Boolean, 42, 41)
+              Dim T = If(TypeOf Z Is Boolean, 42, 41)
 '                 ^ definition local 20
 '                   documentation ```vb\nT As Object\n```
 '                               ^ reference local 19
@@ -317,7 +317,7 @@
 '                                                 ^ reference local 21
 '                                                    ^ reference local 22
 '                                                           ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
-              Dim E = CType((C.nested.nested2), Cast.Cast2)
+              Dim E = CType((C.Nested.Nested2), Cast.Cast2)
 '                 ^ definition local 25
 '                   documentation ```vb\nE As Class Cast2\n```
 '                            ^ reference local 23
@@ -347,11 +347,11 @@
 '                 ^ definition local 29
 '                   documentation ```vb\nX As AnonymousType <anonymous type: Key Helper As String>\n```
 '                                    ^^^^^^ reference local 31
-              Dim Y = New With {x}
+              Dim Y = New With {X}
 '                 ^ definition local 32
-'                   documentation ```vb\nY As AnonymousType <anonymous type: x As AnonymousType <anonymous type: Key Helper As String>>\n```
+'                   documentation ```vb\nY As AnonymousType <anonymous type: X As AnonymousType <anonymous type: Key Helper As String>>\n```
 '                               ^ reference local 29
-              Return Y.X.Helper
+              Return Y.x.Helper
 '                    ^ reference local 32
 '                      ^ reference local 34
 '                        ^^^^^^ reference local 31
@@ -458,11 +458,11 @@
 '                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParameters().
 '                                          documentation ```vb\nPrivate Function Expressions.NamedParameters() As NamedParametersClass\n```
 '                                               ^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#
-              Dim A = New NamedParametersClass(B:="hi", A:=1)
+              Dim A = New NamedParametersClass(b:="hi", a:=1)
 '                 ^ definition local 37
 '                   documentation ```vb\nA As Class NamedParametersClass\n```
 '                         ^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#
-              A.Update(B:="foo", A:=42)
+              A.Update(b:="foo", a:=42)
 '             ^ reference local 37
               Return A
 '                    ^ reference local 37
@@ -542,7 +542,7 @@
               Dim A = (1, 2, "")
 '                 ^ definition local 55
 '                   documentation ```vb\nA As (Integer, Integer, String)\n```
-          End Sub 
+          End Sub
 
           Private Sub ArrayCreation()
 '                     ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#ArrayCreation().
@@ -589,9 +589,9 @@
 '                       documentation ```vb\nsales As Double()()\n```
           End Sub
 
-           Private Sub [TypeOf]()
-'                      ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#TypeOf().
-'                               documentation ```vb\nPrivate Sub Expressions.TypeOf()\n```
+          Private Sub [TypeOf]()
+'                     ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#TypeOf().
+'                              documentation ```vb\nPrivate Sub Expressions.TypeOf()\n```
               Dim a = GetType(Integer)
 '                 ^ definition local 65
 '                   documentation ```vb\na As Type\n```
@@ -626,7 +626,7 @@
           Private Sub Dictionary()
 '                     ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Dictionary().
 '                                documentation ```vb\nPrivate Sub Expressions.Dictionary()\n```
-              Dim A = New Dictionary(Of String, Integer) From {{ 1, "Test1" }, { 2, "Test1" }}
+              Dim A = New Dictionary(Of String, Integer) From {{1, "Test1"}, {2, "Test1"}}
 '                 ^ definition local 70
 '                   documentation ```vb\nA As Dictionary\n```
           End Sub

--- a/snapshots/output-net6.0/syntax/VBMain/Expressions.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Expressions.vb
@@ -1,0 +1,635 @@
+  Imports System.Diagnostics.CodeAnalysis
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+      Public Class Expressions
+'                  ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#
+'                              documentation ```vb\nClass Expressions\n```
+
+          Private Sub AssignmentToPrefixUnaryExpressions()
+'                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AssignmentToPrefixUnaryExpressions().
+'                                                        documentation ```vb\nPrivate Sub Expressions.AssignmentToPrefixUnaryExpressions()\n```
+              Dim A = 42
+'                 ^ definition local 0
+'                   documentation ```vb\nA As Integer\n```
+              Dim B = 42
+'                 ^ definition local 1
+'                   documentation ```vb\nB As Integer\n```
+              A = +A
+'             ^ reference local 0
+'                  ^ reference local 0
+              A = -A
+'             ^ reference local 0
+'                  ^ reference local 0
+              A = Not A
+'             ^ reference local 0
+'                     ^ reference local 0
+              b = A
+'             ^ reference local 1
+'                 ^ reference local 0
+              Dim C = True
+'                 ^ definition local 2
+'                   documentation ```vb\nC As Boolean\n```
+              C = Not C
+'             ^ reference local 2
+'                     ^ reference local 2
+          End Sub
+
+          Private Sub AssignmentToPrefixBinaryExpressions()
+'                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AssignmentToPrefixBinaryExpressions().
+'                                                         documentation ```vb\nPrivate Sub Expressions.AssignmentToPrefixBinaryExpressions()\n```
+              Dim A = 42
+'                 ^ definition local 3
+'                   documentation ```vb\nA As Integer\n```
+              A = A + A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                     ^ reference local 3
+              A = A - A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                     ^ reference local 3
+              A = A * A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                     ^ reference local 3
+              A = A / A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                     ^ reference local 3
+              A = A \ A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                     ^ reference local 3
+              A = A ^ A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                     ^ reference local 3
+              A = A Mod A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                       ^ reference local 3
+              A = A And A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                       ^ reference local 3
+              A = A Or A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                      ^ reference local 3
+              A = A Xor A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                       ^ reference local 3
+              A = A << A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                      ^ reference local 3
+              A = A >> A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                      ^ reference local 3
+          End Sub
+
+          Private Sub AssignmentToBinaryEqualityExpression()
+'                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AssignmentToBinaryEqualityExpression().
+'                                                          documentation ```vb\nPrivate Sub Expressions.AssignmentToBinaryEqualityExpression()\n```
+              Dim A = True
+'                 ^ definition local 4
+'                   documentation ```vb\nA As Boolean\n```
+              Dim B = True
+'                 ^ definition local 5
+'                   documentation ```vb\nB As Boolean\n```
+              Dim C = 42
+'                 ^ definition local 6
+'                   documentation ```vb\nC As Integer\n```
+              Dim D = 42
+'                 ^ definition local 7
+'                   documentation ```vb\nD As Integer\n```
+              A = A = B
+'             ^ reference local 4
+'                 ^ reference local 4
+'                     ^ reference local 5
+              A = A <> B
+'             ^ reference local 4
+'                 ^ reference local 4
+'                      ^ reference local 5
+              A = C < D
+'             ^ reference local 4
+'                 ^ reference local 6
+'                     ^ reference local 7
+              A = C <= D
+'             ^ reference local 4
+'                 ^ reference local 6
+'                      ^ reference local 7
+              A = C > D
+'             ^ reference local 4
+'                 ^ reference local 6
+'                     ^ reference local 7
+              A = C >= D
+'             ^ reference local 4
+'                 ^ reference local 6
+'                      ^ reference local 7
+          End Sub
+
+           Private Sub AssignmentToBinaryExpression()
+'                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AssignmentToBinaryExpression().
+'                                                   documentation ```vb\nPrivate Sub Expressions.AssignmentToBinaryExpression()\n```
+              Dim A = 42
+'                 ^ definition local 8
+'                   documentation ```vb\nA As Integer\n```
+              A += A
+'             ^ reference local 8
+'                  ^ reference local 8
+              A -= A
+'             ^ reference local 8
+'                  ^ reference local 8
+              A *= A
+'             ^ reference local 8
+'                  ^ reference local 8
+              A /= A
+'             ^ reference local 8
+'                  ^ reference local 8
+              A \= A
+'             ^ reference local 8
+'                  ^ reference local 8
+              A &= A
+'             ^ reference local 8
+'                  ^ reference local 8
+              A <<= A
+'             ^ reference local 8
+'                   ^ reference local 8
+              A >>= A
+'             ^ reference local 8
+'                   ^ reference local 8
+              A ^= A
+'             ^ reference local 8
+'                  ^ reference local 8
+          End Sub
+
+           Structure Struct
+'                    ^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Struct#
+'                           documentation ```vb\nStructure Struct\n```
+              Public [Property] As Integer
+'                    ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Struct#Property.
+'                               documentation ```vb\nPublic Struct.Property As Integer\n```
+           End Structure
+
+          Structure IndexedClass
+'                   ^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#IndexedClass#
+'                                documentation ```vb\nStructure IndexedClass\n```
+              Public [Property] As Integer
+'                    ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Property.
+'                               documentation ```vb\nPublic IndexedClass.Property As Integer\n```
+
+              Default Public Property Item(ByVal index As Integer) As Integer
+'                                     ^^^^ definition scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Item.
+'                                          documentation ```vb\nPublic Default Property IndexedClass.Item(index As Integer) As Integer\n```
+'                                                ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Item.(index)
+'                                                      documentation ```vb\nindex As Integer\n```
+                  Get
+                      Return [Property]
+'                            ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Property.
+                  End Get
+                  Set(ByVal value As Integer)
+'                           ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#IndexedClass#set_Item().(value)
+'                                 documentation ```vb\nvalue As Integer\n```
+                      [Property] = value
+'                     ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Property.
+'                                  ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#set_Item().(value)
+                  End Set
+              End Property
+          End Structure
+
+          Private Sub AssignmentToLeftValueTypes()
+'                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AssignmentToLeftValueTypes().
+'                                                documentation ```vb\nPrivate Sub Expressions.AssignmentToLeftValueTypes()\n```
+              Dim E As (A As Integer, B As Integer) = (1, 2) 
+'                 ^ definition local 9
+'                   documentation ```vb\nE As (A As Integer, B As Integer)\n```
+              Dim A = 1
+'                 ^ definition local 10
+'                   documentation ```vb\nA As Integer\n```
+              Dim C = New Struct With {
+'                 ^ definition local 11
+'                   documentation ```vb\nC As Structure Struct\n```
+'                         ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Struct#
+                  .[Property] = 42
+'                  ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Struct#Property.
+              }
+              C.[Property] = 1
+'             ^ reference local 11
+'               ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Struct#Property.
+              Dim D = New IndexedClass()
+'                 ^ definition local 12
+'                   documentation ```vb\nD As Structure IndexedClass\n```
+'                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#
+              d(E.B) = 1
+'             ^ reference local 12
+'               ^ reference local 9
+'                 ^ reference local 14
+              Dim X = New IndexedClass With {
+'                 ^ definition local 15
+'                   documentation ```vb\nX As Structure IndexedClass\n```
+'                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#
+                  .[Property] = 1
+'                  ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Property.
+              }
+              E.A = 1
+'             ^ reference local 9
+'               ^ reference local 16
+          End Sub
+
+          Private Sub TernaryExpression()
+'                     ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#TernaryExpression().
+'                                       documentation ```vb\nPrivate Sub Expressions.TernaryExpression()\n```
+              Dim X = True
+'                 ^ definition local 17
+'                   documentation ```vb\nX As Boolean\n```
+              Dim Y = If(x, "foo", "bar")
+'                 ^ definition local 18
+'                   documentation ```vb\nY As Object\n```
+'                        ^ reference local 17
+              Dim Z As Object = True
+'                 ^ definition local 19
+'                   documentation ```vb\nZ As Object\n```
+              Dim T = If(TypeOf z Is Boolean, 42, 41)
+'                 ^ definition local 20
+'                   documentation ```vb\nT As Object\n```
+'                               ^ reference local 19
+          End Sub
+
+          Class Cast
+'               ^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Cast#
+'                    documentation ```vb\nClass Cast\n```
+              Public Nested As Cast
+'                    ^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Cast#Nested.
+'                           documentation ```vb\nPublic Cast.Nested As Cast\n```
+'                              ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+              Public Nested2 As Cast2
+'                    ^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Cast#Nested2.
+'                            documentation ```vb\nPublic Cast.Nested2 As Cast2\n```
+'                               ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Cast2#
+
+              Public Function Plus(ByVal other As Cast) As Cast
+'                             ^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Cast#Plus().
+'                                  documentation ```vb\nPublic Function Cast.Plus(other As Cast) As Cast\n```
+'                                        ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Cast#Plus().(other)
+'                                              documentation ```vb\nother As Cast\n```
+'                                                 ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+'                                                          ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+                  Nested = other
+'                 ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Nested.
+'                          ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Plus().(other)
+                  Return Me
+              End Function
+
+              Public Class Cast2
+'                          ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Cast#Cast2#
+'                                documentation ```vb\nClass Cast2\n```
+              End Class
+          End Class
+
+          Private Function CastExpressions() As Integer
+'                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#CastExpressions().
+'                                          documentation ```vb\nPrivate Function Expressions.CastExpressions() As Integer\n```
+              Dim A As Object = New Cast()
+'                 ^ definition local 21
+'                   documentation ```vb\nA As Object\n```
+'                                   ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+              Dim B As Object = New Cast()
+'                 ^ definition local 22
+'                   documentation ```vb\nB As Object\n```
+'                                   ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+              Dim C As Cast = (CType(A, Cast)).Plus(CType(B, Cast))
+'                 ^ definition local 23
+'                   documentation ```vb\nC As Class Cast\n```
+'                      ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+'                                    ^ reference local 21
+'                                       ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+'                                                         ^ reference local 22
+'                                                            ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+              Dim D As Cast = CType(New Object() {A, B}(0), Cast)
+'                 ^ definition local 24
+'                   documentation ```vb\nD As Class Cast\n```
+'                      ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+'                                                 ^ reference local 21
+'                                                    ^ reference local 22
+'                                                           ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+              Dim E = CType((C.nested.nested2), Cast.Cast2)
+'                 ^ definition local 25
+'                   documentation ```vb\nE As Class Cast2\n```
+'                            ^ reference local 23
+'                              ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Nested.
+'                                     ^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Nested2.
+'                                               ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+'                                                    ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Cast2#
+              Dim F = CType((1), Int32)
+'                 ^ definition local 26
+'                   documentation ```vb\nF As Int32\n```
+              Dim G = CType((1), Int32)
+'                 ^ definition local 27
+'                   documentation ```vb\nG As Int32\n```
+              Dim H = CType(((1)), Int32)
+'                 ^ definition local 28
+'                   documentation ```vb\nH As Int32\n```
+              Return F + G + H
+'                    ^ reference local 26
+'                        ^ reference local 27
+'                            ^ reference local 28
+          End Function
+
+          Private Function AnonymousObject() As Object
+'                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AnonymousObject().
+'                                          documentation ```vb\nPrivate Function Expressions.AnonymousObject() As Object\n```
+              Dim X = New With {Key .Helper = ""}
+'                 ^ definition local 29
+'                   documentation ```vb\nX As AnonymousType <anonymous type: Key Helper As String>\n```
+'                                    ^^^^^^ reference local 31
+              Dim Y = New With {x}
+'                 ^ definition local 32
+'                   documentation ```vb\nY As AnonymousType <anonymous type: x As AnonymousType <anonymous type: Key Helper As String>>\n```
+'                               ^ reference local 29
+              Return Y.X.Helper
+'                    ^ reference local 32
+'                      ^ reference local 34
+'                        ^^^^^^ reference local 31
+          End Function
+
+          Class ObjectCreationClass
+'               ^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#
+'                                   documentation ```vb\nClass ObjectCreationClass\n```
+              Public Field As D
+'                    ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#Field.
+'                          documentation ```vb\nPublic ObjectCreationClass.Field As D\n```
+'                             ^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#
+
+              Public Sub New(ByVal field As D)
+'                        ^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#`.ctor`().
+'                            documentation ```vb\nPublic Sub ObjectCreationClass.New(field As D)\n```
+'                                  ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#`.ctor`().(field)
+'                                        documentation ```vb\nfield As D\n```
+'                                           ^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#
+                  Me.Field = field
+'                    ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#Field.
+'                            ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#`.ctor`().(field)
+              End Sub
+
+              Public Class D
+'                          ^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#
+'                            documentation ```vb\nClass D\n```
+                  Public Sub New(ByVal a As Integer, ByVal b As String)
+'                            ^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#`.ctor`().
+'                                documentation ```vb\nPublic Sub D.New(a As Integer, b As String)\n```
+'                                      ^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#`.ctor`().(a)
+'                                        documentation ```vb\na As Integer\n```
+'                                                          ^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#`.ctor`().(b)
+'                                                            documentation ```vb\nb As String\n```
+                  End Sub
+              End Class
+          End Class
+
+          Private Sub ObjectCreation()
+'                     ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreation().
+'                                    documentation ```vb\nPrivate Sub Expressions.ObjectCreation()\n```
+              Dim A = New ObjectCreationClass.D(1, "hi")
+'                 ^ definition local 35
+'                   documentation ```vb\nA As Class D\n```
+'                         ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#
+'                                             ^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#
+              Dim B = New ObjectCreationClass(A) With {
+'                 ^ definition local 36
+'                   documentation ```vb\nB As Class ObjectCreationClass\n```
+'                         ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#
+'                                             ^ reference local 35
+                  .Field = A
+'                  ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#Field.
+'                          ^ reference local 35
+              }
+              B = New ObjectCreationClass(A)
+'             ^ reference local 36
+'                     ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#
+'                                         ^ reference local 35
+          End Sub
+
+          Class NamedParametersClass
+'               ^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#
+'                                    documentation ```vb\nClass NamedParametersClass\n```
+              Public A As Integer
+'                    ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#A.
+'                      documentation ```vb\nPublic NamedParametersClass.A As Integer\n```
+              Public B As String
+'                    ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#B.
+'                      documentation ```vb\nPublic NamedParametersClass.B As String\n```
+
+              Public Sub New(ByVal a As Integer, ByVal b As String)
+'                        ^^^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().
+'                            documentation ```vb\nPublic Sub NamedParametersClass.New(a As Integer, b As String)\n```
+'                                  ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(a)
+'                                    documentation ```vb\na As Integer\n```
+'                                                      ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(b)
+'                                                        documentation ```vb\nb As String\n```
+                  Me.A = a
+'                    ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#A.
+'                        ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(a)
+                  Me.B = b
+'                    ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#B.
+'                        ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(b)
+              End Sub
+
+              Public Sub Update(ByVal a As Integer, ByVal b As String)
+'                        ^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().
+'                               documentation ```vb\nPublic Sub NamedParametersClass.Update(a As Integer, b As String)\n```
+'                                     ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(a)
+'                                       documentation ```vb\na As Integer\n```
+'                                                         ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(b)
+'                                                           documentation ```vb\nb As String\n```
+                  Me.A = a
+'                    ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#A.
+'                        ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(a)
+                  Me.B = b
+'                    ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#B.
+'                        ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(b)
+              End Sub
+          End Class
+
+          Private Function NamedParameters() As NamedParametersClass
+'                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParameters().
+'                                          documentation ```vb\nPrivate Function Expressions.NamedParameters() As NamedParametersClass\n```
+'                                               ^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#
+              Dim A = New NamedParametersClass(B:="hi", A:=1)
+'                 ^ definition local 37
+'                   documentation ```vb\nA As Class NamedParametersClass\n```
+'                         ^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#
+              A.Update(B:="foo", A:=42)
+'             ^ reference local 37
+              Return A
+'                    ^ reference local 37
+          End Function
+
+          Private Function AnonymousFunction() As Func(Of Integer, Integer)
+'                          ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AnonymousFunction().
+'                                            documentation ```vb\nPrivate Function Expressions.AnonymousFunction() As Func\n```
+              Dim d = Function(ByVal __ As Integer, ByVal ___ As Integer) 42
+'                 ^ definition local 38
+'                   documentation ```vb\nd As AnonymousType Function <generated method>(__ As Integer, ___ As Integer) As \n```
+'                                    ^^ definition local 40
+'                                       documentation ```vb\n__ As Integer\n```
+'                                                         ^^^ definition local 41
+'                                                             documentation ```vb\n___ As Integer\n```
+              Return Function(ByVal a As Integer) a + d.Invoke(a, a)
+'                                   ^ definition local 43
+'                                     documentation ```vb\na As Integer\n```
+'                                                 ^ reference local 43
+'                                                     ^ reference local 38
+'                                                              ^ reference local 43
+'                                                                 ^ reference local 43
+          End Function
+
+          Class Lambda
+'               ^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Lambda#
+'                      documentation ```vb\nClass Lambda\n```
+              Public Function func(ByVal x As Lambda) As String
+'                             ^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Lambda#func().
+'                                  documentation ```vb\nPublic Function Lambda.func(x As Lambda) As String\n```
+'                                        ^ definition scip-dotnet nuget . . VBMain/Expressions#Lambda#func().(x)
+'                                          documentation ```vb\nx As Lambda\n```
+'                                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
+                  Return ""
+              End Function
+          End Class
+
+          Private Sub LambdaExpressions()
+'                     ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#LambdaExpressions().
+'                                       documentation ```vb\nPrivate Sub Expressions.LambdaExpressions()\n```
+              Dim a = Function(ByVal x As String) x & 1
+'                 ^ definition local 44
+'                   documentation ```vb\na As AnonymousType Function <generated method>(x As String) As \n```
+'                                    ^ definition local 46
+'                                      documentation ```vb\nx As String\n```
+'                                                 ^ reference local 46
+              Dim b = Function(ByVal aa As Lambda, ByVal bb As Lambda) aa.func(bb)
+'                 ^ definition local 47
+'                   documentation ```vb\nb As AnonymousType Function <generated method>(aa As Lambda, bb As Lambda) As \n```
+'                                    ^^ definition local 49
+'                                       documentation ```vb\naa As Lambda\n```
+'                                          ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
+'                                                        ^^ definition local 50
+'                                                           documentation ```vb\nbb As Lambda\n```
+'                                                              ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
+'                                                                      ^^ reference local 49
+'                                                                         ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#func().
+'                                                                              ^^ reference local 50
+              Dim c = Function(aaa As Lambda, __ As Lambda)
+'                 ^ definition local 51
+'                   documentation ```vb\nc As AnonymousType Function <generated method>(aaa As Lambda, __ As Lambda) As \n```
+'                              ^^^ definition local 53
+'                                  documentation ```vb\naaa As Lambda\n```
+'                                     ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
+'                                             ^^ definition local 54
+'                                                documentation ```vb\n__ As Lambda\n```
+'                                                   ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
+                          If True Then
+                              Return "hi"
+                          End If
+                      End Function
+          End Sub
+
+          Private Sub TupleExpression()
+'                     ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#TupleExpression().
+'                                     documentation ```vb\nPrivate Sub Expressions.TupleExpression()\n```
+              Dim A = (1, 2, "")
+'                 ^ definition local 55
+'                   documentation ```vb\nA As (Integer, Integer, String)\n```
+          End Sub 
+
+          Private Sub ArrayCreation()
+'                     ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#ArrayCreation().
+'                                   documentation ```vb\nPrivate Sub Expressions.ArrayCreation()\n```
+              Dim a = {
+'                 ^ definition local 56
+'                   documentation ```vb\na As Object(*,*)\n```
+              {1, 1},
+              {2, 2},
+              {3, 3}}
+              Dim d = New Integer(2) {1, 2, 3}
+'                 ^ definition local 57
+'                   documentation ```vb\nd As Integer()\n```
+              Dim e = New Byte(,) {
+'                 ^ definition local 58
+'                   documentation ```vb\ne As Byte(*,*)\n```
+              {1, 2},
+              {2, 3}}
+              Dim f = New Integer(2, 1) {
+'                 ^ definition local 59
+'                   documentation ```vb\nf As Integer(*,*)\n```
+              {1, 1},
+              {2, 2},
+              {3, 3}}
+
+              Dim numbers(4) As Integer
+'                 ^^^^^^^ definition local 60
+'                         documentation ```vb\nnumbers As Integer()\n```
+              Dim numbers2 = New Integer() {1, 2, 4, 8}
+'                 ^^^^^^^^ definition local 61
+'                          documentation ```vb\nnumbers2 As Integer()\n```
+              ReDim Preserve numbers(15)
+'                            ^^^^^^^ reference local 60
+              ReDim numbers(15)
+'                   ^^^^^^^ reference local 60
+              Dim matrix(5, 5) As Double
+'                 ^^^^^^ definition local 62
+'                        documentation ```vb\nmatrix As Double(*,*)\n```
+              Dim matrix2 = New Integer(,) {{1, 2, 3}, {2, 3, 4}, {3, 4, 5}, {4, 5, 6}}
+'                 ^^^^^^^ definition local 63
+'                         documentation ```vb\nmatrix2 As Integer(*,*)\n```
+              Dim sales()() As Double = New Double(11)() {}
+'                 ^^^^^ definition local 64
+'                       documentation ```vb\nsales As Double()()\n```
+          End Sub
+
+           Private Sub [TypeOf]()
+'                      ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#TypeOf().
+'                               documentation ```vb\nPrivate Sub Expressions.TypeOf()\n```
+              Dim a = GetType(Integer)
+'                 ^ definition local 65
+'                   documentation ```vb\na As Type\n```
+              Dim b = GetType(List(Of String).Enumerator)
+'                 ^ definition local 66
+'                   documentation ```vb\nb As Type\n```
+              Dim c = GetType(Dictionary(Of,))
+'                 ^ definition local 67
+'                   documentation ```vb\nc As Type\n```
+              Dim d = GetType(Tuple(Of,,,))
+'                 ^ definition local 68
+'                   documentation ```vb\nd As Type\n```
+          End Sub
+
+          Private Sub SelectCase()
+'                     ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#SelectCase().
+'                                documentation ```vb\nPrivate Sub Expressions.SelectCase()\n```
+              Dim Some = 42
+'                 ^^^^ definition local 69
+'                      documentation ```vb\nSome As Integer\n```
+              Select Case Some
+'                         ^^^^ reference local 69
+                  Case 1
+                      Debug.WriteLine("One")
+                  Case 2
+                      Debug.WriteLine("One")
+                  Case Else
+                      Debug.WriteLine("More")
+              End Select
+          End Sub
+
+          Private Sub Dictionary()
+'                     ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Dictionary().
+'                                documentation ```vb\nPrivate Sub Expressions.Dictionary()\n```
+              Dim A = New Dictionary(Of String, Integer) From {{ 1, "Test1" }, { 2, "Test1" }}
+'                 ^ definition local 70
+'                   documentation ```vb\nA As Dictionary\n```
+          End Sub
+
+      End Class
+  End Namespace

--- a/snapshots/output-net6.0/syntax/VBMain/Fields.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Fields.vb
@@ -1,0 +1,50 @@
+  Imports System.Diagnostics.CodeAnalysis
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+      Public Class Fields
+'                  ^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#
+'                         documentation ```vb\nClass Fields\n```
+          Class Fields1
+'               ^^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#
+'                       documentation ```vb\nClass Fields1\n```
+              Private ReadOnly Property1 As Integer
+'                              ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#Property1.
+'                                        documentation ```vb\nPrivate ReadOnly Fields1.Property1 As Integer\n```
+              Private Property2, Property3 As Int64
+'                     ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#Property2.
+'                               documentation ```vb\nPrivate Fields1.Property2 As Int64\n```
+'                                ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#Property3.
+'                                          documentation ```vb\nPrivate Fields1.Property3 As Int64\n```
+              Private Property4 As Tuple(Of Char, Nullable(Of Integer))
+'                     ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#Property4.
+'                               documentation ```vb\nPrivate Fields1.Property4 As Tuple\n```
+
+              Public Sub New(ByVal field2 As Long, ByVal field3 As Long, ByVal field4 As Tuple(Of Char, Integer?), ByVal field1 As Integer)
+'                        ^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().
+'                            documentation ```vb\nPublic Sub Fields1.New(field2 As Long, field3 As Long, field4 As Tuple, field1 As Integer)\n```
+'                                  ^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field2)
+'                                         documentation ```vb\nfield2 As Long\n```
+'                                                        ^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field3)
+'                                                               documentation ```vb\nfield3 As Long\n```
+'                                                                              ^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field4)
+'                                                                                     documentation ```vb\nfield4 As Tuple\n```
+'                                                                                                                        ^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field1)
+'                                                                                                                               documentation ```vb\nfield1 As Integer\n```
+                  Property2 = field2
+'                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#Property2.
+'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field2)
+                  Property3 = field3
+'                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#Property3.
+'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field3)
+                  Property4 = field4
+'                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#Property4.
+'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field4)
+                  Property1 = field1
+'                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#Property1.
+'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field1)
+              End Sub
+          End Class
+      End Class
+  End Namespace

--- a/snapshots/output-net6.0/syntax/VBMain/GlobalAttributes.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/GlobalAttributes.vb
@@ -1,0 +1,70 @@
+  Imports System.Diagnostics.CodeAnalysis
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+      <AttributeUsage(AttributeTargets.[Class], AllowMultiple:=True, Inherited:=True)>
+      Public Class GlobalAttributes
+'                  ^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#
+'                                   documentation ```vb\nClass GlobalAttributes\n```
+'                                   relationship implementation Attribute#
+          Inherits Attribute
+
+          Class AuthorAttribute
+'               ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#AuthorAttribute#
+'                               documentation ```vb\nClass AuthorAttribute\n```
+'                               relationship implementation Attribute#
+              Inherits Attribute
+
+              Public Sub New(ByVal name As String)
+'                        ^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#AuthorAttribute#`.ctor`().
+'                            documentation ```vb\nPublic Sub AuthorAttribute.New(name As String)\n```
+'                                  ^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#AuthorAttribute#`.ctor`().(name)
+'                                       documentation ```vb\nname As String\n```
+              End Sub
+          End Class
+
+          <Author("PropertyAttribute")>
+          Public Z As Integer
+'                ^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#Z.
+'                  documentation ```vb\nPublic GlobalAttributes.Z As Integer\n```
+
+          <Author("MethodAttribute")>
+          Private Function Method1() As Integer
+'                          ^^^^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#Method1().
+'                                  documentation ```vb\nPrivate Function GlobalAttributes.Method1() As Integer\n```
+              Return 0
+          End Function
+
+          <Author("EnumAttribute")>
+          Enum A
+'              ^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#A#
+'                documentation ```vb\nEnum A\n```
+              B
+'             ^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#A#B.
+'               documentation ```vb\nA.B = 0\n```
+              C
+'             ^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#A#C.
+'               documentation ```vb\nA.C = 1\n```
+          End Enum
+
+          <Author("EventAttribute")>
+          Public Event SomeEvent As EventHandler
+'                      ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#SomeEvent#
+'                                documentation ```vb\nPublic Event GlobalAttributes.SomeEvent As EventHandler\n```
+
+          <Author("TypeParameterAttribute")>
+          Public Class InnerClass(Of T)
+'                      ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#InnerClass#
+'                                 documentation ```vb\nClass InnerClass(Of T)\n```
+'                                    ^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#InnerClass#[T]
+'                                      documentation ```vb\nT\n```
+              Private Sub Method(Of T2)()
+'                         ^^^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#InnerClass#Method().
+'                                documentation ```vb\nPrivate Sub InnerClass(Of T).Method(Of T2)()\n```
+'                                   ^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#InnerClass#Method().[T2]
+'                                      documentation ```vb\nT2\n```
+              End Sub
+          End Class
+      End Class
+  End Namespace

--- a/snapshots/output-net6.0/syntax/VBMain/Identifiers.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Identifiers.vb
@@ -1,0 +1,42 @@
+  Imports System.Diagnostics.CodeAnalysis
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+      Public Class Identifiers
+'                  ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Identifiers#
+'                              documentation ```vb\nClass Identifiers\n```
+          Private Sub SpecialNames()
+'                     ^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Identifiers#SpecialNames().
+'                                  documentation ```vb\nPrivate Sub Identifiers.SpecialNames()\n```
+              Dim [const] = 42
+'                 ^^^^^^^ definition local 0
+'                         documentation ```vb\n[const] As Integer\n```
+              Dim var As Integer = [const]
+'                 ^^^ definition local 1
+'                     documentation ```vb\nvar As Integer\n```
+'                                  ^^^^^^^ reference local 0
+              Dim under_score = 0
+'                 ^^^^^^^^^^^ definition local 2
+'                             documentation ```vb\nunder_score As Integer\n```
+              Dim with1number = 0
+'                 ^^^^^^^^^^^ definition local 3
+'                             documentation ```vb\nwith1number As Integer\n```
+              Dim varæble = 0
+'                 ^^^^^^^ definition local 4
+'                         documentation ```vb\nvaræble As Integer\n```
+              Dim Переменная = 0
+'                 ^^^^^^^^^^ definition local 5
+'                            documentation ```vb\nПеременная As Integer\n```
+              Dim first‿letter = 0
+'                 ^^^^^^^^^^^^ definition local 6
+'                              documentation ```vb\nfirst‿letter As Integer\n```
+              Dim ග්රහලෝකය = 0
+'                 ^^^^^^^^ definition local 7
+'                          documentation ```vb\nග්රහලෝකය As Integer\n```
+              Dim _كوكبxxx = 0
+'                 ^^^^^^^^ definition local 8
+'                          documentation ```vb\n_كوكبxxx As Integer\n```
+          End Sub
+      End Class
+  End Namespace

--- a/snapshots/output-net6.0/syntax/VBMain/Interfaces.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Interfaces.vb
@@ -1,0 +1,90 @@
+  Imports System.Diagnostics.CodeAnalysis
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+      Public Class Interfaces
+'                  ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#
+'                             documentation ```vb\nClass Interfaces\n```
+          Interface IOne
+'                   ^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IOne#
+'                        documentation ```vb\nInterface IOne\n```
+          End Interface
+
+          Interface ITwo
+'                   ^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#ITwo#
+'                        documentation ```vb\nInterface ITwo\n```
+          End Interface
+
+          Interface IThree
+'                   ^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IThree#
+'                          documentation ```vb\nInterface IThree\n```
+          End Interface
+
+          Interface IProperties
+'                   ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IProperties#
+'                               documentation ```vb\nInterface IProperties\n```
+              ReadOnly Property [Get] As Byte
+'                               ^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IProperties#Get.
+'                                     documentation ```vb\nReadOnly Property IProperties.Get As Byte\n```
+              WriteOnly Property [Set] As Char
+'                                ^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IProperties#Set.
+'                                      documentation ```vb\nWriteOnly Property IProperties.Set As Char\n```
+              Property GetSet As UInteger
+'                      ^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IProperties#GetSet.
+'                             documentation ```vb\nProperty IProperties.GetSet As UInteger\n```
+              Property SetGet As Long
+'                      ^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IProperties#SetGet.
+'                             documentation ```vb\nProperty IProperties.SetGet As Long\n```
+          End Interface
+
+          Interface IMethods
+'                   ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#
+'                            documentation ```vb\nInterface IMethods\n```
+              Sub [Nothing]()
+'                 ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#Nothing().
+'                           documentation ```vb\nSub IMethods.Nothing()\n```
+              Function Output() As Integer
+'                      ^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#Output().
+'                             documentation ```vb\nFunction IMethods.Output() As Integer\n```
+              Sub Input(ByVal a As String)
+'                 ^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#Input().
+'                       documentation ```vb\nSub IMethods.Input(a As String)\n```
+'                             ^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#Input().(a)
+'                               documentation ```vb\na As String\n```
+              Function InputOutput(ByVal a As String) As Integer
+'                      ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#InputOutput().
+'                                  documentation ```vb\nFunction IMethods.InputOutput(a As String) As Integer\n```
+'                                        ^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#InputOutput().(a)
+'                                          documentation ```vb\na As String\n```
+          End Interface
+
+          Interface IEvent
+'                   ^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IEvent#
+'                          documentation ```vb\nInterface IEvent\n```
+               Event SomeEvent As EventHandler(Of Integer)
+'                    ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IEvent#SomeEvent#
+'                              documentation ```vb\nEvent IEvent.SomeEvent As EventHandler\n```
+          End Interface
+
+          Interface IIndex
+'                   ^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IIndex#
+'                          documentation ```vb\nInterface IIndex\n```
+              Default Property Item(ByVal index As Integer) As Boolean
+'                              ^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IIndex#Item.
+'                                   documentation ```vb\nDefault Property IIndex.Item(index As Integer) As Boolean\n```
+'                                         ^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IIndex#Item.(index)
+'                                               documentation ```vb\nindex As Integer\n```
+          End Interface
+
+          Private Interface IInherit
+'                           ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IInherit#
+'                                    documentation ```vb\nInterface IInherit\n```
+'                                    relationship implementation scip-dotnet nuget . . VBMain/Interfaces#IOne#
+'                                    relationship implementation scip-dotnet nuget . . VBMain/Interfaces#ITwo#
+              Inherits IOne, ITwo
+'                      ^^^^ reference scip-dotnet nuget . . VBMain/Interfaces#IOne#
+'                            ^^^^ reference scip-dotnet nuget . . VBMain/Interfaces#ITwo#
+          End Interface
+      End Class
+  End Namespace

--- a/snapshots/output-net6.0/syntax/VBMain/Interfaces.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Interfaces.vb
@@ -62,9 +62,9 @@
           Interface IEvent
 '                   ^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IEvent#
 '                          documentation ```vb\nInterface IEvent\n```
-               Event SomeEvent As EventHandler(Of Integer)
-'                    ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IEvent#SomeEvent#
-'                              documentation ```vb\nEvent IEvent.SomeEvent As EventHandler\n```
+              Event SomeEvent As EventHandler(Of Integer)
+'                   ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IEvent#SomeEvent#
+'                             documentation ```vb\nEvent IEvent.SomeEvent As EventHandler\n```
           End Interface
 
           Interface IIndex

--- a/snapshots/output-net6.0/syntax/VBMain/Literals.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Literals.vb
@@ -1,0 +1,31 @@
+  Imports System.Diagnostics.CodeAnalysis
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+      Public Class Literals
+'                  ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Literals#
+'                           documentation ```vb\nClass Literals\n```
+          Private Function Interpolation() As String
+'                          ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Literals#Interpolation().
+'                                        documentation ```vb\nPrivate Function Literals.Interpolation() As String\n```
+              Dim a = 1
+'                 ^ definition local 0
+'                   documentation ```vb\na As Integer\n```
+              Dim b = 2
+'                 ^ definition local 1
+'                   documentation ```vb\nb As Integer\n```
+              Dim c = 3
+'                 ^ definition local 2
+'                   documentation ```vb\nc As Integer\n```
+              Dim d = 3
+'                 ^ definition local 3
+'                   documentation ```vb\nd As Integer\n```
+              Return $"a={a} b={b} c={c} d={d}"
+'                         ^ reference local 0
+'                               ^ reference local 1
+'                                     ^ reference local 2
+'                                           ^ reference local 3
+          End Function
+      End Class
+  End Namespace

--- a/snapshots/output-net6.0/syntax/VBMain/Methods.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Methods.vb
@@ -174,7 +174,7 @@
           Public Shared Sub InheritedOverloads()
 '                           ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads().
 '                                              documentation ```vb\nPublic Shared Sub Methods.InheritedOverloads()\n```
-              Dim a as InheritedOverloads1 = New InheritedOverloads1
+              Dim a As InheritedOverloads1 = New InheritedOverloads1
 '                 ^ definition local 0
 '                   documentation ```vb\na As Class InheritedOverloads1\n```
 '                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
@@ -182,7 +182,7 @@
               a.Method()
 '             ^ reference local 0
 '               ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#Method().
-              Dim b as InheritedOverloads2 = New InheritedOverloads2
+              Dim b As InheritedOverloads2 = New InheritedOverloads2
 '                 ^ definition local 1
 '                   documentation ```vb\nb As Class InheritedOverloads2\n```
 '                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
@@ -193,7 +193,7 @@
 '                                                ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#Method().
               b.Method(42)
 '             ^ reference local 1
-              Dim c as InheritedOverloads3 = New InheritedOverloads3
+              Dim c As InheritedOverloads3 = New InheritedOverloads3
 '                 ^ definition local 2
 '                   documentation ```vb\nc As Class InheritedOverloads3\n```
 '                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#

--- a/snapshots/output-net6.0/syntax/VBMain/Methods.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Methods.vb
@@ -1,0 +1,212 @@
+  Imports System.Diagnostics.CodeAnalysis
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+      Public Class Methods
+'                  ^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#
+'                          documentation ```vb\nClass Methods\n```
+          Private Function SingleParameter(ByVal b As Integer) As Integer
+'                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#SingleParameter().
+'                                          documentation ```vb\nPrivate Function Methods.SingleParameter(b As Integer) As Integer\n```
+'                                                ^ definition scip-dotnet nuget . . VBMain/Methods#SingleParameter().(b)
+'                                                  documentation ```vb\nb As Integer\n```
+              Return b
+'                    ^ reference scip-dotnet nuget . . VBMain/Methods#SingleParameter().(b)
+          End Function
+
+          Private Function TwoParameters(ByVal a As Integer, ByVal b As Integer) As Integer
+'                          ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#TwoParameters().
+'                                        documentation ```vb\nPrivate Function Methods.TwoParameters(a As Integer, b As Integer) As Integer\n```
+'                                              ^ definition scip-dotnet nuget . . VBMain/Methods#TwoParameters().(a)
+'                                                documentation ```vb\na As Integer\n```
+'                                                                  ^ definition scip-dotnet nuget . . VBMain/Methods#TwoParameters().(b)
+'                                                                    documentation ```vb\nb As Integer\n```
+              Return a + b
+'                    ^ reference scip-dotnet nuget . . VBMain/Methods#TwoParameters().(a)
+'                        ^ reference scip-dotnet nuget . . VBMain/Methods#TwoParameters().(b)
+          End Function
+
+          Private Function Overload1(ByVal a As Integer) As Integer
+'                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#Overload1().
+'                                    documentation ```vb\nPrivate Function Methods.Overload1(a As Integer) As Integer\n```
+'                                          ^ definition scip-dotnet nuget . . VBMain/Methods#Overload1().(a)
+'                                            documentation ```vb\na As Integer\n```
+              Return a
+'                    ^ reference scip-dotnet nuget . . VBMain/Methods#Overload1().(a)
+          End Function
+
+          Private Function Overload1(ByVal a As Integer, ByVal b As Integer) As Integer
+'                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#Overload1(+1).
+'                                    documentation ```vb\nPrivate Function Methods.Overload1(a As Integer, b As Integer) As Integer\n```
+'                                          ^ definition scip-dotnet nuget . . VBMain/Methods#Overload1(+1).(a)
+'                                            documentation ```vb\na As Integer\n```
+'                                                              ^ definition scip-dotnet nuget . . VBMain/Methods#Overload1(+1).(b)
+'                                                                documentation ```vb\nb As Integer\n```
+              Return a + b
+'                    ^ reference scip-dotnet nuget . . VBMain/Methods#Overload1(+1).(a)
+'                        ^ reference scip-dotnet nuget . . VBMain/Methods#Overload1(+1).(b)
+          End Function
+
+          Private Function Generic(Of T)(ByVal param As T) As T
+'                          ^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#Generic().
+'                                  documentation ```vb\nPrivate Function Methods.Generic(Of T)(param As T) As T\n```
+'                                     ^ definition scip-dotnet nuget . . VBMain/Methods#Generic().[T]
+'                                       documentation ```vb\nT\n```
+'                                              ^^^^^ definition scip-dotnet nuget . . VBMain/Methods#Generic().(param)
+'                                                    documentation ```vb\nparam As T\n```
+'                                                       ^ reference scip-dotnet nuget . . VBMain/Methods#Generic().[T]
+'                                                             ^ reference scip-dotnet nuget . . VBMain/Methods#Generic().[T]
+              Return param
+'                    ^^^^^ reference scip-dotnet nuget . . VBMain/Methods#Generic().(param)
+          End Function
+
+          Private Function GenericConstraint(Of T As New)(ByVal param As T) As T
+'                          ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#GenericConstraint().
+'                                            documentation ```vb\nPrivate Function Methods.GenericConstraint(Of T As New)(param As T) As T\n```
+'                                               ^ definition scip-dotnet nuget . . VBMain/Methods#GenericConstraint().[T]
+'                                                 documentation ```vb\nT\n```
+'                                                               ^^^^^ definition scip-dotnet nuget . . VBMain/Methods#GenericConstraint().(param)
+'                                                                     documentation ```vb\nparam As T\n```
+'                                                                        ^ reference scip-dotnet nuget . . VBMain/Methods#GenericConstraint().[T]
+'                                                                              ^ reference scip-dotnet nuget . . VBMain/Methods#GenericConstraint().[T]
+              Return param
+'                    ^^^^^ reference scip-dotnet nuget . . VBMain/Methods#GenericConstraint().(param)
+          End Function
+
+          Private Sub DefaultParameter(ByVal Optional a As Integer = 5)
+'                     ^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameter().
+'                                      documentation ```vb\nPrivate Sub Methods.DefaultParameter([a As Integer = 5])\n```
+'                                                     ^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameter().(a)
+'                                                       documentation ```vb\n[a As Integer = 5]\n```
+          End Sub
+
+          Private Function DefaultParameterOverload(ByVal Optional a As Integer = 5) As Integer
+'                          ^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload().
+'                                                   documentation ```vb\nPrivate Function Methods.DefaultParameterOverload([a As Integer = 5]) As Integer\n```
+'                                                                  ^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload().(a)
+'                                                                    documentation ```vb\n[a As Integer = 5]\n```
+              Return DefaultParameterOverload(a, a)
+'                                             ^ reference scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload().(a)
+'                                                ^ reference scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload().(a)
+          End Function
+
+          Private Function DefaultParameterOverload(ByVal a As Integer, ByVal b As Integer) As Integer
+'                          ^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload(+1).
+'                                                   documentation ```vb\nPrivate Function Methods.DefaultParameterOverload(a As Integer, b As Integer) As Integer\n```
+'                                                         ^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload(+1).(a)
+'                                                           documentation ```vb\na As Integer\n```
+'                                                                             ^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload(+1).(b)
+'                                                                               documentation ```vb\nb As Integer\n```
+              Return DefaultParameterOverload()
+          End Function
+
+          Interface IHello
+'                   ^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#IHello#
+'                          documentation ```vb\nInterface IHello\n```
+              Function Hello() As String
+'                      ^^^^^ definition scip-dotnet nuget . . VBMain/Methods#IHello#Hello().
+'                            documentation ```vb\nFunction IHello.Hello() As String\n```
+          End Interface
+
+          Class ImplementsHello
+'               ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#ImplementsHello#
+'                               documentation ```vb\nClass ImplementsHello\n```
+'                               relationship implementation scip-dotnet nuget . . VBMain/Methods#IHello#
+              Implements IHello
+'                        ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#IHello#
+
+              Private Function Hello() As String Implements IHello.Hello
+'                              ^^^^^ definition scip-dotnet nuget . . VBMain/Methods#ImplementsHello#Hello().
+'                                    documentation ```vb\nPrivate Function ImplementsHello.Hello() As String\n```
+'                                    relationship implementation reference scip-dotnet nuget . . VBMain/Methods#IHello#Hello().
+'                                                           ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#IHello#
+'                                                                  ^^^^^ reference scip-dotnet nuget . . VBMain/Methods#IHello#Hello().
+                  Throw New NotImplementedException()
+              End Function
+
+          End Class
+
+          Class InheritedOverloads1
+'               ^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+'                                   documentation ```vb\nClass InheritedOverloads1\n```
+              Public Sub Method()
+'                        ^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#Method().
+'                               documentation ```vb\nPublic Sub InheritedOverloads1.Method()\n```
+              End Sub
+          End Class
+
+          Class InheritedOverloads2
+'               ^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
+'                                   documentation ```vb\nClass InheritedOverloads2\n```
+'                                   relationship implementation scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+              Inherits InheritedOverloads1
+'                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+
+              Public Function Method(ByVal parameter As Integer) As Integer
+'                             ^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#Method().
+'                                    documentation ```vb\nPublic Function InheritedOverloads2.Method(parameter As Integer) As Integer\n```
+'                                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#Method().(parameter)
+'                                                    documentation ```vb\nparameter As Integer\n```
+                  Return parameter
+'                        ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#Method().(parameter)
+              End Function
+          End Class
+
+          Class InheritedOverloads3
+'               ^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#
+'                                   documentation ```vb\nClass InheritedOverloads3\n```
+'                                   relationship implementation scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
+'                                   relationship implementation scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+              Inherits InheritedOverloads2
+'                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
+
+              Public Function Method(ByVal parameter As String) As String
+'                             ^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#Method().
+'                                    documentation ```vb\nPublic Function InheritedOverloads3.Method(parameter As String) As String\n```
+'                                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#Method().(parameter)
+'                                                    documentation ```vb\nparameter As String\n```
+                  Return parameter
+'                        ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#Method().(parameter)
+              End Function
+          End Class
+
+          Public Shared Sub InheritedOverloads()
+'                           ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads().
+'                                              documentation ```vb\nPublic Shared Sub Methods.InheritedOverloads()\n```
+              Dim a as InheritedOverloads1 = New InheritedOverloads1
+'                 ^ definition local 0
+'                   documentation ```vb\na As Class InheritedOverloads1\n```
+'                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+'                                                ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+              a.Method()
+'             ^ reference local 0
+'               ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#Method().
+              Dim b as InheritedOverloads2 = New InheritedOverloads2
+'                 ^ definition local 1
+'                   documentation ```vb\nb As Class InheritedOverloads2\n```
+'                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
+'                                                ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
+              DirectCast(b, InheritedOverloads1).Method()
+'                        ^ reference local 1
+'                           ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+'                                                ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#Method().
+              b.Method(42)
+'             ^ reference local 1
+              Dim c as InheritedOverloads3 = New InheritedOverloads3
+'                 ^ definition local 2
+'                   documentation ```vb\nc As Class InheritedOverloads3\n```
+'                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#
+'                                                ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#
+              DirectCast(c, InheritedOverloads1).Method()
+'                        ^ reference local 2
+'                           ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+'                                                ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#Method().
+              DirectCast(c, InheritedOverloads2).Method(42)
+'                        ^ reference local 2
+'                           ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
+              c.Method("42")
+'             ^ reference local 2
+          End Sub
+      End Class
+  End Namespace

--- a/snapshots/output-net6.0/syntax/VBMain/Modules.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Modules.vb
@@ -1,0 +1,26 @@
+  Imports System.Diagnostics.CodeAnalysis
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+      Public Module Modules
+'                   ^^^^^^^ definition scip-dotnet nuget . . VBMain/Modules#
+'                           documentation ```vb\nModule Modules\n```
+          Private Function [Function](ByVal b As Integer) As Integer
+'                          ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Modules#Function().
+'                                     documentation ```vb\nPrivate Function Modules.Function(b As Integer) As Integer\n```
+'                                           ^ definition scip-dotnet nuget . . VBMain/Modules#Function().(b)
+'                                             documentation ```vb\nb As Integer\n```
+              Return b
+'                    ^ reference scip-dotnet nuget . . VBMain/Modules#Function().(b)
+          End Function
+
+          Private Sub [Sub](ByVal Optional a As Integer = 5)
+'                     ^^^^^ definition scip-dotnet nuget . . VBMain/Modules#Sub().
+'                           documentation ```vb\nPrivate Sub Modules.Sub([a As Integer = 5])\n```
+'                                          ^ definition scip-dotnet nuget . . VBMain/Modules#Sub().(a)
+'                                            documentation ```vb\n[a As Integer = 5]\n```
+          End Sub
+
+      End Module
+  End Namespace

--- a/snapshots/output-net6.0/syntax/VBMain/Operators.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Operators.vb
@@ -1,0 +1,98 @@
+  Imports System.Diagnostics.CodeAnalysis
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+      Public Class Operators
+'                  ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Operators#
+'                            documentation ```vb\nClass Operators\n```
+          Public Class PlusMinus
+'                      ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#
+'                                documentation ```vb\nClass PlusMinus\n```
+              Public Shared Operator +(A As PlusMinus)
+'                                      ^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#op_UnaryPlus().(A)
+'                                        documentation ```vb\nA As PlusMinus\n```
+'                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#PlusMinus#
+                  Return 0
+              End Operator
+
+              Public Shared Operator +(A As PlusMinus, B As PlusMinus)
+'                                      ^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#op_Addition().(A)
+'                                        documentation ```vb\nA As PlusMinus\n```
+'                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#PlusMinus#
+'                                                      ^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#op_Addition().(B)
+'                                                        documentation ```vb\nB As PlusMinus\n```
+'                                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#PlusMinus#
+                  Return 0
+              End Operator
+
+              Public Shared Operator -(A As PlusMinus)
+'                                      ^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#op_UnaryNegation().(A)
+'                                        documentation ```vb\nA As PlusMinus\n```
+'                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#PlusMinus#
+                  Return 0
+              End Operator
+          End Class
+
+          Public Class TrueFalse
+'                      ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+'                                documentation ```vb\nClass TrueFalse\n```
+              Public Shared Operator IsTrue(A As TrueFalse) As Boolean
+'                                           ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_True().(A)
+'                                             documentation ```vb\nA As TrueFalse\n```
+'                                                ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+                  Return True
+              End Operator
+
+              Public Shared Operator IsFalse(A As TrueFalse) As Boolean
+'                                            ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_False().(A)
+'                                              documentation ```vb\nA As TrueFalse\n```
+'                                                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+                  Return False
+              End Operator
+
+              Public Shared Operator =(A As TrueFalse, B As TrueFalse) As Boolean
+'                                      ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_Equality().(A)
+'                                        documentation ```vb\nA As TrueFalse\n```
+'                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+'                                                      ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_Equality().(B)
+'                                                        documentation ```vb\nB As TrueFalse\n```
+'                                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+                  Return True
+              End Operator
+
+              Public Shared Operator <>(A As TrueFalse, B As TrueFalse) As Boolean
+'                                       ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_Inequality().(A)
+'                                         documentation ```vb\nA As TrueFalse\n```
+'                                            ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+'                                                       ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_Inequality().(B)
+'                                                         documentation ```vb\nB As TrueFalse\n```
+'                                                            ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+                  Return True
+              End Operator
+
+              Public Overrides Function Equals(obj As Object) As Boolean
+'                                       ^^^^^^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().
+'                                              documentation ```vb\nPublic Overrides Function TrueFalse.Equals(obj As Object) As Boolean\n```
+'                                              ^^^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+'                                                  documentation ```vb\nobj As Object\n```
+                  If ReferenceEquals(Nothing, obj) Then Return False
+'                                             ^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+                  If ReferenceEquals(Me, obj) Then Return True
+'                                        ^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+                  If obj.GetType() <> Me.GetType() Then Return False
+'                    ^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+                  Return Equals(CType(obj, TrueFalse))
+'                                     ^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+'                                          ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+              End Function
+
+              Public Overrides Function GetHashCode() As Integer
+'                                       ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#GetHashCode().
+'                                                   documentation ```vb\nPublic Overrides Function TrueFalse.GetHashCode() As Integer\n```
+                  Throw New NotImplementedException()
+              End Function
+
+          End Class
+      End Class
+  End Namespace

--- a/snapshots/output-net6.0/syntax/VBMain/Packages.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Packages.vb
@@ -1,0 +1,24 @@
+  Imports System.Diagnostics.CodeAnalysis
+  Imports DiffPlex.DiffBuilder
+'         ^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 DiffPlex/
+'                  ^^^^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 DiffBuilder/
+  Imports DiffPlex.DiffBuilder.Model
+'         ^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 DiffPlex/
+'                  ^^^^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 DiffBuilder/
+'                              ^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 Model/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+      Public Class Packages
+'                  ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Packages#
+'                           documentation ```vb\nClass Packages\n```
+          Private Function Diff() As DiffPaneModel
+'                          ^^^^ definition scip-dotnet nuget . . VBMain/Packages#Diff().
+'                               documentation ```vb\nPrivate Function Packages.Diff() As DiffPaneModel\n```
+'                                    ^^^^^^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 Model/DiffPaneModel#
+              Return InlineDiffBuilder.Diff("a", "b")
+'                    ^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 DiffBuilder/InlineDiffBuilder#
+          End Function
+      End Class
+  End Namespace

--- a/snapshots/output-net6.0/syntax/VBMain/Preprocessors.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Preprocessors.vb
@@ -1,0 +1,27 @@
+  Imports System.Diagnostics.CodeAnalysis
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+      Public Class Preprocessors
+'                  ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Preprocessors#
+'                                documentation ```vb\nClass Preprocessors\n```
+          Private Function OperatingSystem() As String
+'                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Preprocessors#OperatingSystem().
+'                                          documentation ```vb\nPrivate Function Preprocessors.OperatingSystem() As String\n```
+  #if WIN32
+              Dim Os As String = "Win32"
+  #warning This class is bad.
+  #error Okay, just stop.
+  #elif MACOS
+              Dim Os As String = "MacOS"
+  #else
+              Dim Os As String = "Unknown"
+'                 ^^ definition local 0
+'                    documentation ```vb\nOs As String\n```
+  #End If
+              Return Os
+'                    ^^ reference local 0
+          End Function
+      End Class
+  End Namespace

--- a/snapshots/output-net6.0/syntax/VBMain/Preprocessors.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Preprocessors.vb
@@ -9,13 +9,13 @@
           Private Function OperatingSystem() As String
 '                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Preprocessors#OperatingSystem().
 '                                          documentation ```vb\nPrivate Function Preprocessors.OperatingSystem() As String\n```
-  #if WIN32
+  #If WIN32 Then
               Dim Os As String = "Win32"
   #warning This class is bad.
   #error Okay, just stop.
   #elif MACOS
               Dim Os As String = "MacOS"
-  #else
+  #Else
               Dim Os As String = "Unknown"
 '                 ^^ definition local 0
 '                    documentation ```vb\nOs As String\n```

--- a/snapshots/output-net6.0/syntax/VBMain/Program.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Program.vb
@@ -6,7 +6,7 @@
 '              documentation ```vb\nPublic Sub Program.Main(args As String())\n```
 '              ^^^^ definition scip-dotnet nuget . . VBMain/Program#Main().(args)
 '                   documentation ```vb\nargs As String()\n```
-          
+
           Console.WriteLine("Hello, World!")
       End Sub
   End Module

--- a/snapshots/output-net6.0/syntax/VBMain/Program.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Program.vb
@@ -1,0 +1,12 @@
+  Module Program
+'        ^^^^^^^ definition scip-dotnet nuget . . VBMain/Program#
+'                documentation ```vb\nModule Program\n```
+      Sub Main(args As String())
+'         ^^^^ definition scip-dotnet nuget . . VBMain/Program#Main().
+'              documentation ```vb\nPublic Sub Program.Main(args As String())\n```
+'              ^^^^ definition scip-dotnet nuget . . VBMain/Program#Main().(args)
+'                   documentation ```vb\nargs As String()\n```
+          
+          Console.WriteLine("Hello, World!")
+      End Sub
+  End Module

--- a/snapshots/output-net6.0/syntax/VBMain/Properties.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Properties.vb
@@ -1,0 +1,30 @@
+  Imports System.Diagnostics.CodeAnalysis
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+      Public Class Properties
+'                  ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Properties#
+'                             documentation ```vb\nClass Properties\n```
+          Private ReadOnly Property [Get] As Byte
+'                                   ^^^^^ definition scip-dotnet nuget . . VBMain/Properties#Get.
+'                                         documentation ```vb\nPrivate ReadOnly Property Properties.Get As Byte\n```
+
+          Private WriteOnly Property [Set] As Char
+'                                    ^^^^^ definition scip-dotnet nuget . . VBMain/Properties#Set.
+'                                          documentation ```vb\nPrivate WriteOnly Property Properties.Set As Char\n```
+              Set(ByVal value As Char)
+'                       ^^^^^ definition scip-dotnet nuget . . VBMain/Properties#set_Set().(value)
+'                             documentation ```vb\nvalue As Char\n```
+                  Throw New NotImplementedException()
+              End Set
+          End Property
+
+          Private Property GetSet As UInteger
+'                          ^^^^^^ definition scip-dotnet nuget . . VBMain/Properties#GetSet.
+'                                 documentation ```vb\nPrivate Property Properties.GetSet As UInteger\n```
+          Private Property SetGet As Long
+'                          ^^^^^^ definition scip-dotnet nuget . . VBMain/Properties#SetGet.
+'                                 documentation ```vb\nPrivate Property Properties.SetGet As Long\n```
+      End Class
+  End Namespace

--- a/snapshots/output-net6.0/syntax/VBMain/QuerySyntax.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/QuerySyntax.vb
@@ -1,0 +1,111 @@
+  Imports System.Diagnostics.CodeAnalysis
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+      Public Class QuerySyntax
+'                  ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#
+'                              documentation ```vb\nClass QuerySyntax\n```
+          Private sourceA As List(Of IGeneric) = New List(Of IGeneric)()
+'                 ^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
+'                         documentation ```vb\nPrivate QuerySyntax.sourceA As List\n```
+'                                    ^^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#
+'                                                            ^^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#
+          Private sourceB As List(Of IGeneric) = New List(Of IGeneric)()
+'                 ^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#sourceB.
+'                         documentation ```vb\nPrivate QuerySyntax.sourceB As List\n```
+'                                    ^^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#
+'                                                            ^^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#
+
+          Interface IGeneric
+'                   ^^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#
+'                            documentation ```vb\nInterface IGeneric\n```
+              Function Method() As String
+'                      ^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                             documentation ```vb\nFunction IGeneric.Method() As String\n```
+          End Interface
+
+          Private Sub [Select]()
+'                     ^^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Select().
+'                              documentation ```vb\nPrivate Sub QuerySyntax.Select()\n```
+              Dim x = From a In sourceA Select a.Method()
+'                 ^ definition local 0
+'                   documentation ```vb\nx As \n```
+'                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
+'                                              ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Select().a.
+          End Sub
+
+          Private Sub Projection()
+'                     ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Projection().
+'                                documentation ```vb\nPrivate Sub QuerySyntax.Projection()\n```
+              Dim x = From a In sourceA Select New With {Key.Name = a.Method()}
+'                 ^ definition local 1
+'                   documentation ```vb\nx As \n```
+'                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
+'                                                            ^^^^ reference local 3
+'                                                                   ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Projection().a.
+              Dim b = From a In x Select a.Name
+'                 ^ definition local 4
+'                   documentation ```vb\nb As \n```
+'                               ^ reference local 1
+'                                        ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Projection().a.
+          End Sub
+
+          Private Sub Where()
+'                     ^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Where().
+'                           documentation ```vb\nPrivate Sub QuerySyntax.Where()\n```
+              Dim x = From a In sourceA Where a.Method().StartsWith("a") Select a
+'                 ^ definition local 5
+'                   documentation ```vb\nx As \n```
+'                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
+'                                             ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Where().a.
+'                                                                               ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Where().a.
+          End Sub
+
+          Private Sub [Let]()
+'                     ^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Let().
+'                           documentation ```vb\nPrivate Sub QuerySyntax.Let()\n```
+              Dim x = From a In sourceA Let z = New With { Key.A = a.Method(), Key.B = a.Method() } Select z
+'                 ^ definition local 6
+'                   documentation ```vb\nx As \n```
+'                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
+'                                                              ^ reference local 8
+'                                                                  ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Let().a.
+'                                                                                  ^ reference local 9
+'                                                                                      ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Let().a.
+'                                                                                                          ^ reference local 11
+          End Sub
+
+          Private Sub Join()
+'                     ^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Join().
+'                          documentation ```vb\nPrivate Sub QuerySyntax.Join()\n```
+              Dim x = From a In sourceA Join b In sourceB On a.Method() Equals b.Method() Select New With { Key.A = a.Method(), Key.B = b.Method() }
+'                 ^ definition local 12
+'                   documentation ```vb\nx As \n```
+'                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
+'                                                 ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceB.
+'                                                            ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Join().a.
+'                                                                              ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Join().b.
+'                                                                                                               ^ reference local 8
+'                                                                                                                   ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Join().a.
+'                                                                                                                                   ^ reference local 9
+'                                                                                                                                       ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Join().b.
+          End Sub
+
+          Private Sub MultipleFrom()
+'                     ^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#MultipleFrom().
+'                                  documentation ```vb\nPrivate Sub QuerySyntax.MultipleFrom()\n```
+              Dim x = From a In sourceA From b In sourceB Where a.Method() = b.Method() Select New With { Key.A = a.Method(), Key.B = b.Method() }
+'                 ^ definition local 13
+'                   documentation ```vb\nx As \n```
+'                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
+'                                                 ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceB.
+'                                                               ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#MultipleFrom().a.
+'                                                                            ^ reference local 15
+'                                                                                                             ^ reference local 8
+'                                                                                                                 ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#MultipleFrom().a.
+'                                                                                                                                 ^ reference local 9
+'                                                                                                                                     ^ reference local 15
+          End Sub
+      End Class
+  End Namespace

--- a/snapshots/output-net6.0/syntax/VBMain/QuerySyntax.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/QuerySyntax.vb
@@ -38,12 +38,12 @@
           Private Sub Projection()
 '                     ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Projection().
 '                                documentation ```vb\nPrivate Sub QuerySyntax.Projection()\n```
-              Dim x = From a In sourceA Select New With {Key.Name = a.Method()}
+              Dim x = From a In sourceA Select New With {Key .Name = a.Method()}
 '                 ^ definition local 1
 '                   documentation ```vb\nx As \n```
 '                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
-'                                                            ^^^^ reference local 3
-'                                                                   ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Projection().a.
+'                                                             ^^^^ reference local 3
+'                                                                    ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Projection().a.
               Dim b = From a In x Select a.Name
 '                 ^ definition local 4
 '                   documentation ```vb\nb As \n```
@@ -65,21 +65,21 @@
           Private Sub [Let]()
 '                     ^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Let().
 '                           documentation ```vb\nPrivate Sub QuerySyntax.Let()\n```
-              Dim x = From a In sourceA Let z = New With { Key.A = a.Method(), Key.B = a.Method() } Select z
+              Dim x = From a In sourceA Let z = New With {Key .A = a.Method(), Key .B = a.Method()} Select z
 '                 ^ definition local 6
 '                   documentation ```vb\nx As \n```
 '                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
 '                                                              ^ reference local 8
 '                                                                  ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Let().a.
-'                                                                                  ^ reference local 9
-'                                                                                      ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Let().a.
+'                                                                                   ^ reference local 9
+'                                                                                       ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Let().a.
 '                                                                                                          ^ reference local 11
           End Sub
 
           Private Sub Join()
 '                     ^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Join().
 '                          documentation ```vb\nPrivate Sub QuerySyntax.Join()\n```
-              Dim x = From a In sourceA Join b In sourceB On a.Method() Equals b.Method() Select New With { Key.A = a.Method(), Key.B = b.Method() }
+              Dim x = From a In sourceA Join b In sourceB On a.Method() Equals b.Method() Select New With {Key .A = a.Method(), Key .B = b.Method()}
 '                 ^ definition local 12
 '                   documentation ```vb\nx As \n```
 '                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
@@ -88,14 +88,14 @@
 '                                                                              ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Join().b.
 '                                                                                                               ^ reference local 8
 '                                                                                                                   ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Join().a.
-'                                                                                                                                   ^ reference local 9
-'                                                                                                                                       ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Join().b.
+'                                                                                                                                    ^ reference local 9
+'                                                                                                                                        ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Join().b.
           End Sub
 
           Private Sub MultipleFrom()
 '                     ^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#MultipleFrom().
 '                                  documentation ```vb\nPrivate Sub QuerySyntax.MultipleFrom()\n```
-              Dim x = From a In sourceA From b In sourceB Where a.Method() = b.Method() Select New With { Key.A = a.Method(), Key.B = b.Method() }
+              Dim x = From a In sourceA From b In sourceB Where a.Method() = b.Method() Select New With {Key .A = a.Method(), Key .B = b.Method()}
 '                 ^ definition local 13
 '                   documentation ```vb\nx As \n```
 '                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
@@ -104,8 +104,8 @@
 '                                                                            ^ reference local 15
 '                                                                                                             ^ reference local 8
 '                                                                                                                 ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#MultipleFrom().a.
-'                                                                                                                                 ^ reference local 9
-'                                                                                                                                     ^ reference local 15
+'                                                                                                                                  ^ reference local 9
+'                                                                                                                                      ^ reference local 15
           End Sub
       End Class
   End Namespace

--- a/snapshots/output-net6.0/syntax/VBMain/Statements.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Statements.vb
@@ -1,0 +1,147 @@
+  Imports System.Diagnostics.CodeAnalysis
+  Imports System.IO
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+      Public Class Statements
+'                  ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#
+'                             documentation ```vb\nClass Statements\n```
+          Private Sub [Try]()
+'                     ^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Try().
+'                           documentation ```vb\nPrivate Sub Statements.Try()\n```
+              Try
+                  File.ReadLines("asd")
+              Catch err As Exception
+'                   ^^^ definition local 0
+'                       documentation ```vb\nerr As Exception\n```
+'                   ^^^ reference local 0
+                  Console.WriteLine(err)
+'                                   ^^^ reference local 0
+              End Try
+          End Sub
+
+          Private Function [Default]() As (A as String, B as Boolean)
+'                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Default().
+'                                    documentation ```vb\nPrivate Function Statements.Default() As (A As String, B As Boolean)\n```
+              Dim C As (A As String, B As Boolean) = ("42", 42)
+'                 ^ definition local 1
+'                   documentation ```vb\nC As (A As String, B As Boolean)\n```
+              Return C
+'                    ^ reference local 1
+          End Function
+
+         Public class Inferred
+'                     ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Inferred#
+'                              documentation ```vb\nClass Inferred\n```
+              Property F1 As Int32
+'                      ^^ definition scip-dotnet nuget . . VBMain/Statements#Inferred#F1.
+'                         documentation ```vb\nPublic Property Inferred.F1 As Int32\n```
+              Property F2 As Int32
+'                      ^^ definition scip-dotnet nuget . . VBMain/Statements#Inferred#F2.
+'                         documentation ```vb\nPublic Property Inferred.F2 As Int32\n```
+         End Class
+
+          Private Sub InferredTuples()
+'                     ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#InferredTuples().
+'                                    documentation ```vb\nPrivate Sub Statements.InferredTuples()\n```
+              Dim List = New List(Of Inferred)()
+'                 ^^^^ definition local 2
+'                      documentation ```vb\nList As List\n```
+'                                    ^^^^^^^^ reference scip-dotnet nuget . . VBMain/Statements#Inferred#
+              Dim Result = List.Select(Function(c) (c.F1, c.F2)).Where(Function(t) t.F2 = 1)
+'                 ^^^^^^ definition local 3
+'                        documentation ```vb\nResult As \n```
+'                          ^^^^ reference local 2
+'                                               ^ definition local 5
+'                                                 documentation ```vb\nc As Object\n```
+'                                                   ^ reference local 5
+'                                                         ^ reference local 5
+'                                                                               ^ definition local 7
+'                                                                                 documentation ```vb\nt As Object\n```
+'                                                                                  ^ reference local 7
+          End Sub
+
+          Private Function MultipleInitializers() As Integer
+'                          ^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#MultipleInitializers().
+'                                               documentation ```vb\nPrivate Function Statements.MultipleInitializers() As Integer\n```
+              Dim a As Integer = 1, b As Integer = 2
+'                 ^ definition local 8
+'                   documentation ```vb\na As Integer\n```
+'                                   ^ definition local 9
+'                                     documentation ```vb\nb As Integer\n```
+              Return a + b
+'                    ^ reference local 8
+'                        ^ reference local 9
+          End Function
+
+          Class MyDisposable
+'               ^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#MyDisposable#
+'                            documentation ```vb\nClass MyDisposable\n```
+'                            relationship implementation IDisposable#
+              Implements IDisposable
+
+              Private Sub Dispose() Implements IDisposable.Dispose
+'                         ^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#MyDisposable#Dispose().
+'                                 documentation ```vb\nPrivate Sub MyDisposable.Dispose()\n```
+                  Throw New NotImplementedException()
+              End Sub
+          End Class
+
+          Private Function [Using]() As MyDisposable
+'                          ^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Using().
+'                                  documentation ```vb\nPrivate Function Statements.Using() As MyDisposable\n```
+'                                       ^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Statements#MyDisposable#
+              Dim b = New MyDisposable()
+'                 ^ definition local 10
+'                   documentation ```vb\nb As Class MyDisposable\n```
+'                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Statements#MyDisposable#
+
+              Using a = b
+'                   ^ definition local 11
+'                     documentation ```vb\na As Class MyDisposable\n```
+'                       ^ reference local 10
+                  Return a
+'                        ^ reference local 11
+              End Using
+          End Function
+
+          Private Function MultipleUsing() As Long
+'                          ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#MultipleUsing().
+'                                        documentation ```vb\nPrivate Function Statements.MultipleUsing() As Long\n```
+              Using a As Stream = File.OpenRead("a"), b As Stream = File.OpenRead("a")
+'                   ^ definition local 12
+'                     documentation ```vb\na As Stream\n```
+'                                                     ^ definition local 13
+'                                                       documentation ```vb\nb As Stream\n```
+                  Return a.Length + b.Length
+'                        ^ reference local 12
+'                                   ^ reference local 13
+              End Using
+          End Function
+
+          Private Function Foreach() As Integer
+'                          ^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Foreach().
+'                                  documentation ```vb\nPrivate Function Statements.Foreach() As Integer\n```
+          Dim y = New Integer() {1}
+'             ^ definition local 14
+'               documentation ```vb\ny As Integer()\n```
+              Dim z = 0
+'                 ^ definition local 15
+'                   documentation ```vb\nz As Integer\n```
+
+              For Each x As Integer In y
+'                      ^ definition local 16
+'                        documentation ```vb\nx As Integer\n```
+'                                      ^ reference local 14
+                  z += x
+'                 ^ reference local 15
+'                      ^ reference local 16
+              Next
+
+              Return z
+'                    ^ reference local 15
+          End Function
+
+      End Class
+  End Namespace

--- a/snapshots/output-net6.0/syntax/VBMain/Statements.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Statements.vb
@@ -21,7 +21,7 @@
               End Try
           End Sub
 
-          Private Function [Default]() As (A as String, B as Boolean)
+          Private Function [Default]() As (A As String, B As Boolean)
 '                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Default().
 '                                    documentation ```vb\nPrivate Function Statements.Default() As (A As String, B As Boolean)\n```
               Dim C As (A As String, B As Boolean) = ("42", 42)
@@ -31,16 +31,16 @@
 '                    ^ reference local 1
           End Function
 
-         Public class Inferred
-'                     ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Inferred#
-'                              documentation ```vb\nClass Inferred\n```
+          Public Class Inferred
+'                      ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Inferred#
+'                               documentation ```vb\nClass Inferred\n```
               Property F1 As Int32
 '                      ^^ definition scip-dotnet nuget . . VBMain/Statements#Inferred#F1.
 '                         documentation ```vb\nPublic Property Inferred.F1 As Int32\n```
               Property F2 As Int32
 '                      ^^ definition scip-dotnet nuget . . VBMain/Statements#Inferred#F2.
 '                         documentation ```vb\nPublic Property Inferred.F2 As Int32\n```
-         End Class
+          End Class
 
           Private Sub InferredTuples()
 '                     ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#InferredTuples().
@@ -123,9 +123,9 @@
           Private Function Foreach() As Integer
 '                          ^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Foreach().
 '                                  documentation ```vb\nPrivate Function Statements.Foreach() As Integer\n```
-          Dim y = New Integer() {1}
-'             ^ definition local 14
-'               documentation ```vb\ny As Integer()\n```
+              Dim y = New Integer() {1}
+'                 ^ definition local 14
+'                   documentation ```vb\ny As Integer()\n```
               Dim z = 0
 '                 ^ definition local 15
 '                   documentation ```vb\nz As Integer\n```

--- a/snapshots/output-net6.0/syntax/VBMain/Structs.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Structs.vb
@@ -1,0 +1,27 @@
+  Imports System.Diagnostics.CodeAnalysis
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+      Public Class Structs
+'                  ^^^^^^^ definition scip-dotnet nuget . . VBMain/Structs#
+'                          documentation ```vb\nClass Structs\n```
+          Structure BasicStruct
+'                   ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Structs#BasicStruct#
+'                               documentation ```vb\nStructure BasicStruct\n```
+              Public Property1 As Integer
+'                    ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Structs#BasicStruct#Property1.
+'                              documentation ```vb\nPublic BasicStruct.Property1 As Integer\n```
+
+              Public Sub New(ByVal field1 As Integer)
+'                        ^^^ definition scip-dotnet nuget . . VBMain/Structs#BasicStruct#`.ctor`(+1).
+'                            documentation ```vb\nPublic Sub BasicStruct.New(field1 As Integer)\n```
+'                                  ^^^^^^ definition scip-dotnet nuget . . VBMain/Structs#BasicStruct#`.ctor`(+1).(field1)
+'                                         documentation ```vb\nfield1 As Integer\n```
+                  Property1 = field1
+'                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Structs#BasicStruct#Property1.
+'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Structs#BasicStruct#`.ctor`(+1).(field1)
+              End Sub
+          End Structure
+      End Class
+  End Namespace

--- a/snapshots/output-net7.0/syntax/Main/Classes.cs
+++ b/snapshots/output-net7.0/syntax/Main/Classes.cs
@@ -49,7 +49,6 @@
 //                ^^^^^^^^^ reference scip-dotnet nuget System.Console 7.0.0.0 System/Console#WriteLine(+7).
       }
 
-
       public class ObjectClass : object, SomeInterface
 //                 ^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#ObjectClass#
 //                             documentation ```cs\nclass ObjectClass\n```

--- a/snapshots/output-net7.0/syntax/VBMain/Classes.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Classes.vb
@@ -1,0 +1,182 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Classes
+'                  ^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#
+'                          documentation ```vb\nClass Classes\n```
+
+          Public Name As String
+'                ^^^^ definition scip-dotnet nuget . . VBMain/Classes#Name.
+'                     documentation ```vb\nPublic Classes.Name As String\n```
+          Public Const IntConstant As Integer = 1
+'                      ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#IntConstant.
+'                                  documentation ```vb\nPublic Const Classes.IntConstant As Integer = 1\n```
+          Public Const StringConstant As String = "hello"
+'                      ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#StringConstant.
+'                                     documentation ```vb\nPublic Const Classes.StringConstant As String = "hello"\n```
+
+          Public Sub New(ByVal name As Integer)
+'                    ^^^ definition scip-dotnet nuget . . VBMain/Classes#`.ctor`().
+'                        documentation ```vb\nPublic Sub Classes.New(name As Integer)\n```
+'                              ^^^^ definition scip-dotnet nuget . . VBMain/Classes#`.ctor`().(name)
+'                                   documentation ```vb\nname As Integer\n```
+              Me.Name = "name"
+'                ^^^^ reference scip-dotnet nuget . . VBMain/Classes#Name.
+          End Sub
+
+          Public Sub New(ByVal name As String)
+'                    ^^^ definition scip-dotnet nuget . . VBMain/Classes#`.ctor`(+1).
+'                        documentation ```vb\nPublic Sub Classes.New(name As String)\n```
+'                              ^^^^ definition scip-dotnet nuget . . VBMain/Classes#`.ctor`(+1).(name)
+'                                   documentation ```vb\nname As String\n```
+              Me.Name = name
+'                ^^^^ reference scip-dotnet nuget . . VBMain/Classes#Name.
+'                       ^^^^ reference scip-dotnet nuget . . VBMain/Classes#`.ctor`(+1).(name)
+          End Sub
+
+          Protected Overrides Sub Finalize()
+'                                 ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#Finalize().
+'                                          documentation ```vb\nProtected Overrides Sub Classes.Finalize()\n```
+'                                          relationship implementation reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Object#Finalize().
+              Console.WriteLine(42)
+'             ^^^^^^^ reference scip-dotnet nuget System.Console 7.0.0.0 System/Console#
+'                     ^^^^^^^^^ reference scip-dotnet nuget System.Console 7.0.0.0 System/Console#WriteLine(+7).
+          End Sub
+
+          Public Class ObjectClass
+'                      ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ObjectClass#
+'                                  documentation ```vb\nClass ObjectClass\n```
+'                                  relationship implementation scip-dotnet nuget . . VBMain/Classes#SomeInterface#
+              Inherits Object
+              Implements SomeInterface
+'                        ^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Classes#SomeInterface#
+          End Class
+
+          Public Partial Class PartialClass
+'                              ^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#PartialClass#
+'                                           documentation ```vb\nClass PartialClass\n```
+          End Class
+
+          Class TypeParameterClass(Of T)
+'               ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#TypeParameterClass#
+'                                  documentation ```vb\nClass TypeParameterClass(Of T)\n```
+'                                     ^ definition scip-dotnet nuget . . VBMain/Classes#TypeParameterClass#[T]
+'                                       documentation ```vb\nT\n```
+          End Class
+
+          Friend Class InternalMultipleTypeParametersClass(Of T1, T2)
+'                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#InternalMultipleTypeParametersClass#
+'                                                          documentation ```vb\nClass InternalMultipleTypeParametersClass(Of T1, T2)\n```
+'                                                             ^^ definition scip-dotnet nuget . . VBMain/Classes#InternalMultipleTypeParametersClass#[T1]
+'                                                                documentation ```vb\nT1\n```
+'                                                                 ^^ definition scip-dotnet nuget . . VBMain/Classes#InternalMultipleTypeParametersClass#[T2]
+'                                                                    documentation ```vb\nT2\n```
+          End Class
+          
+          Interface ICovariantContravariant(Of In T1, Out T2)
+'                   ^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#
+'                                           documentation ```vb\nInterface ICovariantContravariant(Of In T1, Out T2)\n```
+'                                                 ^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T1]
+'                                                    documentation ```vb\nIn T1\n```
+'                                                         ^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T2]
+'                                                            documentation ```vb\nOut T2\n```
+          Sub Method1(ByVal t1 As T1)
+'             ^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method1().
+'                     documentation ```vb\nSub ICovariantContravariant(Of In T1, Out T2).Method1(t1 As T1)\n```
+'                           ^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method1().(t1)
+'                              documentation ```vb\nt1 As T1\n```
+'                                 ^^ reference scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T1]
+
+          Function Method2() As T2
+'                  ^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method2().
+'                          documentation ```vb\nFunction ICovariantContravariant(Of In T1, Out T2).Method2() As T2\n```
+'                               ^^ reference scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T2]
+
+          End Interface
+
+          Public Class StructConstraintClass(Of T As Structure)
+'                      ^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#StructConstraintClass#
+'                                            documentation ```vb\nClass StructConstraintClass(Of T As Structure)\n```
+'                                               ^ definition scip-dotnet nuget . . VBMain/Classes#StructConstraintClass#[T]
+'                                                 documentation ```vb\nT\n```
+          End Class
+
+          Public Class ClassConstraintClass(Of T As Class)
+'                      ^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ClassConstraintClass#
+'                                           documentation ```vb\nClass ClassConstraintClass(Of T As Class)\n```
+'                                              ^ definition scip-dotnet nuget . . VBMain/Classes#ClassConstraintClass#[T]
+'                                                documentation ```vb\nT\n```
+          End Class
+
+          Public Class NewConstraintClass(Of T As New)
+'                      ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#NewConstraintClass#
+'                                         documentation ```vb\nClass NewConstraintClass(Of T As New)\n```
+'                                            ^ definition scip-dotnet nuget . . VBMain/Classes#NewConstraintClass#[T]
+'                                              documentation ```vb\nT\n```
+          End Class
+
+          Public Class TypeParameterConstraintClass(Of T As SomeInterface)
+'                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#TypeParameterConstraintClass#
+'                                                   documentation ```vb\nClass TypeParameterConstraintClass(Of T As SomeInterface)\n```
+'                                                      ^ definition scip-dotnet nuget . . VBMain/Classes#TypeParameterConstraintClass#[T]
+'                                                        documentation ```vb\nT\n```
+'                                                           ^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Classes#SomeInterface#
+          End Class
+
+          Private Class MultipleTypeParameterConstraintsClass(Of T1 As {SomeInterface, SomeInterface2, New}, T2 As SomeInterface2)
+'                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#MultipleTypeParameterConstraintsClass#
+'                                                             documentation ```vb\nClass MultipleTypeParameterConstraintsClass(Of T1 As {SomeInterface, SomeInterface2, New}, T2 As SomeInterface2)\n```
+'                                                                ^^ definition scip-dotnet nuget . . VBMain/Classes#MultipleTypeParameterConstraintsClass#[T1]
+'                                                                   documentation ```vb\nT1\n```
+'                                                                       ^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Classes#SomeInterface#
+'                                                                                      ^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Classes#SomeInterface2#
+'                                                                                                            ^^ definition scip-dotnet nuget . . VBMain/Classes#MultipleTypeParameterConstraintsClass#[T2]
+'                                                                                                               documentation ```vb\nT2\n```
+'                                                                                                                  ^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Classes#SomeInterface2#
+          End Class
+
+          Class IndexClass
+'               ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#IndexClass#
+'                          documentation ```vb\nClass IndexClass\n```
+              Private a As Boolean
+'                     ^ definition scip-dotnet nuget . . VBMain/Classes#IndexClass#a.
+'                       documentation ```vb\nPrivate IndexClass.a As Boolean\n```
+
+              Default Public Property Item(ByVal index As Integer) As Boolean
+'                                     ^^^^ definition scip-dotnet nuget . . VBMain/Classes#IndexClass#Item.
+'                                          documentation ```vb\nPublic Default Property IndexClass.Item(index As Integer) As Boolean\n```
+'                                                ^^^^^ definition scip-dotnet nuget . . VBMain/Classes#IndexClass#Item.(index)
+'                                                      documentation ```vb\nindex As Integer\n```
+                  Get
+                      Return a
+'                            ^ reference scip-dotnet nuget . . VBMain/Classes#IndexClass#a.
+                  End Get
+                  Set(ByVal value As Boolean)
+'                           ^^^^^ definition scip-dotnet nuget . . VBMain/Classes#IndexClass#set_Item().(value)
+'                                 documentation ```vb\nvalue As Boolean\n```
+                      a = value
+'                     ^ reference scip-dotnet nuget . . VBMain/Classes#IndexClass#a.
+'                         ^^^^^ reference scip-dotnet nuget . . VBMain/Classes#IndexClass#set_Item().(value)
+                  End Set
+              End Property
+          End Class
+
+      Interface SomeInterface
+'               ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#SomeInterface#
+'                             documentation ```vb\nInterface SomeInterface\n```
+      End Interface
+
+      Friend Interface SomeInterface2
+'                      ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#SomeInterface2#
+'                                     documentation ```vb\nInterface SomeInterface2\n```
+      End Interface
+
+      End Class
+
+  End Namespace

--- a/snapshots/output-net7.0/syntax/VBMain/Classes.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Classes.vb
@@ -78,7 +78,7 @@
 '                                                                 ^^ definition scip-dotnet nuget . . VBMain/Classes#InternalMultipleTypeParametersClass#[T2]
 '                                                                    documentation ```vb\nT2\n```
           End Class
-          
+
           Interface ICovariantContravariant(Of In T1, Out T2)
 '                   ^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#
 '                                           documentation ```vb\nInterface ICovariantContravariant(Of In T1, Out T2)\n```
@@ -86,17 +86,17 @@
 '                                                    documentation ```vb\nIn T1\n```
 '                                                         ^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T2]
 '                                                            documentation ```vb\nOut T2\n```
-          Sub Method1(ByVal t1 As T1)
-'             ^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method1().
-'                     documentation ```vb\nSub ICovariantContravariant(Of In T1, Out T2).Method1(t1 As T1)\n```
-'                           ^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method1().(t1)
-'                              documentation ```vb\nt1 As T1\n```
-'                                 ^^ reference scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T1]
+              Sub Method1(ByVal t1 As T1)
+'                 ^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method1().
+'                         documentation ```vb\nSub ICovariantContravariant(Of In T1, Out T2).Method1(t1 As T1)\n```
+'                               ^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method1().(t1)
+'                                  documentation ```vb\nt1 As T1\n```
+'                                     ^^ reference scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T1]
 
-          Function Method2() As T2
-'                  ^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method2().
-'                          documentation ```vb\nFunction ICovariantContravariant(Of In T1, Out T2).Method2() As T2\n```
-'                               ^^ reference scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T2]
+              Function Method2() As T2
+'                      ^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method2().
+'                              documentation ```vb\nFunction ICovariantContravariant(Of In T1, Out T2).Method2() As T2\n```
+'                                   ^^ reference scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T2]
 
           End Interface
 
@@ -167,15 +167,15 @@
               End Property
           End Class
 
-      Interface SomeInterface
-'               ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#SomeInterface#
-'                             documentation ```vb\nInterface SomeInterface\n```
-      End Interface
+          Interface SomeInterface
+'                   ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#SomeInterface#
+'                                 documentation ```vb\nInterface SomeInterface\n```
+          End Interface
 
-      Friend Interface SomeInterface2
-'                      ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#SomeInterface2#
-'                                     documentation ```vb\nInterface SomeInterface2\n```
-      End Interface
+          Friend Interface SomeInterface2
+'                          ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#SomeInterface2#
+'                                         documentation ```vb\nInterface SomeInterface2\n```
+          End Interface
 
       End Class
 

--- a/snapshots/output-net7.0/syntax/VBMain/Enums.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Enums.vb
@@ -1,0 +1,41 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Enums
+'                  ^^^^^ definition scip-dotnet nuget . . VBMain/Enums#
+'                        documentation ```vb\nClass Enums\n```
+          Enum EnumWithIntValues
+'              ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Enums#EnumWithIntValues#
+'                                documentation ```vb\nEnum EnumWithIntValues\n```
+'                                relationship implementation scip-dotnet nuget System.Runtime 7.0.0.0 System/IComparable#
+'                                relationship implementation scip-dotnet nuget System.Runtime 7.0.0.0 System/IConvertible#
+'                                relationship implementation scip-dotnet nuget System.Runtime 7.0.0.0 System/IFormattable#
+              Ten = 10
+'             ^^^ definition scip-dotnet nuget . . VBMain/Enums#EnumWithIntValues#Ten.
+'                 documentation ```vb\nEnumWithIntValues.Ten = 10\n```
+              Twenty = 20
+'             ^^^^^^ definition scip-dotnet nuget . . VBMain/Enums#EnumWithIntValues#Twenty.
+'                    documentation ```vb\nEnumWithIntValues.Twenty = 20\n```
+          End Enum
+
+          Enum EnumWithByteValues
+'              ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Enums#EnumWithByteValues#
+'                                 documentation ```vb\nEnum EnumWithByteValues\n```
+'                                 relationship implementation scip-dotnet nuget System.Runtime 7.0.0.0 System/IComparable#
+'                                 relationship implementation scip-dotnet nuget System.Runtime 7.0.0.0 System/IConvertible#
+'                                 relationship implementation scip-dotnet nuget System.Runtime 7.0.0.0 System/IFormattable#
+              Five = &H05
+'             ^^^^ definition scip-dotnet nuget . . VBMain/Enums#EnumWithByteValues#Five.
+'                  documentation ```vb\nEnumWithByteValues.Five = 5\n```
+              Fifteen = &H0F
+'             ^^^^^^^ definition scip-dotnet nuget . . VBMain/Enums#EnumWithByteValues#Fifteen.
+'                     documentation ```vb\nEnumWithByteValues.Fifteen = 15\n```
+          End Enum
+      End Class
+  End Namespace

--- a/snapshots/output-net7.0/syntax/VBMain/Enums.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Enums.vb
@@ -30,10 +30,10 @@
 '                                 relationship implementation scip-dotnet nuget System.Runtime 7.0.0.0 System/IComparable#
 '                                 relationship implementation scip-dotnet nuget System.Runtime 7.0.0.0 System/IConvertible#
 '                                 relationship implementation scip-dotnet nuget System.Runtime 7.0.0.0 System/IFormattable#
-              Five = &H05
+              Five = &H5
 '             ^^^^ definition scip-dotnet nuget . . VBMain/Enums#EnumWithByteValues#Five.
 '                  documentation ```vb\nEnumWithByteValues.Five = 5\n```
-              Fifteen = &H0F
+              Fifteen = &HF
 '             ^^^^^^^ definition scip-dotnet nuget . . VBMain/Enums#EnumWithByteValues#Fifteen.
 '                     documentation ```vb\nEnumWithByteValues.Fifteen = 15\n```
           End Enum

--- a/snapshots/output-net7.0/syntax/VBMain/Events.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Events.vb
@@ -33,7 +33,7 @@
 '                                  ^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 Collections/ArrayList#Add().
 '                                      ^^^^^ reference scip-dotnet nuget . . VBMain/Events#add_Event2().(value)
               End AddHandler
-              
+
               RemoveHandler(ByVal value As EventHandler)
 '                                 ^^^^^ definition scip-dotnet nuget . . VBMain/Events#remove_Event2().(value)
 '                                       documentation ```vb\nvalue As EventHandler\n```
@@ -43,14 +43,13 @@
 '                                  ^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 Collections/ArrayList#Remove().
 '                                         ^^^^^ reference scip-dotnet nuget . . VBMain/Events#remove_Event2().(value)
               End RemoveHandler
-              
+
               RaiseEvent(ByVal sender As Object, ByVal e As EventArgs)
 '                              ^^^^^^ definition scip-dotnet nuget . . VBMain/Events#raise_Event2().(sender)
 '                                     documentation ```vb\nsender As Object\n```
 '                                                      ^ definition scip-dotnet nuget . . VBMain/Events#raise_Event2().(e)
 '                                                        documentation ```vb\ne As EventArgs\n```
 '                                                           ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/EventArgs#
-              
                   For Each handler As EventHandler In EventHandlerList
 '                          ^^^^^^^ definition local 0
 '                                  documentation ```vb\nhandler As Delegate Sub EventHandler(sender As Object, e As EventArgs)\n```
@@ -58,11 +57,11 @@
 '                                                     ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Events#EventHandlerList.
                       If handler IsNot Nothing Then
 '                        ^^^^^^^ reference local 0
-                      handler.BeginInvoke(sender, e, Nothing, Nothing)
-'                     ^^^^^^^ reference local 0
-'                             ^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/EventHandler#BeginInvoke().
-'                                         ^^^^^^ reference scip-dotnet nuget . . VBMain/Events#raise_Event2().(sender)
-'                                                 ^ reference scip-dotnet nuget . . VBMain/Events#raise_Event2().(e)
+                          handler.BeginInvoke(sender, e, Nothing, Nothing)
+'                         ^^^^^^^ reference local 0
+'                                 ^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/EventHandler#BeginInvoke().
+'                                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Events#raise_Event2().(sender)
+'                                                     ^ reference scip-dotnet nuget . . VBMain/Events#raise_Event2().(e)
                       End If
                   Next
               End RaiseEvent

--- a/snapshots/output-net7.0/syntax/VBMain/Events.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Events.vb
@@ -1,0 +1,79 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Events
+'                  ^^^^^^ definition scip-dotnet nuget . . VBMain/Events#
+'                         documentation ```vb\nClass Events\n```
+          Private EventHandlerList As New ArrayList
+'                 ^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Events#EventHandlerList.
+'                                  documentation ```vb\nPrivate Events.EventHandlerList As ArrayList\n```
+'                                         ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 Collections/ArrayList#
+
+          Public Event Event1 As EventHandler(Of Integer)
+'                      ^^^^^^ definition scip-dotnet nuget . . VBMain/Events#Event1#
+'                             documentation ```vb\nPublic Event Events.Event1 As EventHandler(Of Integer)\n```
+
+          Public Custom Event Event2 As EventHandler
+'                             ^^^^^^ definition scip-dotnet nuget . . VBMain/Events#Event2#
+'                                    documentation ```vb\nPublic Event Events.Event2 As EventHandler\n```
+'                                       ^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/EventHandler#
+
+              AddHandler(ByVal value As EventHandler)
+'                              ^^^^^ definition scip-dotnet nuget . . VBMain/Events#add_Event2().(value)
+'                                    documentation ```vb\nvalue As EventHandler\n```
+'                                       ^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/EventHandler#
+                  EventHandlerList.Add(value)
+'                 ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Events#EventHandlerList.
+'                                  ^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 Collections/ArrayList#Add().
+'                                      ^^^^^ reference scip-dotnet nuget . . VBMain/Events#add_Event2().(value)
+              End AddHandler
+              
+              RemoveHandler(ByVal value As EventHandler)
+'                                 ^^^^^ definition scip-dotnet nuget . . VBMain/Events#remove_Event2().(value)
+'                                       documentation ```vb\nvalue As EventHandler\n```
+'                                          ^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/EventHandler#
+                  EventHandlerList.Remove(value)
+'                 ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Events#EventHandlerList.
+'                                  ^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 Collections/ArrayList#Remove().
+'                                         ^^^^^ reference scip-dotnet nuget . . VBMain/Events#remove_Event2().(value)
+              End RemoveHandler
+              
+              RaiseEvent(ByVal sender As Object, ByVal e As EventArgs)
+'                              ^^^^^^ definition scip-dotnet nuget . . VBMain/Events#raise_Event2().(sender)
+'                                     documentation ```vb\nsender As Object\n```
+'                                                      ^ definition scip-dotnet nuget . . VBMain/Events#raise_Event2().(e)
+'                                                        documentation ```vb\ne As EventArgs\n```
+'                                                           ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/EventArgs#
+              
+                  For Each handler As EventHandler In EventHandlerList
+'                          ^^^^^^^ definition local 0
+'                                  documentation ```vb\nhandler As Delegate Sub EventHandler(sender As Object, e As EventArgs)\n```
+'                                     ^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/EventHandler#
+'                                                     ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Events#EventHandlerList.
+                      If handler IsNot Nothing Then
+'                        ^^^^^^^ reference local 0
+                      handler.BeginInvoke(sender, e, Nothing, Nothing)
+'                     ^^^^^^^ reference local 0
+'                             ^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/EventHandler#BeginInvoke().
+'                                         ^^^^^^ reference scip-dotnet nuget . . VBMain/Events#raise_Event2().(sender)
+'                                                 ^ reference scip-dotnet nuget . . VBMain/Events#raise_Event2().(e)
+                      End If
+                  Next
+              End RaiseEvent
+          End Event
+
+          Private Sub Event1Handler() Handles Me.Event1
+'                     ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Events#Event1Handler().
+'                                   documentation ```vb\nPrivate Sub Events.Event1Handler()\n```
+'                                                ^^^^^^ reference scip-dotnet nuget . . VBMain/Events#Event1#
+              Throw New NotImplementedException()
+'                       ^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/NotImplementedException#
+          End Sub
+      End Class
+  End Namespace

--- a/snapshots/output-net7.0/syntax/VBMain/Expressions.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Expressions.vb
@@ -1,0 +1,656 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Expressions
+'                  ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#
+'                              documentation ```vb\nClass Expressions\n```
+
+          Private Sub AssignmentToPrefixUnaryExpressions()
+'                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AssignmentToPrefixUnaryExpressions().
+'                                                        documentation ```vb\nPrivate Sub Expressions.AssignmentToPrefixUnaryExpressions()\n```
+              Dim A = 42
+'                 ^ definition local 0
+'                   documentation ```vb\nA As Integer\n```
+              Dim B = 42
+'                 ^ definition local 1
+'                   documentation ```vb\nB As Integer\n```
+              A = +A
+'             ^ reference local 0
+'                  ^ reference local 0
+              A = -A
+'             ^ reference local 0
+'                  ^ reference local 0
+              A = Not A
+'             ^ reference local 0
+'                     ^ reference local 0
+              b = A
+'             ^ reference local 1
+'                 ^ reference local 0
+              Dim C = True
+'                 ^ definition local 2
+'                   documentation ```vb\nC As Boolean\n```
+              C = Not C
+'             ^ reference local 2
+'                     ^ reference local 2
+          End Sub
+
+          Private Sub AssignmentToPrefixBinaryExpressions()
+'                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AssignmentToPrefixBinaryExpressions().
+'                                                         documentation ```vb\nPrivate Sub Expressions.AssignmentToPrefixBinaryExpressions()\n```
+              Dim A = 42
+'                 ^ definition local 3
+'                   documentation ```vb\nA As Integer\n```
+              A = A + A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                     ^ reference local 3
+              A = A - A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                     ^ reference local 3
+              A = A * A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                     ^ reference local 3
+              A = A / A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                     ^ reference local 3
+              A = A \ A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                     ^ reference local 3
+              A = A ^ A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                     ^ reference local 3
+              A = A Mod A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                       ^ reference local 3
+              A = A And A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                       ^ reference local 3
+              A = A Or A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                      ^ reference local 3
+              A = A Xor A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                       ^ reference local 3
+              A = A << A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                      ^ reference local 3
+              A = A >> A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                      ^ reference local 3
+          End Sub
+
+          Private Sub AssignmentToBinaryEqualityExpression()
+'                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AssignmentToBinaryEqualityExpression().
+'                                                          documentation ```vb\nPrivate Sub Expressions.AssignmentToBinaryEqualityExpression()\n```
+              Dim A = True
+'                 ^ definition local 4
+'                   documentation ```vb\nA As Boolean\n```
+              Dim B = True
+'                 ^ definition local 5
+'                   documentation ```vb\nB As Boolean\n```
+              Dim C = 42
+'                 ^ definition local 6
+'                   documentation ```vb\nC As Integer\n```
+              Dim D = 42
+'                 ^ definition local 7
+'                   documentation ```vb\nD As Integer\n```
+              A = A = B
+'             ^ reference local 4
+'                 ^ reference local 4
+'                     ^ reference local 5
+              A = A <> B
+'             ^ reference local 4
+'                 ^ reference local 4
+'                      ^ reference local 5
+              A = C < D
+'             ^ reference local 4
+'                 ^ reference local 6
+'                     ^ reference local 7
+              A = C <= D
+'             ^ reference local 4
+'                 ^ reference local 6
+'                      ^ reference local 7
+              A = C > D
+'             ^ reference local 4
+'                 ^ reference local 6
+'                     ^ reference local 7
+              A = C >= D
+'             ^ reference local 4
+'                 ^ reference local 6
+'                      ^ reference local 7
+          End Sub
+
+           Private Sub AssignmentToBinaryExpression()
+'                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AssignmentToBinaryExpression().
+'                                                   documentation ```vb\nPrivate Sub Expressions.AssignmentToBinaryExpression()\n```
+              Dim A = 42
+'                 ^ definition local 8
+'                   documentation ```vb\nA As Integer\n```
+              A += A
+'             ^ reference local 8
+'                  ^ reference local 8
+              A -= A
+'             ^ reference local 8
+'                  ^ reference local 8
+              A *= A
+'             ^ reference local 8
+'                  ^ reference local 8
+              A /= A
+'             ^ reference local 8
+'                  ^ reference local 8
+              A \= A
+'             ^ reference local 8
+'                  ^ reference local 8
+              A &= A
+'             ^ reference local 8
+'                  ^ reference local 8
+              A <<= A
+'             ^ reference local 8
+'                   ^ reference local 8
+              A >>= A
+'             ^ reference local 8
+'                   ^ reference local 8
+              A ^= A
+'             ^ reference local 8
+'                  ^ reference local 8
+          End Sub
+
+           Structure Struct
+'                    ^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Struct#
+'                           documentation ```vb\nStructure Struct\n```
+              Public [Property] As Integer
+'                    ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Struct#Property.
+'                               documentation ```vb\nPublic Struct.Property As Integer\n```
+           End Structure
+
+          Structure IndexedClass
+'                   ^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#IndexedClass#
+'                                documentation ```vb\nStructure IndexedClass\n```
+              Public [Property] As Integer
+'                    ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Property.
+'                               documentation ```vb\nPublic IndexedClass.Property As Integer\n```
+
+              Default Public Property Item(ByVal index As Integer) As Integer
+'                                     ^^^^ definition scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Item.
+'                                          documentation ```vb\nPublic Default Property IndexedClass.Item(index As Integer) As Integer\n```
+'                                                ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Item.(index)
+'                                                      documentation ```vb\nindex As Integer\n```
+                  Get
+                      Return [Property]
+'                            ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Property.
+                  End Get
+                  Set(ByVal value As Integer)
+'                           ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#IndexedClass#set_Item().(value)
+'                                 documentation ```vb\nvalue As Integer\n```
+                      [Property] = value
+'                     ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Property.
+'                                  ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#set_Item().(value)
+                  End Set
+              End Property
+          End Structure
+
+          Private Sub AssignmentToLeftValueTypes()
+'                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AssignmentToLeftValueTypes().
+'                                                documentation ```vb\nPrivate Sub Expressions.AssignmentToLeftValueTypes()\n```
+              Dim E As (A As Integer, B As Integer) = (1, 2) 
+'                 ^ definition local 9
+'                   documentation ```vb\nE As (A As Integer, B As Integer)\n```
+              Dim A = 1
+'                 ^ definition local 10
+'                   documentation ```vb\nA As Integer\n```
+              Dim C = New Struct With {
+'                 ^ definition local 11
+'                   documentation ```vb\nC As Structure Struct\n```
+'                         ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Struct#
+                  .[Property] = 42
+'                  ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Struct#Property.
+              }
+              C.[Property] = 1
+'             ^ reference local 11
+'               ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Struct#Property.
+              Dim D = New IndexedClass()
+'                 ^ definition local 12
+'                   documentation ```vb\nD As Structure IndexedClass\n```
+'                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#
+              d(E.B) = 1
+'             ^ reference local 12
+'               ^ reference local 9
+'                 ^ reference local 14
+              Dim X = New IndexedClass With {
+'                 ^ definition local 15
+'                   documentation ```vb\nX As Structure IndexedClass\n```
+'                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#
+                  .[Property] = 1
+'                  ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Property.
+              }
+              E.A = 1
+'             ^ reference local 9
+'               ^ reference local 16
+          End Sub
+
+          Private Sub TernaryExpression()
+'                     ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#TernaryExpression().
+'                                       documentation ```vb\nPrivate Sub Expressions.TernaryExpression()\n```
+              Dim X = True
+'                 ^ definition local 17
+'                   documentation ```vb\nX As Boolean\n```
+              Dim Y = If(x, "foo", "bar")
+'                 ^ definition local 18
+'                   documentation ```vb\nY As String\n```
+'                        ^ reference local 17
+              Dim Z As Object = True
+'                 ^ definition local 19
+'                   documentation ```vb\nZ As Object\n```
+              Dim T = If(TypeOf z Is Boolean, 42, 41)
+'                 ^ definition local 20
+'                   documentation ```vb\nT As Integer\n```
+'                               ^ reference local 19
+          End Sub
+
+          Class Cast
+'               ^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Cast#
+'                    documentation ```vb\nClass Cast\n```
+              Public Nested As Cast
+'                    ^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Cast#Nested.
+'                           documentation ```vb\nPublic Cast.Nested As Cast\n```
+'                              ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+              Public Nested2 As Cast2
+'                    ^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Cast#Nested2.
+'                            documentation ```vb\nPublic Cast.Nested2 As Cast2\n```
+'                               ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Cast2#
+
+              Public Function Plus(ByVal other As Cast) As Cast
+'                             ^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Cast#Plus().
+'                                  documentation ```vb\nPublic Function Cast.Plus(other As Cast) As Cast\n```
+'                                        ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Cast#Plus().(other)
+'                                              documentation ```vb\nother As Cast\n```
+'                                                 ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+'                                                          ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+                  Nested = other
+'                 ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Nested.
+'                          ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Plus().(other)
+                  Return Me
+              End Function
+
+              Public Class Cast2
+'                          ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Cast#Cast2#
+'                                documentation ```vb\nClass Cast2\n```
+              End Class
+          End Class
+
+          Private Function CastExpressions() As Integer
+'                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#CastExpressions().
+'                                          documentation ```vb\nPrivate Function Expressions.CastExpressions() As Integer\n```
+              Dim A As Object = New Cast()
+'                 ^ definition local 21
+'                   documentation ```vb\nA As Object\n```
+'                                   ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+              Dim B As Object = New Cast()
+'                 ^ definition local 22
+'                   documentation ```vb\nB As Object\n```
+'                                   ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+              Dim C As Cast = (CType(A, Cast)).Plus(CType(B, Cast))
+'                 ^ definition local 23
+'                   documentation ```vb\nC As Class Cast\n```
+'                      ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+'                                    ^ reference local 21
+'                                       ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+'                                              ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Plus().
+'                                                         ^ reference local 22
+'                                                            ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+              Dim D As Cast = CType(New Object() {A, B}(0), Cast)
+'                 ^ definition local 24
+'                   documentation ```vb\nD As Class Cast\n```
+'                      ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+'                                                 ^ reference local 21
+'                                                    ^ reference local 22
+'                                                           ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+              Dim E = CType((C.nested.nested2), Cast.Cast2)
+'                 ^ definition local 25
+'                   documentation ```vb\nE As Class Cast2\n```
+'                            ^ reference local 23
+'                              ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Nested.
+'                                     ^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Nested2.
+'                                               ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+'                                                    ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Cast2#
+              Dim F = CType((1), Int32)
+'                 ^ definition local 26
+'                   documentation ```vb\nF As Integer\n```
+'                                ^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Int32#
+              Dim G = CType((1), Int32)
+'                 ^ definition local 27
+'                   documentation ```vb\nG As Integer\n```
+'                                ^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Int32#
+              Dim H = CType(((1)), Int32)
+'                 ^ definition local 28
+'                   documentation ```vb\nH As Integer\n```
+'                                  ^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Int32#
+              Return F + G + H
+'                    ^ reference local 26
+'                        ^ reference local 27
+'                            ^ reference local 28
+          End Function
+
+          Private Function AnonymousObject() As Object
+'                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AnonymousObject().
+'                                          documentation ```vb\nPrivate Function Expressions.AnonymousObject() As Object\n```
+              Dim X = New With {Key .Helper = ""}
+'                 ^ definition local 29
+'                   documentation ```vb\nX As AnonymousType <anonymous type: Key Helper As String>\n```
+'                                    ^^^^^^ reference local 31
+              Dim Y = New With {x}
+'                 ^ definition local 32
+'                   documentation ```vb\nY As AnonymousType <anonymous type: x As AnonymousType <anonymous type: Key Helper As String>>\n```
+'                               ^ reference local 29
+              Return Y.X.Helper
+'                    ^ reference local 32
+'                      ^ reference local 34
+'                        ^^^^^^ reference local 31
+          End Function
+
+          Class ObjectCreationClass
+'               ^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#
+'                                   documentation ```vb\nClass ObjectCreationClass\n```
+              Public Field As D
+'                    ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#Field.
+'                          documentation ```vb\nPublic ObjectCreationClass.Field As D\n```
+'                             ^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#
+
+              Public Sub New(ByVal field As D)
+'                        ^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#`.ctor`().
+'                            documentation ```vb\nPublic Sub ObjectCreationClass.New(field As D)\n```
+'                                  ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#`.ctor`().(field)
+'                                        documentation ```vb\nfield As D\n```
+'                                           ^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#
+                  Me.Field = field
+'                    ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#Field.
+'                            ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#`.ctor`().(field)
+              End Sub
+
+              Public Class D
+'                          ^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#
+'                            documentation ```vb\nClass D\n```
+                  Public Sub New(ByVal a As Integer, ByVal b As String)
+'                            ^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#`.ctor`().
+'                                documentation ```vb\nPublic Sub D.New(a As Integer, b As String)\n```
+'                                      ^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#`.ctor`().(a)
+'                                        documentation ```vb\na As Integer\n```
+'                                                          ^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#`.ctor`().(b)
+'                                                            documentation ```vb\nb As String\n```
+                  End Sub
+              End Class
+          End Class
+
+          Private Sub ObjectCreation()
+'                     ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreation().
+'                                    documentation ```vb\nPrivate Sub Expressions.ObjectCreation()\n```
+              Dim A = New ObjectCreationClass.D(1, "hi")
+'                 ^ definition local 35
+'                   documentation ```vb\nA As Class D\n```
+'                         ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#
+'                                             ^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#
+              Dim B = New ObjectCreationClass(A) With {
+'                 ^ definition local 36
+'                   documentation ```vb\nB As Class ObjectCreationClass\n```
+'                         ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#
+'                                             ^ reference local 35
+                  .Field = A
+'                  ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#Field.
+'                          ^ reference local 35
+              }
+              B = New ObjectCreationClass(A)
+'             ^ reference local 36
+'                     ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#
+'                                         ^ reference local 35
+          End Sub
+
+          Class NamedParametersClass
+'               ^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#
+'                                    documentation ```vb\nClass NamedParametersClass\n```
+              Public A As Integer
+'                    ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#A.
+'                      documentation ```vb\nPublic NamedParametersClass.A As Integer\n```
+              Public B As String
+'                    ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#B.
+'                      documentation ```vb\nPublic NamedParametersClass.B As String\n```
+
+              Public Sub New(ByVal a As Integer, ByVal b As String)
+'                        ^^^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().
+'                            documentation ```vb\nPublic Sub NamedParametersClass.New(a As Integer, b As String)\n```
+'                                  ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(a)
+'                                    documentation ```vb\na As Integer\n```
+'                                                      ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(b)
+'                                                        documentation ```vb\nb As String\n```
+                  Me.A = a
+'                    ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#A.
+'                        ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(a)
+                  Me.B = b
+'                    ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#B.
+'                        ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(b)
+              End Sub
+
+              Public Sub Update(ByVal a As Integer, ByVal b As String)
+'                        ^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().
+'                               documentation ```vb\nPublic Sub NamedParametersClass.Update(a As Integer, b As String)\n```
+'                                     ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(a)
+'                                       documentation ```vb\na As Integer\n```
+'                                                         ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(b)
+'                                                           documentation ```vb\nb As String\n```
+                  Me.A = a
+'                    ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#A.
+'                        ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(a)
+                  Me.B = b
+'                    ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#B.
+'                        ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(b)
+              End Sub
+          End Class
+
+          Private Function NamedParameters() As NamedParametersClass
+'                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParameters().
+'                                          documentation ```vb\nPrivate Function Expressions.NamedParameters() As NamedParametersClass\n```
+'                                               ^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#
+              Dim A = New NamedParametersClass(B:="hi", A:=1)
+'                 ^ definition local 37
+'                   documentation ```vb\nA As Class NamedParametersClass\n```
+'                         ^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#
+'                                              ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(b)
+'                                                       ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(a)
+              A.Update(B:="foo", A:=42)
+'             ^ reference local 37
+'               ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().
+'                      ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(b)
+'                                ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(a)
+              Return A
+'                    ^ reference local 37
+          End Function
+
+          Private Function AnonymousFunction() As Func(Of Integer, Integer)
+'                          ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AnonymousFunction().
+'                                            documentation ```vb\nPrivate Function Expressions.AnonymousFunction() As Func(Of Integer, Integer)\n```
+              Dim d = Function(ByVal __ As Integer, ByVal ___ As Integer) 42
+'                 ^ definition local 38
+'                   documentation ```vb\nd As AnonymousType Function <generated method>(__ As Integer, ___ As Integer) As Integer\n```
+'                                    ^^ definition local 40
+'                                       documentation ```vb\n__ As Integer\n```
+'                                                         ^^^ definition local 41
+'                                                             documentation ```vb\n___ As Integer\n```
+              Return Function(ByVal a As Integer) a + d.Invoke(a, a)
+'                                   ^ definition local 43
+'                                     documentation ```vb\na As Integer\n```
+'                                                 ^ reference local 43
+'                                                     ^ reference local 38
+'                                                       ^^^^^^ reference local 45
+'                                                              ^ reference local 43
+'                                                                 ^ reference local 43
+          End Function
+
+          Class Lambda
+'               ^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Lambda#
+'                      documentation ```vb\nClass Lambda\n```
+              Public Function func(ByVal x As Lambda) As String
+'                             ^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Lambda#func().
+'                                  documentation ```vb\nPublic Function Lambda.func(x As Lambda) As String\n```
+'                                        ^ definition scip-dotnet nuget . . VBMain/Expressions#Lambda#func().(x)
+'                                          documentation ```vb\nx As Lambda\n```
+'                                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
+                  Return ""
+              End Function
+          End Class
+
+          Private Sub LambdaExpressions()
+'                     ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#LambdaExpressions().
+'                                       documentation ```vb\nPrivate Sub Expressions.LambdaExpressions()\n```
+              Dim a = Function(ByVal x As String) x & 1
+'                 ^ definition local 46
+'                   documentation ```vb\na As AnonymousType Function <generated method>(x As String) As String\n```
+'                                    ^ definition local 48
+'                                      documentation ```vb\nx As String\n```
+'                                                 ^ reference local 48
+              Dim b = Function(ByVal aa As Lambda, ByVal bb As Lambda) aa.func(bb)
+'                 ^ definition local 49
+'                   documentation ```vb\nb As AnonymousType Function <generated method>(aa As Lambda, bb As Lambda) As String\n```
+'                                    ^^ definition local 51
+'                                       documentation ```vb\naa As Lambda\n```
+'                                          ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
+'                                                        ^^ definition local 52
+'                                                           documentation ```vb\nbb As Lambda\n```
+'                                                              ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
+'                                                                      ^^ reference local 51
+'                                                                         ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#func().
+'                                                                              ^^ reference local 52
+              Dim c = Function(aaa As Lambda, __ As Lambda)
+'                 ^ definition local 53
+'                   documentation ```vb\nc As AnonymousType Function <generated method>(aaa As Lambda, __ As Lambda) As String\n```
+'                              ^^^ definition local 55
+'                                  documentation ```vb\naaa As Lambda\n```
+'                                     ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
+'                                             ^^ definition local 56
+'                                                documentation ```vb\n__ As Lambda\n```
+'                                                   ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
+                          If True Then
+                              Return "hi"
+                          End If
+                      End Function
+          End Sub
+
+          Private Sub TupleExpression()
+'                     ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#TupleExpression().
+'                                     documentation ```vb\nPrivate Sub Expressions.TupleExpression()\n```
+              Dim A = (1, 2, "")
+'                 ^ definition local 57
+'                   documentation ```vb\nA As (Integer, Integer, String)\n```
+          End Sub 
+
+          Private Sub ArrayCreation()
+'                     ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#ArrayCreation().
+'                                   documentation ```vb\nPrivate Sub Expressions.ArrayCreation()\n```
+              Dim a = {
+'                 ^ definition local 58
+'                   documentation ```vb\na As Integer(*,*)\n```
+              {1, 1},
+              {2, 2},
+              {3, 3}}
+              Dim d = New Integer(2) {1, 2, 3}
+'                 ^ definition local 59
+'                   documentation ```vb\nd As Integer()\n```
+              Dim e = New Byte(,) {
+'                 ^ definition local 60
+'                   documentation ```vb\ne As Byte(*,*)\n```
+              {1, 2},
+              {2, 3}}
+              Dim f = New Integer(2, 1) {
+'                 ^ definition local 61
+'                   documentation ```vb\nf As Integer(*,*)\n```
+              {1, 1},
+              {2, 2},
+              {3, 3}}
+
+              Dim numbers(4) As Integer
+'                 ^^^^^^^ definition local 62
+'                         documentation ```vb\nnumbers As Integer()\n```
+              Dim numbers2 = New Integer() {1, 2, 4, 8}
+'                 ^^^^^^^^ definition local 63
+'                          documentation ```vb\nnumbers2 As Integer()\n```
+              ReDim Preserve numbers(15)
+'                            ^^^^^^^ reference local 62
+              ReDim numbers(15)
+'                   ^^^^^^^ reference local 62
+              Dim matrix(5, 5) As Double
+'                 ^^^^^^ definition local 64
+'                        documentation ```vb\nmatrix As Double(*,*)\n```
+              Dim matrix2 = New Integer(,) {{1, 2, 3}, {2, 3, 4}, {3, 4, 5}, {4, 5, 6}}
+'                 ^^^^^^^ definition local 65
+'                         documentation ```vb\nmatrix2 As Integer(*,*)\n```
+              Dim sales()() As Double = New Double(11)() {}
+'                 ^^^^^ definition local 66
+'                       documentation ```vb\nsales As Double()()\n```
+          End Sub
+
+           Private Sub [TypeOf]()
+'                      ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#TypeOf().
+'                               documentation ```vb\nPrivate Sub Expressions.TypeOf()\n```
+              Dim a = GetType(Integer)
+'                 ^ definition local 67
+'                   documentation ```vb\na As Class Type\n```
+              Dim b = GetType(List(Of String).Enumerator)
+'                 ^ definition local 68
+'                   documentation ```vb\nb As Class Type\n```
+'                                             ^^^^^^^^^^ reference scip-dotnet nuget System.Collections 7.0.0.0 Generic/List#Enumerator#
+              Dim c = GetType(Dictionary(Of,))
+'                 ^ definition local 69
+'                   documentation ```vb\nc As Class Type\n```
+              Dim d = GetType(Tuple(Of,,,))
+'                 ^ definition local 70
+'                   documentation ```vb\nd As Class Type\n```
+          End Sub
+
+          Private Sub SelectCase()
+'                     ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#SelectCase().
+'                                documentation ```vb\nPrivate Sub Expressions.SelectCase()\n```
+              Dim Some = 42
+'                 ^^^^ definition local 71
+'                      documentation ```vb\nSome As Integer\n```
+              Select Case Some
+'                         ^^^^ reference local 71
+                  Case 1
+                      Debug.WriteLine("One")
+'                     ^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 Diagnostics/Debug#
+'                           ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 Diagnostics/Debug#WriteLine(+2).
+                  Case 2
+                      Debug.WriteLine("One")
+'                     ^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 Diagnostics/Debug#
+'                           ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 Diagnostics/Debug#WriteLine(+2).
+                  Case Else
+                      Debug.WriteLine("More")
+'                     ^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 Diagnostics/Debug#
+'                           ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 Diagnostics/Debug#WriteLine(+2).
+              End Select
+          End Sub
+
+          Private Sub Dictionary()
+'                     ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Dictionary().
+'                                documentation ```vb\nPrivate Sub Expressions.Dictionary()\n```
+              Dim A = New Dictionary(Of String, Integer) From {{ 1, "Test1" }, { 2, "Test1" }}
+'                 ^ definition local 72
+'                   documentation ```vb\nA As Class Dictionary(Of String, Integer)\n```
+          End Sub
+
+      End Class
+  End Namespace

--- a/snapshots/output-net7.0/syntax/VBMain/Expressions.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Expressions.vb
@@ -29,7 +29,7 @@
               A = Not A
 '             ^ reference local 0
 '                     ^ reference local 0
-              b = A
+              B = A
 '             ^ reference local 1
 '                 ^ reference local 0
               Dim C = True
@@ -137,9 +137,9 @@
 '                      ^ reference local 7
           End Sub
 
-           Private Sub AssignmentToBinaryExpression()
-'                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AssignmentToBinaryExpression().
-'                                                   documentation ```vb\nPrivate Sub Expressions.AssignmentToBinaryExpression()\n```
+          Private Sub AssignmentToBinaryExpression()
+'                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AssignmentToBinaryExpression().
+'                                                  documentation ```vb\nPrivate Sub Expressions.AssignmentToBinaryExpression()\n```
               Dim A = 42
 '                 ^ definition local 8
 '                   documentation ```vb\nA As Integer\n```
@@ -172,13 +172,13 @@
 '                  ^ reference local 8
           End Sub
 
-           Structure Struct
-'                    ^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Struct#
-'                           documentation ```vb\nStructure Struct\n```
+          Structure Struct
+'                   ^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Struct#
+'                          documentation ```vb\nStructure Struct\n```
               Public [Property] As Integer
 '                    ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Struct#Property.
 '                               documentation ```vb\nPublic Struct.Property As Integer\n```
-           End Structure
+          End Structure
 
           Structure IndexedClass
 '                   ^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#IndexedClass#
@@ -209,7 +209,7 @@
           Private Sub AssignmentToLeftValueTypes()
 '                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AssignmentToLeftValueTypes().
 '                                                documentation ```vb\nPrivate Sub Expressions.AssignmentToLeftValueTypes()\n```
-              Dim E As (A As Integer, B As Integer) = (1, 2) 
+              Dim E As (A As Integer, B As Integer) = (1, 2)
 '                 ^ definition local 9
 '                   documentation ```vb\nE As (A As Integer, B As Integer)\n```
               Dim A = 1
@@ -229,7 +229,7 @@
 '                 ^ definition local 12
 '                   documentation ```vb\nD As Structure IndexedClass\n```
 '                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#
-              d(E.B) = 1
+              D(E.B) = 1
 '             ^ reference local 12
 '               ^ reference local 9
 '                 ^ reference local 14
@@ -251,14 +251,14 @@
               Dim X = True
 '                 ^ definition local 17
 '                   documentation ```vb\nX As Boolean\n```
-              Dim Y = If(x, "foo", "bar")
+              Dim Y = If(X, "foo", "bar")
 '                 ^ definition local 18
 '                   documentation ```vb\nY As String\n```
 '                        ^ reference local 17
               Dim Z As Object = True
 '                 ^ definition local 19
 '                   documentation ```vb\nZ As Object\n```
-              Dim T = If(TypeOf z Is Boolean, 42, 41)
+              Dim T = If(TypeOf Z Is Boolean, 42, 41)
 '                 ^ definition local 20
 '                   documentation ```vb\nT As Integer\n```
 '                               ^ reference local 19
@@ -322,7 +322,7 @@
 '                                                 ^ reference local 21
 '                                                    ^ reference local 22
 '                                                           ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
-              Dim E = CType((C.nested.nested2), Cast.Cast2)
+              Dim E = CType((C.Nested.Nested2), Cast.Cast2)
 '                 ^ definition local 25
 '                   documentation ```vb\nE As Class Cast2\n```
 '                            ^ reference local 23
@@ -355,11 +355,11 @@
 '                 ^ definition local 29
 '                   documentation ```vb\nX As AnonymousType <anonymous type: Key Helper As String>\n```
 '                                    ^^^^^^ reference local 31
-              Dim Y = New With {x}
+              Dim Y = New With {X}
 '                 ^ definition local 32
-'                   documentation ```vb\nY As AnonymousType <anonymous type: x As AnonymousType <anonymous type: Key Helper As String>>\n```
+'                   documentation ```vb\nY As AnonymousType <anonymous type: X As AnonymousType <anonymous type: Key Helper As String>>\n```
 '                               ^ reference local 29
-              Return Y.X.Helper
+              Return Y.x.Helper
 '                    ^ reference local 32
 '                      ^ reference local 34
 '                        ^^^^^^ reference local 31
@@ -466,13 +466,13 @@
 '                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParameters().
 '                                          documentation ```vb\nPrivate Function Expressions.NamedParameters() As NamedParametersClass\n```
 '                                               ^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#
-              Dim A = New NamedParametersClass(B:="hi", A:=1)
+              Dim A = New NamedParametersClass(b:="hi", a:=1)
 '                 ^ definition local 37
 '                   documentation ```vb\nA As Class NamedParametersClass\n```
 '                         ^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#
 '                                              ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(b)
 '                                                       ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(a)
-              A.Update(B:="foo", A:=42)
+              A.Update(b:="foo", a:=42)
 '             ^ reference local 37
 '               ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().
 '                      ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(b)
@@ -556,7 +556,7 @@
               Dim A = (1, 2, "")
 '                 ^ definition local 57
 '                   documentation ```vb\nA As (Integer, Integer, String)\n```
-          End Sub 
+          End Sub
 
           Private Sub ArrayCreation()
 '                     ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#ArrayCreation().
@@ -603,9 +603,9 @@
 '                       documentation ```vb\nsales As Double()()\n```
           End Sub
 
-           Private Sub [TypeOf]()
-'                      ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#TypeOf().
-'                               documentation ```vb\nPrivate Sub Expressions.TypeOf()\n```
+          Private Sub [TypeOf]()
+'                     ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#TypeOf().
+'                              documentation ```vb\nPrivate Sub Expressions.TypeOf()\n```
               Dim a = GetType(Integer)
 '                 ^ definition local 67
 '                   documentation ```vb\na As Class Type\n```
@@ -647,7 +647,7 @@
           Private Sub Dictionary()
 '                     ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Dictionary().
 '                                documentation ```vb\nPrivate Sub Expressions.Dictionary()\n```
-              Dim A = New Dictionary(Of String, Integer) From {{ 1, "Test1" }, { 2, "Test1" }}
+              Dim A = New Dictionary(Of String, Integer) From {{1, "Test1"}, {2, "Test1"}}
 '                 ^ definition local 72
 '                   documentation ```vb\nA As Class Dictionary(Of String, Integer)\n```
           End Sub

--- a/snapshots/output-net7.0/syntax/VBMain/Fields.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Fields.vb
@@ -1,0 +1,55 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Fields
+'                  ^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#
+'                         documentation ```vb\nClass Fields\n```
+          Class Fields1
+'               ^^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#
+'                       documentation ```vb\nClass Fields1\n```
+              Private ReadOnly Property1 As Integer
+'                              ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#Property1.
+'                                        documentation ```vb\nPrivate ReadOnly Fields1.Property1 As Integer\n```
+              Private Property2, Property3 As Int64
+'                     ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#Property2.
+'                               documentation ```vb\nPrivate Fields1.Property2 As Long\n```
+'                                ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#Property3.
+'                                          documentation ```vb\nPrivate Fields1.Property3 As Long\n```
+'                                             ^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Int64#
+              Private Property4 As Tuple(Of Char, Nullable(Of Integer))
+'                     ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#Property4.
+'                               documentation ```vb\nPrivate Fields1.Property4 As Tuple(Of Char, Integer?)\n```
+
+              Public Sub New(ByVal field2 As Long, ByVal field3 As Long, ByVal field4 As Tuple(Of Char, Integer?), ByVal field1 As Integer)
+'                        ^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().
+'                            documentation ```vb\nPublic Sub Fields1.New(field2 As Long, field3 As Long, field4 As Tuple(Of Char, Integer?), field1 As Integer)\n```
+'                                  ^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field2)
+'                                         documentation ```vb\nfield2 As Long\n```
+'                                                        ^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field3)
+'                                                               documentation ```vb\nfield3 As Long\n```
+'                                                                              ^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field4)
+'                                                                                     documentation ```vb\nfield4 As Tuple(Of Char, Integer?)\n```
+'                                                                                                                        ^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field1)
+'                                                                                                                               documentation ```vb\nfield1 As Integer\n```
+                  Property2 = field2
+'                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#Property2.
+'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field2)
+                  Property3 = field3
+'                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#Property3.
+'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field3)
+                  Property4 = field4
+'                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#Property4.
+'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field4)
+                  Property1 = field1
+'                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#Property1.
+'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field1)
+              End Sub
+          End Class
+      End Class
+  End Namespace

--- a/snapshots/output-net7.0/syntax/VBMain/GlobalAttributes.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/GlobalAttributes.vb
@@ -1,0 +1,90 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      <AttributeUsage(AttributeTargets.[Class], AllowMultiple:=True, Inherited:=True)>
+'      ^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/AttributeUsageAttribute#`.ctor`().
+'                     ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/AttributeTargets#
+'                                      ^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/AttributeTargets#Class.
+'                                               ^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/AttributeUsageAttribute#AllowMultiple.
+'                                                                    ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/AttributeUsageAttribute#Inherited.
+      Public Class GlobalAttributes
+'                  ^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#
+'                                   documentation ```vb\nClass GlobalAttributes\n```
+'                                   relationship implementation scip-dotnet nuget System.Runtime 7.0.0.0 System/Attribute#
+          Inherits Attribute
+'                  ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Attribute#
+
+          Class AuthorAttribute
+'               ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#AuthorAttribute#
+'                               documentation ```vb\nClass AuthorAttribute\n```
+'                               relationship implementation scip-dotnet nuget System.Runtime 7.0.0.0 System/Attribute#
+              Inherits Attribute
+'                      ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Attribute#
+
+              Public Sub New(ByVal name As String)
+'                        ^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#AuthorAttribute#`.ctor`().
+'                            documentation ```vb\nPublic Sub AuthorAttribute.New(name As String)\n```
+'                                  ^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#AuthorAttribute#`.ctor`().(name)
+'                                       documentation ```vb\nname As String\n```
+              End Sub
+          End Class
+
+          <Author("PropertyAttribute")>
+'          ^^^^^^ reference scip-dotnet nuget . . VBMain/GlobalAttributes#AuthorAttribute#`.ctor`().
+          Public Z As Integer
+'                ^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#Z.
+'                  documentation ```vb\nPublic GlobalAttributes.Z As Integer\n```
+
+          <Author("MethodAttribute")>
+'          ^^^^^^ reference scip-dotnet nuget . . VBMain/GlobalAttributes#AuthorAttribute#`.ctor`().
+          Private Function Method1() As Integer
+'                          ^^^^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#Method1().
+'                                  documentation ```vb\nPrivate Function GlobalAttributes.Method1() As Integer\n```
+              Return 0
+          End Function
+
+          <Author("EnumAttribute")>
+'          ^^^^^^ reference scip-dotnet nuget . . VBMain/GlobalAttributes#AuthorAttribute#`.ctor`().
+          Enum A
+'              ^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#A#
+'                documentation ```vb\nEnum A\n```
+'                relationship implementation scip-dotnet nuget System.Runtime 7.0.0.0 System/IComparable#
+'                relationship implementation scip-dotnet nuget System.Runtime 7.0.0.0 System/IConvertible#
+'                relationship implementation scip-dotnet nuget System.Runtime 7.0.0.0 System/IFormattable#
+              B
+'             ^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#A#B.
+'               documentation ```vb\nA.B = 0\n```
+              C
+'             ^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#A#C.
+'               documentation ```vb\nA.C = 1\n```
+          End Enum
+
+          <Author("EventAttribute")>
+'          ^^^^^^ reference scip-dotnet nuget . . VBMain/GlobalAttributes#AuthorAttribute#`.ctor`().
+          Public Event SomeEvent As EventHandler
+'                      ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#SomeEvent#
+'                                documentation ```vb\nPublic Event GlobalAttributes.SomeEvent As EventHandler\n```
+'                                   ^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/EventHandler#
+
+          <Author("TypeParameterAttribute")>
+'          ^^^^^^ reference scip-dotnet nuget . . VBMain/GlobalAttributes#AuthorAttribute#`.ctor`().
+          Public Class InnerClass(Of T)
+'                      ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#InnerClass#
+'                                 documentation ```vb\nClass InnerClass(Of T)\n```
+'                                    ^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#InnerClass#[T]
+'                                      documentation ```vb\nT\n```
+              Private Sub Method(Of T2)()
+'                         ^^^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#InnerClass#Method().
+'                                documentation ```vb\nPrivate Sub InnerClass(Of T).Method(Of T2)()\n```
+'                                   ^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#InnerClass#Method().[T2]
+'                                      documentation ```vb\nT2\n```
+              End Sub
+          End Class
+      End Class
+  End Namespace

--- a/snapshots/output-net7.0/syntax/VBMain/Identifiers.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Identifiers.vb
@@ -1,0 +1,46 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Identifiers
+'                  ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Identifiers#
+'                              documentation ```vb\nClass Identifiers\n```
+          Private Sub SpecialNames()
+'                     ^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Identifiers#SpecialNames().
+'                                  documentation ```vb\nPrivate Sub Identifiers.SpecialNames()\n```
+              Dim [const] = 42
+'                 ^^^^^^^ definition local 0
+'                         documentation ```vb\n[const] As Integer\n```
+              Dim var As Integer = [const]
+'                 ^^^ definition local 1
+'                     documentation ```vb\nvar As Integer\n```
+'                                  ^^^^^^^ reference local 0
+              Dim under_score = 0
+'                 ^^^^^^^^^^^ definition local 2
+'                             documentation ```vb\nunder_score As Integer\n```
+              Dim with1number = 0
+'                 ^^^^^^^^^^^ definition local 3
+'                             documentation ```vb\nwith1number As Integer\n```
+              Dim varæble = 0
+'                 ^^^^^^^ definition local 4
+'                         documentation ```vb\nvaræble As Integer\n```
+              Dim Переменная = 0
+'                 ^^^^^^^^^^ definition local 5
+'                            documentation ```vb\nПеременная As Integer\n```
+              Dim first‿letter = 0
+'                 ^^^^^^^^^^^^ definition local 6
+'                              documentation ```vb\nfirst‿letter As Integer\n```
+              Dim ග්රහලෝකය = 0
+'                 ^^^^^^^^ definition local 7
+'                          documentation ```vb\nග්රහලෝකය As Integer\n```
+              Dim _كوكبxxx = 0
+'                 ^^^^^^^^ definition local 8
+'                          documentation ```vb\n_كوكبxxx As Integer\n```
+          End Sub
+      End Class
+  End Namespace

--- a/snapshots/output-net7.0/syntax/VBMain/Interfaces.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Interfaces.vb
@@ -66,9 +66,9 @@
           Interface IEvent
 '                   ^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IEvent#
 '                          documentation ```vb\nInterface IEvent\n```
-               Event SomeEvent As EventHandler(Of Integer)
-'                    ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IEvent#SomeEvent#
-'                              documentation ```vb\nEvent IEvent.SomeEvent As EventHandler(Of Integer)\n```
+              Event SomeEvent As EventHandler(Of Integer)
+'                   ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IEvent#SomeEvent#
+'                             documentation ```vb\nEvent IEvent.SomeEvent As EventHandler(Of Integer)\n```
           End Interface
 
           Interface IIndex

--- a/snapshots/output-net7.0/syntax/VBMain/Interfaces.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Interfaces.vb
@@ -1,0 +1,94 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Interfaces
+'                  ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#
+'                             documentation ```vb\nClass Interfaces\n```
+          Interface IOne
+'                   ^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IOne#
+'                        documentation ```vb\nInterface IOne\n```
+          End Interface
+
+          Interface ITwo
+'                   ^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#ITwo#
+'                        documentation ```vb\nInterface ITwo\n```
+          End Interface
+
+          Interface IThree
+'                   ^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IThree#
+'                          documentation ```vb\nInterface IThree\n```
+          End Interface
+
+          Interface IProperties
+'                   ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IProperties#
+'                               documentation ```vb\nInterface IProperties\n```
+              ReadOnly Property [Get] As Byte
+'                               ^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IProperties#Get.
+'                                     documentation ```vb\nReadOnly Property IProperties.Get As Byte\n```
+              WriteOnly Property [Set] As Char
+'                                ^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IProperties#Set.
+'                                      documentation ```vb\nWriteOnly Property IProperties.Set As Char\n```
+              Property GetSet As UInteger
+'                      ^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IProperties#GetSet.
+'                             documentation ```vb\nProperty IProperties.GetSet As UInteger\n```
+              Property SetGet As Long
+'                      ^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IProperties#SetGet.
+'                             documentation ```vb\nProperty IProperties.SetGet As Long\n```
+          End Interface
+
+          Interface IMethods
+'                   ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#
+'                            documentation ```vb\nInterface IMethods\n```
+              Sub [Nothing]()
+'                 ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#Nothing().
+'                           documentation ```vb\nSub IMethods.Nothing()\n```
+              Function Output() As Integer
+'                      ^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#Output().
+'                             documentation ```vb\nFunction IMethods.Output() As Integer\n```
+              Sub Input(ByVal a As String)
+'                 ^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#Input().
+'                       documentation ```vb\nSub IMethods.Input(a As String)\n```
+'                             ^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#Input().(a)
+'                               documentation ```vb\na As String\n```
+              Function InputOutput(ByVal a As String) As Integer
+'                      ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#InputOutput().
+'                                  documentation ```vb\nFunction IMethods.InputOutput(a As String) As Integer\n```
+'                                        ^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#InputOutput().(a)
+'                                          documentation ```vb\na As String\n```
+          End Interface
+
+          Interface IEvent
+'                   ^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IEvent#
+'                          documentation ```vb\nInterface IEvent\n```
+               Event SomeEvent As EventHandler(Of Integer)
+'                    ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IEvent#SomeEvent#
+'                              documentation ```vb\nEvent IEvent.SomeEvent As EventHandler(Of Integer)\n```
+          End Interface
+
+          Interface IIndex
+'                   ^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IIndex#
+'                          documentation ```vb\nInterface IIndex\n```
+              Default Property Item(ByVal index As Integer) As Boolean
+'                              ^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IIndex#Item.
+'                                   documentation ```vb\nDefault Property IIndex.Item(index As Integer) As Boolean\n```
+'                                         ^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IIndex#Item.(index)
+'                                               documentation ```vb\nindex As Integer\n```
+          End Interface
+
+          Private Interface IInherit
+'                           ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IInherit#
+'                                    documentation ```vb\nInterface IInherit\n```
+'                                    relationship implementation scip-dotnet nuget . . VBMain/Interfaces#IOne#
+'                                    relationship implementation scip-dotnet nuget . . VBMain/Interfaces#ITwo#
+              Inherits IOne, ITwo
+'                      ^^^^ reference scip-dotnet nuget . . VBMain/Interfaces#IOne#
+'                            ^^^^ reference scip-dotnet nuget . . VBMain/Interfaces#ITwo#
+          End Interface
+      End Class
+  End Namespace

--- a/snapshots/output-net7.0/syntax/VBMain/Literals.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Literals.vb
@@ -1,0 +1,35 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Literals
+'                  ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Literals#
+'                           documentation ```vb\nClass Literals\n```
+          Private Function Interpolation() As String
+'                          ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Literals#Interpolation().
+'                                        documentation ```vb\nPrivate Function Literals.Interpolation() As String\n```
+              Dim a = 1
+'                 ^ definition local 0
+'                   documentation ```vb\na As Integer\n```
+              Dim b = 2
+'                 ^ definition local 1
+'                   documentation ```vb\nb As Integer\n```
+              Dim c = 3
+'                 ^ definition local 2
+'                   documentation ```vb\nc As Integer\n```
+              Dim d = 3
+'                 ^ definition local 3
+'                   documentation ```vb\nd As Integer\n```
+              Return $"a={a} b={b} c={c} d={d}"
+'                         ^ reference local 0
+'                               ^ reference local 1
+'                                     ^ reference local 2
+'                                           ^ reference local 3
+          End Function
+      End Class
+  End Namespace

--- a/snapshots/output-net7.0/syntax/VBMain/Methods.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Methods.vb
@@ -1,0 +1,222 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Methods
+'                  ^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#
+'                          documentation ```vb\nClass Methods\n```
+          Private Function SingleParameter(ByVal b As Integer) As Integer
+'                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#SingleParameter().
+'                                          documentation ```vb\nPrivate Function Methods.SingleParameter(b As Integer) As Integer\n```
+'                                                ^ definition scip-dotnet nuget . . VBMain/Methods#SingleParameter().(b)
+'                                                  documentation ```vb\nb As Integer\n```
+              Return b
+'                    ^ reference scip-dotnet nuget . . VBMain/Methods#SingleParameter().(b)
+          End Function
+
+          Private Function TwoParameters(ByVal a As Integer, ByVal b As Integer) As Integer
+'                          ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#TwoParameters().
+'                                        documentation ```vb\nPrivate Function Methods.TwoParameters(a As Integer, b As Integer) As Integer\n```
+'                                              ^ definition scip-dotnet nuget . . VBMain/Methods#TwoParameters().(a)
+'                                                documentation ```vb\na As Integer\n```
+'                                                                  ^ definition scip-dotnet nuget . . VBMain/Methods#TwoParameters().(b)
+'                                                                    documentation ```vb\nb As Integer\n```
+              Return a + b
+'                    ^ reference scip-dotnet nuget . . VBMain/Methods#TwoParameters().(a)
+'                        ^ reference scip-dotnet nuget . . VBMain/Methods#TwoParameters().(b)
+          End Function
+
+          Private Function Overload1(ByVal a As Integer) As Integer
+'                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#Overload1().
+'                                    documentation ```vb\nPrivate Function Methods.Overload1(a As Integer) As Integer\n```
+'                                          ^ definition scip-dotnet nuget . . VBMain/Methods#Overload1().(a)
+'                                            documentation ```vb\na As Integer\n```
+              Return a
+'                    ^ reference scip-dotnet nuget . . VBMain/Methods#Overload1().(a)
+          End Function
+
+          Private Function Overload1(ByVal a As Integer, ByVal b As Integer) As Integer
+'                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#Overload1(+1).
+'                                    documentation ```vb\nPrivate Function Methods.Overload1(a As Integer, b As Integer) As Integer\n```
+'                                          ^ definition scip-dotnet nuget . . VBMain/Methods#Overload1(+1).(a)
+'                                            documentation ```vb\na As Integer\n```
+'                                                              ^ definition scip-dotnet nuget . . VBMain/Methods#Overload1(+1).(b)
+'                                                                documentation ```vb\nb As Integer\n```
+              Return a + b
+'                    ^ reference scip-dotnet nuget . . VBMain/Methods#Overload1(+1).(a)
+'                        ^ reference scip-dotnet nuget . . VBMain/Methods#Overload1(+1).(b)
+          End Function
+
+          Private Function Generic(Of T)(ByVal param As T) As T
+'                          ^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#Generic().
+'                                  documentation ```vb\nPrivate Function Methods.Generic(Of T)(param As T) As T\n```
+'                                     ^ definition scip-dotnet nuget . . VBMain/Methods#Generic().[T]
+'                                       documentation ```vb\nT\n```
+'                                              ^^^^^ definition scip-dotnet nuget . . VBMain/Methods#Generic().(param)
+'                                                    documentation ```vb\nparam As T\n```
+'                                                       ^ reference scip-dotnet nuget . . VBMain/Methods#Generic().[T]
+'                                                             ^ reference scip-dotnet nuget . . VBMain/Methods#Generic().[T]
+              Return param
+'                    ^^^^^ reference scip-dotnet nuget . . VBMain/Methods#Generic().(param)
+          End Function
+
+          Private Function GenericConstraint(Of T As New)(ByVal param As T) As T
+'                          ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#GenericConstraint().
+'                                            documentation ```vb\nPrivate Function Methods.GenericConstraint(Of T As New)(param As T) As T\n```
+'                                               ^ definition scip-dotnet nuget . . VBMain/Methods#GenericConstraint().[T]
+'                                                 documentation ```vb\nT\n```
+'                                                               ^^^^^ definition scip-dotnet nuget . . VBMain/Methods#GenericConstraint().(param)
+'                                                                     documentation ```vb\nparam As T\n```
+'                                                                        ^ reference scip-dotnet nuget . . VBMain/Methods#GenericConstraint().[T]
+'                                                                              ^ reference scip-dotnet nuget . . VBMain/Methods#GenericConstraint().[T]
+              Return param
+'                    ^^^^^ reference scip-dotnet nuget . . VBMain/Methods#GenericConstraint().(param)
+          End Function
+
+          Private Sub DefaultParameter(ByVal Optional a As Integer = 5)
+'                     ^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameter().
+'                                      documentation ```vb\nPrivate Sub Methods.DefaultParameter([a As Integer = 5])\n```
+'                                                     ^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameter().(a)
+'                                                       documentation ```vb\n[a As Integer = 5]\n```
+          End Sub
+
+          Private Function DefaultParameterOverload(ByVal Optional a As Integer = 5) As Integer
+'                          ^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload().
+'                                                   documentation ```vb\nPrivate Function Methods.DefaultParameterOverload([a As Integer = 5]) As Integer\n```
+'                                                                  ^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload().(a)
+'                                                                    documentation ```vb\n[a As Integer = 5]\n```
+              Return DefaultParameterOverload(a, a)
+'                    ^^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload(+1).
+'                                             ^ reference scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload().(a)
+'                                                ^ reference scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload().(a)
+          End Function
+
+          Private Function DefaultParameterOverload(ByVal a As Integer, ByVal b As Integer) As Integer
+'                          ^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload(+1).
+'                                                   documentation ```vb\nPrivate Function Methods.DefaultParameterOverload(a As Integer, b As Integer) As Integer\n```
+'                                                         ^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload(+1).(a)
+'                                                           documentation ```vb\na As Integer\n```
+'                                                                             ^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload(+1).(b)
+'                                                                               documentation ```vb\nb As Integer\n```
+              Return DefaultParameterOverload()
+'                    ^^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload().
+          End Function
+
+          Interface IHello
+'                   ^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#IHello#
+'                          documentation ```vb\nInterface IHello\n```
+              Function Hello() As String
+'                      ^^^^^ definition scip-dotnet nuget . . VBMain/Methods#IHello#Hello().
+'                            documentation ```vb\nFunction IHello.Hello() As String\n```
+          End Interface
+
+          Class ImplementsHello
+'               ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#ImplementsHello#
+'                               documentation ```vb\nClass ImplementsHello\n```
+'                               relationship implementation scip-dotnet nuget . . VBMain/Methods#IHello#
+              Implements IHello
+'                        ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#IHello#
+
+              Private Function Hello() As String Implements IHello.Hello
+'                              ^^^^^ definition scip-dotnet nuget . . VBMain/Methods#ImplementsHello#Hello().
+'                                    documentation ```vb\nPrivate Function ImplementsHello.Hello() As String\n```
+'                                    relationship implementation reference scip-dotnet nuget . . VBMain/Methods#IHello#Hello().
+'                                                           ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#IHello#
+'                                                                  ^^^^^ reference scip-dotnet nuget . . VBMain/Methods#IHello#Hello().
+                  Throw New NotImplementedException()
+'                           ^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/NotImplementedException#
+              End Function
+
+          End Class
+
+          Class InheritedOverloads1
+'               ^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+'                                   documentation ```vb\nClass InheritedOverloads1\n```
+              Public Sub Method()
+'                        ^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#Method().
+'                               documentation ```vb\nPublic Sub InheritedOverloads1.Method()\n```
+              End Sub
+          End Class
+
+          Class InheritedOverloads2
+'               ^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
+'                                   documentation ```vb\nClass InheritedOverloads2\n```
+'                                   relationship implementation scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+              Inherits InheritedOverloads1
+'                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+
+              Public Function Method(ByVal parameter As Integer) As Integer
+'                             ^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#Method().
+'                                    documentation ```vb\nPublic Function InheritedOverloads2.Method(parameter As Integer) As Integer\n```
+'                                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#Method().(parameter)
+'                                                    documentation ```vb\nparameter As Integer\n```
+                  Return parameter
+'                        ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#Method().(parameter)
+              End Function
+          End Class
+
+          Class InheritedOverloads3
+'               ^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#
+'                                   documentation ```vb\nClass InheritedOverloads3\n```
+'                                   relationship implementation scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
+'                                   relationship implementation scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+              Inherits InheritedOverloads2
+'                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
+
+              Public Function Method(ByVal parameter As String) As String
+'                             ^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#Method().
+'                                    documentation ```vb\nPublic Function InheritedOverloads3.Method(parameter As String) As String\n```
+'                                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#Method().(parameter)
+'                                                    documentation ```vb\nparameter As String\n```
+                  Return parameter
+'                        ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#Method().(parameter)
+              End Function
+          End Class
+
+          Public Shared Sub InheritedOverloads()
+'                           ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads().
+'                                              documentation ```vb\nPublic Shared Sub Methods.InheritedOverloads()\n```
+              Dim a as InheritedOverloads1 = New InheritedOverloads1
+'                 ^ definition local 0
+'                   documentation ```vb\na As Class InheritedOverloads1\n```
+'                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+'                                                ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+              a.Method()
+'             ^ reference local 0
+'               ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#Method().
+              Dim b as InheritedOverloads2 = New InheritedOverloads2
+'                 ^ definition local 1
+'                   documentation ```vb\nb As Class InheritedOverloads2\n```
+'                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
+'                                                ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
+              DirectCast(b, InheritedOverloads1).Method()
+'                        ^ reference local 1
+'                           ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+'                                                ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#Method().
+              b.Method(42)
+'             ^ reference local 1
+'               ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#Method().
+              Dim c as InheritedOverloads3 = New InheritedOverloads3
+'                 ^ definition local 2
+'                   documentation ```vb\nc As Class InheritedOverloads3\n```
+'                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#
+'                                                ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#
+              DirectCast(c, InheritedOverloads1).Method()
+'                        ^ reference local 2
+'                           ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+'                                                ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#Method().
+              DirectCast(c, InheritedOverloads2).Method(42)
+'                        ^ reference local 2
+'                           ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
+'                                                ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#Method().
+              c.Method("42")
+'             ^ reference local 2
+'               ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#Method().
+          End Sub
+      End Class
+  End Namespace

--- a/snapshots/output-net7.0/syntax/VBMain/Methods.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Methods.vb
@@ -181,7 +181,7 @@
           Public Shared Sub InheritedOverloads()
 '                           ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads().
 '                                              documentation ```vb\nPublic Shared Sub Methods.InheritedOverloads()\n```
-              Dim a as InheritedOverloads1 = New InheritedOverloads1
+              Dim a As InheritedOverloads1 = New InheritedOverloads1
 '                 ^ definition local 0
 '                   documentation ```vb\na As Class InheritedOverloads1\n```
 '                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
@@ -189,7 +189,7 @@
               a.Method()
 '             ^ reference local 0
 '               ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#Method().
-              Dim b as InheritedOverloads2 = New InheritedOverloads2
+              Dim b As InheritedOverloads2 = New InheritedOverloads2
 '                 ^ definition local 1
 '                   documentation ```vb\nb As Class InheritedOverloads2\n```
 '                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
@@ -201,7 +201,7 @@
               b.Method(42)
 '             ^ reference local 1
 '               ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#Method().
-              Dim c as InheritedOverloads3 = New InheritedOverloads3
+              Dim c As InheritedOverloads3 = New InheritedOverloads3
 '                 ^ definition local 2
 '                   documentation ```vb\nc As Class InheritedOverloads3\n```
 '                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#

--- a/snapshots/output-net7.0/syntax/VBMain/Modules.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Modules.vb
@@ -1,0 +1,30 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Module Modules
+'                   ^^^^^^^ definition scip-dotnet nuget . . VBMain/Modules#
+'                           documentation ```vb\nModule Modules\n```
+          Private Function [Function](ByVal b As Integer) As Integer
+'                          ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Modules#Function().
+'                                     documentation ```vb\nPrivate Function Modules.Function(b As Integer) As Integer\n```
+'                                           ^ definition scip-dotnet nuget . . VBMain/Modules#Function().(b)
+'                                             documentation ```vb\nb As Integer\n```
+              Return b
+'                    ^ reference scip-dotnet nuget . . VBMain/Modules#Function().(b)
+          End Function
+
+          Private Sub [Sub](ByVal Optional a As Integer = 5)
+'                     ^^^^^ definition scip-dotnet nuget . . VBMain/Modules#Sub().
+'                           documentation ```vb\nPrivate Sub Modules.Sub([a As Integer = 5])\n```
+'                                          ^ definition scip-dotnet nuget . . VBMain/Modules#Sub().(a)
+'                                            documentation ```vb\n[a As Integer = 5]\n```
+          End Sub
+
+      End Module
+  End Namespace

--- a/snapshots/output-net7.0/syntax/VBMain/Operators.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Operators.vb
@@ -1,0 +1,110 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Operators
+'                  ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Operators#
+'                            documentation ```vb\nClass Operators\n```
+          Public Class PlusMinus
+'                      ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#
+'                                documentation ```vb\nClass PlusMinus\n```
+              Public Shared Operator +(A As PlusMinus)
+'                                      ^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#op_UnaryPlus().(A)
+'                                        documentation ```vb\nA As PlusMinus\n```
+'                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#PlusMinus#
+                  Return 0
+              End Operator
+
+              Public Shared Operator +(A As PlusMinus, B As PlusMinus)
+'                                      ^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#op_Addition().(A)
+'                                        documentation ```vb\nA As PlusMinus\n```
+'                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#PlusMinus#
+'                                                      ^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#op_Addition().(B)
+'                                                        documentation ```vb\nB As PlusMinus\n```
+'                                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#PlusMinus#
+                  Return 0
+              End Operator
+
+              Public Shared Operator -(A As PlusMinus)
+'                                      ^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#op_UnaryNegation().(A)
+'                                        documentation ```vb\nA As PlusMinus\n```
+'                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#PlusMinus#
+                  Return 0
+              End Operator
+          End Class
+
+          Public Class TrueFalse
+'                      ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+'                                documentation ```vb\nClass TrueFalse\n```
+              Public Shared Operator IsTrue(A As TrueFalse) As Boolean
+'                                           ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_True().(A)
+'                                             documentation ```vb\nA As TrueFalse\n```
+'                                                ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+                  Return True
+              End Operator
+
+              Public Shared Operator IsFalse(A As TrueFalse) As Boolean
+'                                            ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_False().(A)
+'                                              documentation ```vb\nA As TrueFalse\n```
+'                                                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+                  Return False
+              End Operator
+
+              Public Shared Operator =(A As TrueFalse, B As TrueFalse) As Boolean
+'                                      ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_Equality().(A)
+'                                        documentation ```vb\nA As TrueFalse\n```
+'                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+'                                                      ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_Equality().(B)
+'                                                        documentation ```vb\nB As TrueFalse\n```
+'                                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+                  Return True
+              End Operator
+
+              Public Shared Operator <>(A As TrueFalse, B As TrueFalse) As Boolean
+'                                       ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_Inequality().(A)
+'                                         documentation ```vb\nA As TrueFalse\n```
+'                                            ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+'                                                       ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_Inequality().(B)
+'                                                         documentation ```vb\nB As TrueFalse\n```
+'                                                            ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+                  Return True
+              End Operator
+
+              Public Overrides Function Equals(obj As Object) As Boolean
+'                                       ^^^^^^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().
+'                                              documentation ```vb\nPublic Overrides Function TrueFalse.Equals(obj As Object) As Boolean\n```
+'                                              relationship implementation reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Object#Equals().
+'                                              ^^^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+'                                                  documentation ```vb\nobj As Object\n```
+                  If ReferenceEquals(Nothing, obj) Then Return False
+'                    ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Object#ReferenceEquals().
+'                                             ^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+                  If ReferenceEquals(Me, obj) Then Return True
+'                    ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Object#ReferenceEquals().
+'                                        ^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+                  If obj.GetType() <> Me.GetType() Then Return False
+'                    ^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+'                        ^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Object#GetType().
+'                                        ^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Object#GetType().
+                  Return Equals(CType(obj, TrueFalse))
+'                        ^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().
+'                                     ^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+'                                          ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+              End Function
+
+              Public Overrides Function GetHashCode() As Integer
+'                                       ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#GetHashCode().
+'                                                   documentation ```vb\nPublic Overrides Function TrueFalse.GetHashCode() As Integer\n```
+'                                                   relationship implementation reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Object#GetHashCode().
+                  Throw New NotImplementedException()
+'                           ^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/NotImplementedException#
+              End Function
+
+          End Class
+      End Class
+  End Namespace

--- a/snapshots/output-net7.0/syntax/VBMain/Packages.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Packages.vb
@@ -1,0 +1,29 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+  Imports DiffPlex.DiffBuilder
+'         ^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 DiffPlex/
+'                  ^^^^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 DiffBuilder/
+  Imports DiffPlex.DiffBuilder.Model
+'         ^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 DiffPlex/
+'                  ^^^^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 DiffBuilder/
+'                              ^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 Model/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Packages
+'                  ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Packages#
+'                           documentation ```vb\nClass Packages\n```
+          Private Function Diff() As DiffPaneModel
+'                          ^^^^ definition scip-dotnet nuget . . VBMain/Packages#Diff().
+'                               documentation ```vb\nPrivate Function Packages.Diff() As DiffPaneModel\n```
+'                                    ^^^^^^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 Model/DiffPaneModel#
+              Return InlineDiffBuilder.Diff("a", "b")
+'                    ^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 DiffBuilder/InlineDiffBuilder#
+'                                      ^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 DiffBuilder/InlineDiffBuilder#Diff().
+          End Function
+      End Class
+  End Namespace

--- a/snapshots/output-net7.0/syntax/VBMain/Preprocessors.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Preprocessors.vb
@@ -13,13 +13,13 @@
           Private Function OperatingSystem() As String
 '                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Preprocessors#OperatingSystem().
 '                                          documentation ```vb\nPrivate Function Preprocessors.OperatingSystem() As String\n```
-  #if WIN32
+  #If WIN32 Then
               Dim Os As String = "Win32"
   #warning This class is bad.
   #error Okay, just stop.
   #elif MACOS
               Dim Os As String = "MacOS"
-  #else
+  #Else
               Dim Os As String = "Unknown"
 '                 ^^ definition local 0
 '                    documentation ```vb\nOs As String\n```

--- a/snapshots/output-net7.0/syntax/VBMain/Preprocessors.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Preprocessors.vb
@@ -1,0 +1,31 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Preprocessors
+'                  ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Preprocessors#
+'                                documentation ```vb\nClass Preprocessors\n```
+          Private Function OperatingSystem() As String
+'                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Preprocessors#OperatingSystem().
+'                                          documentation ```vb\nPrivate Function Preprocessors.OperatingSystem() As String\n```
+  #if WIN32
+              Dim Os As String = "Win32"
+  #warning This class is bad.
+  #error Okay, just stop.
+  #elif MACOS
+              Dim Os As String = "MacOS"
+  #else
+              Dim Os As String = "Unknown"
+'                 ^^ definition local 0
+'                    documentation ```vb\nOs As String\n```
+  #End If
+              Return Os
+'                    ^^ reference local 0
+          End Function
+      End Class
+  End Namespace

--- a/snapshots/output-net7.0/syntax/VBMain/Program.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Program.vb
@@ -6,7 +6,7 @@
 '              documentation ```vb\nPublic Sub Program.Main(args As String())\n```
 '              ^^^^ definition scip-dotnet nuget . . VBMain/Program#Main().(args)
 '                   documentation ```vb\nargs As String()\n```
-          
+
           Console.WriteLine("Hello, World!")
 '         ^^^^^^^ reference scip-dotnet nuget System.Console 7.0.0.0 System/Console#
 '                 ^^^^^^^^^ reference scip-dotnet nuget System.Console 7.0.0.0 System/Console#WriteLine(+11).

--- a/snapshots/output-net7.0/syntax/VBMain/Program.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Program.vb
@@ -1,0 +1,14 @@
+  Module Program
+'        ^^^^^^^ definition scip-dotnet nuget . . VBMain/Program#
+'                documentation ```vb\nModule Program\n```
+      Sub Main(args As String())
+'         ^^^^ definition scip-dotnet nuget . . VBMain/Program#Main().
+'              documentation ```vb\nPublic Sub Program.Main(args As String())\n```
+'              ^^^^ definition scip-dotnet nuget . . VBMain/Program#Main().(args)
+'                   documentation ```vb\nargs As String()\n```
+          
+          Console.WriteLine("Hello, World!")
+'         ^^^^^^^ reference scip-dotnet nuget System.Console 7.0.0.0 System/Console#
+'                 ^^^^^^^^^ reference scip-dotnet nuget System.Console 7.0.0.0 System/Console#WriteLine(+11).
+      End Sub
+  End Module

--- a/snapshots/output-net7.0/syntax/VBMain/Properties.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Properties.vb
@@ -1,0 +1,35 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Properties
+'                  ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Properties#
+'                             documentation ```vb\nClass Properties\n```
+          Private ReadOnly Property [Get] As Byte
+'                                   ^^^^^ definition scip-dotnet nuget . . VBMain/Properties#Get.
+'                                         documentation ```vb\nPrivate ReadOnly Property Properties.Get As Byte\n```
+
+          Private WriteOnly Property [Set] As Char
+'                                    ^^^^^ definition scip-dotnet nuget . . VBMain/Properties#Set.
+'                                          documentation ```vb\nPrivate WriteOnly Property Properties.Set As Char\n```
+              Set(ByVal value As Char)
+'                       ^^^^^ definition scip-dotnet nuget . . VBMain/Properties#set_Set().(value)
+'                             documentation ```vb\nvalue As Char\n```
+                  Throw New NotImplementedException()
+'                           ^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/NotImplementedException#
+              End Set
+          End Property
+
+          Private Property GetSet As UInteger
+'                          ^^^^^^ definition scip-dotnet nuget . . VBMain/Properties#GetSet.
+'                                 documentation ```vb\nPrivate Property Properties.GetSet As UInteger\n```
+          Private Property SetGet As Long
+'                          ^^^^^^ definition scip-dotnet nuget . . VBMain/Properties#SetGet.
+'                                 documentation ```vb\nPrivate Property Properties.SetGet As Long\n```
+      End Class
+  End Namespace

--- a/snapshots/output-net7.0/syntax/VBMain/QuerySyntax.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/QuerySyntax.vb
@@ -43,13 +43,13 @@
           Private Sub Projection()
 '                     ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Projection().
 '                                documentation ```vb\nPrivate Sub QuerySyntax.Projection()\n```
-              Dim x = From a In sourceA Select New With {Key.Name = a.Method()}
+              Dim x = From a In sourceA Select New With {Key .Name = a.Method()}
 '                 ^ definition local 1
 '                   documentation ```vb\nx As Interface IEnumerable(Of <anonymous type: Key Name As String>)\n```
 '                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
-'                                                            ^^^^ reference local 3
-'                                                                   ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Projection().a.
-'                                                                     ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                                                             ^^^^ reference local 3
+'                                                                    ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Projection().a.
+'                                                                      ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
               Dim b = From a In x Select a.Name
 '                 ^ definition local 4
 '                   documentation ```vb\nb As Interface IEnumerable(Of String)\n```
@@ -74,23 +74,23 @@
           Private Sub [Let]()
 '                     ^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Let().
 '                           documentation ```vb\nPrivate Sub QuerySyntax.Let()\n```
-              Dim x = From a In sourceA Let z = New With { Key.A = a.Method(), Key.B = a.Method() } Select z
+              Dim x = From a In sourceA Let z = New With {Key .A = a.Method(), Key .B = a.Method()} Select z
 '                 ^ definition local 6
 '                   documentation ```vb\nx As Interface IEnumerable(Of <anonymous type: Key A As String, Key B As String>)\n```
 '                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
 '                                                              ^ reference local 8
 '                                                                  ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Let().a.
 '                                                                    ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
-'                                                                                  ^ reference local 9
-'                                                                                      ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Let().a.
-'                                                                                        ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                                                                                   ^ reference local 9
+'                                                                                       ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Let().a.
+'                                                                                         ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
 '                                                                                                          ^ reference local 11
           End Sub
 
           Private Sub Join()
 '                     ^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Join().
 '                          documentation ```vb\nPrivate Sub QuerySyntax.Join()\n```
-              Dim x = From a In sourceA Join b In sourceB On a.Method() Equals b.Method() Select New With { Key.A = a.Method(), Key.B = b.Method() }
+              Dim x = From a In sourceA Join b In sourceB On a.Method() Equals b.Method() Select New With {Key .A = a.Method(), Key .B = b.Method()}
 '                 ^ definition local 12
 '                   documentation ```vb\nx As Interface IEnumerable(Of <anonymous type: Key A As String, Key B As String>)\n```
 '                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
@@ -102,15 +102,15 @@
 '                                                                                                               ^ reference local 8
 '                                                                                                                   ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Join().a.
 '                                                                                                                     ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
-'                                                                                                                                   ^ reference local 9
-'                                                                                                                                       ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Join().b.
-'                                                                                                                                         ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                                                                                                                                    ^ reference local 9
+'                                                                                                                                        ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Join().b.
+'                                                                                                                                          ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
           End Sub
 
           Private Sub MultipleFrom()
 '                     ^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#MultipleFrom().
 '                                  documentation ```vb\nPrivate Sub QuerySyntax.MultipleFrom()\n```
-              Dim x = From a In sourceA From b In sourceB Where a.Method() = b.Method() Select New With { Key.A = a.Method(), Key.B = b.Method() }
+              Dim x = From a In sourceA From b In sourceB Where a.Method() = b.Method() Select New With {Key .A = a.Method(), Key .B = b.Method()}
 '                 ^ definition local 13
 '                   documentation ```vb\nx As Interface IEnumerable(Of <anonymous type: Key A As String, Key B As String>)\n```
 '                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
@@ -122,9 +122,9 @@
 '                                                                                                             ^ reference local 8
 '                                                                                                                 ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#MultipleFrom().a.
 '                                                                                                                   ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
-'                                                                                                                                 ^ reference local 9
-'                                                                                                                                     ^ reference local 15
-'                                                                                                                                       ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                                                                                                                                  ^ reference local 9
+'                                                                                                                                      ^ reference local 15
+'                                                                                                                                        ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
           End Sub
       End Class
   End Namespace

--- a/snapshots/output-net7.0/syntax/VBMain/QuerySyntax.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/QuerySyntax.vb
@@ -1,0 +1,130 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class QuerySyntax
+'                  ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#
+'                              documentation ```vb\nClass QuerySyntax\n```
+          Private sourceA As List(Of IGeneric) = New List(Of IGeneric)()
+'                 ^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
+'                         documentation ```vb\nPrivate QuerySyntax.sourceA As List(Of IGeneric)\n```
+'                                    ^^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#
+'                                                            ^^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#
+          Private sourceB As List(Of IGeneric) = New List(Of IGeneric)()
+'                 ^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#sourceB.
+'                         documentation ```vb\nPrivate QuerySyntax.sourceB As List(Of IGeneric)\n```
+'                                    ^^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#
+'                                                            ^^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#
+
+          Interface IGeneric
+'                   ^^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#
+'                            documentation ```vb\nInterface IGeneric\n```
+              Function Method() As String
+'                      ^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                             documentation ```vb\nFunction IGeneric.Method() As String\n```
+          End Interface
+
+          Private Sub [Select]()
+'                     ^^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Select().
+'                              documentation ```vb\nPrivate Sub QuerySyntax.Select()\n```
+              Dim x = From a In sourceA Select a.Method()
+'                 ^ definition local 0
+'                   documentation ```vb\nx As Interface IEnumerable(Of String)\n```
+'                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
+'                                              ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Select().a.
+'                                                ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+          End Sub
+
+          Private Sub Projection()
+'                     ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Projection().
+'                                documentation ```vb\nPrivate Sub QuerySyntax.Projection()\n```
+              Dim x = From a In sourceA Select New With {Key.Name = a.Method()}
+'                 ^ definition local 1
+'                   documentation ```vb\nx As Interface IEnumerable(Of <anonymous type: Key Name As String>)\n```
+'                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
+'                                                            ^^^^ reference local 3
+'                                                                   ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Projection().a.
+'                                                                     ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+              Dim b = From a In x Select a.Name
+'                 ^ definition local 4
+'                   documentation ```vb\nb As Interface IEnumerable(Of String)\n```
+'                               ^ reference local 1
+'                                        ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Projection().a.
+'                                          ^^^^ reference local 3
+          End Sub
+
+          Private Sub Where()
+'                     ^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Where().
+'                           documentation ```vb\nPrivate Sub QuerySyntax.Where()\n```
+              Dim x = From a In sourceA Where a.Method().StartsWith("a") Select a
+'                 ^ definition local 5
+'                   documentation ```vb\nx As Interface IEnumerable(Of IGeneric)\n```
+'                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
+'                                             ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Where().a.
+'                                               ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                                                        ^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/String#StartsWith(+1).
+'                                                                               ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Where().a.
+          End Sub
+
+          Private Sub [Let]()
+'                     ^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Let().
+'                           documentation ```vb\nPrivate Sub QuerySyntax.Let()\n```
+              Dim x = From a In sourceA Let z = New With { Key.A = a.Method(), Key.B = a.Method() } Select z
+'                 ^ definition local 6
+'                   documentation ```vb\nx As Interface IEnumerable(Of <anonymous type: Key A As String, Key B As String>)\n```
+'                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
+'                                                              ^ reference local 8
+'                                                                  ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Let().a.
+'                                                                    ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                                                                                  ^ reference local 9
+'                                                                                      ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Let().a.
+'                                                                                        ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                                                                                                          ^ reference local 11
+          End Sub
+
+          Private Sub Join()
+'                     ^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Join().
+'                          documentation ```vb\nPrivate Sub QuerySyntax.Join()\n```
+              Dim x = From a In sourceA Join b In sourceB On a.Method() Equals b.Method() Select New With { Key.A = a.Method(), Key.B = b.Method() }
+'                 ^ definition local 12
+'                   documentation ```vb\nx As Interface IEnumerable(Of <anonymous type: Key A As String, Key B As String>)\n```
+'                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
+'                                                 ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceB.
+'                                                            ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Join().a.
+'                                                              ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                                                                              ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Join().b.
+'                                                                                ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                                                                                                               ^ reference local 8
+'                                                                                                                   ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Join().a.
+'                                                                                                                     ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                                                                                                                                   ^ reference local 9
+'                                                                                                                                       ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Join().b.
+'                                                                                                                                         ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+          End Sub
+
+          Private Sub MultipleFrom()
+'                     ^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#MultipleFrom().
+'                                  documentation ```vb\nPrivate Sub QuerySyntax.MultipleFrom()\n```
+              Dim x = From a In sourceA From b In sourceB Where a.Method() = b.Method() Select New With { Key.A = a.Method(), Key.B = b.Method() }
+'                 ^ definition local 13
+'                   documentation ```vb\nx As Interface IEnumerable(Of <anonymous type: Key A As String, Key B As String>)\n```
+'                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
+'                                                 ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceB.
+'                                                               ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#MultipleFrom().a.
+'                                                                 ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                                                                            ^ reference local 15
+'                                                                              ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                                                                                                             ^ reference local 8
+'                                                                                                                 ^ reference scip-dotnet nuget . . VBMain/QuerySyntax#MultipleFrom().a.
+'                                                                                                                   ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                                                                                                                                 ^ reference local 9
+'                                                                                                                                     ^ reference local 15
+'                                                                                                                                       ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+          End Sub
+      End Class
+  End Namespace

--- a/snapshots/output-net7.0/syntax/VBMain/Statements.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Statements.vb
@@ -32,7 +32,7 @@
               End Try
           End Sub
 
-          Private Function [Default]() As (A as String, B as Boolean)
+          Private Function [Default]() As (A As String, B As Boolean)
 '                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Default().
 '                                    documentation ```vb\nPrivate Function Statements.Default() As (A As String, B As Boolean)\n```
               Dim C As (A As String, B As Boolean) = ("42", 42)
@@ -42,9 +42,9 @@
 '                    ^ reference local 1
           End Function
 
-         Public class Inferred
-'                     ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Inferred#
-'                              documentation ```vb\nClass Inferred\n```
+          Public Class Inferred
+'                      ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Inferred#
+'                               documentation ```vb\nClass Inferred\n```
               Property F1 As Int32
 '                      ^^ definition scip-dotnet nuget . . VBMain/Statements#Inferred#F1.
 '                         documentation ```vb\nPublic Property Inferred.F1 As Integer\n```
@@ -53,7 +53,7 @@
 '                      ^^ definition scip-dotnet nuget . . VBMain/Statements#Inferred#F2.
 '                         documentation ```vb\nPublic Property Inferred.F2 As Integer\n```
 '                            ^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Int32#
-         End Class
+          End Class
 
           Private Sub InferredTuples()
 '                     ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#InferredTuples().
@@ -154,9 +154,9 @@
           Private Function Foreach() As Integer
 '                          ^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Foreach().
 '                                  documentation ```vb\nPrivate Function Statements.Foreach() As Integer\n```
-          Dim y = New Integer() {1}
-'             ^ definition local 16
-'               documentation ```vb\ny As Integer()\n```
+              Dim y = New Integer() {1}
+'                 ^ definition local 16
+'                   documentation ```vb\ny As Integer()\n```
               Dim z = 0
 '                 ^ definition local 17
 '                   documentation ```vb\nz As Integer\n```

--- a/snapshots/output-net7.0/syntax/VBMain/Statements.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Statements.vb
@@ -1,0 +1,178 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+  Imports System.IO
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^ reference scip-dotnet nuget . . IO/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Statements
+'                  ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#
+'                             documentation ```vb\nClass Statements\n```
+          Private Sub [Try]()
+'                     ^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Try().
+'                           documentation ```vb\nPrivate Sub Statements.Try()\n```
+              Try
+                  File.ReadLines("asd")
+'                 ^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 IO/File#
+'                      ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 IO/File#ReadLines().
+              Catch err As Exception
+'                   ^^^ definition local 0
+'                       documentation ```vb\nerr As Class Exception\n```
+'                   ^^^ reference local 0
+'                          ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Exception#
+                  Console.WriteLine(err)
+'                 ^^^^^^^ reference scip-dotnet nuget System.Console 7.0.0.0 System/Console#
+'                         ^^^^^^^^^ reference scip-dotnet nuget System.Console 7.0.0.0 System/Console#WriteLine(+9).
+'                                   ^^^ reference local 0
+              End Try
+          End Sub
+
+          Private Function [Default]() As (A as String, B as Boolean)
+'                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Default().
+'                                    documentation ```vb\nPrivate Function Statements.Default() As (A As String, B As Boolean)\n```
+              Dim C As (A As String, B As Boolean) = ("42", 42)
+'                 ^ definition local 1
+'                   documentation ```vb\nC As (A As String, B As Boolean)\n```
+              Return C
+'                    ^ reference local 1
+          End Function
+
+         Public class Inferred
+'                     ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Inferred#
+'                              documentation ```vb\nClass Inferred\n```
+              Property F1 As Int32
+'                      ^^ definition scip-dotnet nuget . . VBMain/Statements#Inferred#F1.
+'                         documentation ```vb\nPublic Property Inferred.F1 As Integer\n```
+'                            ^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Int32#
+              Property F2 As Int32
+'                      ^^ definition scip-dotnet nuget . . VBMain/Statements#Inferred#F2.
+'                         documentation ```vb\nPublic Property Inferred.F2 As Integer\n```
+'                            ^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Int32#
+         End Class
+
+          Private Sub InferredTuples()
+'                     ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#InferredTuples().
+'                                    documentation ```vb\nPrivate Sub Statements.InferredTuples()\n```
+              Dim List = New List(Of Inferred)()
+'                 ^^^^ definition local 2
+'                      documentation ```vb\nList As Class List(Of Inferred)\n```
+'                                    ^^^^^^^^ reference scip-dotnet nuget . . VBMain/Statements#Inferred#
+              Dim Result = List.Select(Function(c) (c.F1, c.F2)).Where(Function(t) t.F2 = 1)
+'                 ^^^^^^ definition local 3
+'                        documentation ```vb\nResult As Interface IEnumerable(Of (F1 As Integer, F2 As Integer))\n```
+'                          ^^^^ reference local 2
+'                               ^^^^^^ reference scip-dotnet nuget System.Linq 7.0.0.0 Linq/Enumerable#Select().
+'                                               ^ definition local 5
+'                                                 documentation ```vb\nc As Inferred\n```
+'                                                   ^ reference local 5
+'                                                     ^^ reference scip-dotnet nuget . . VBMain/Statements#Inferred#F1.
+'                                                         ^ reference local 5
+'                                                           ^^ reference scip-dotnet nuget . . VBMain/Statements#Inferred#F2.
+'                                                                ^^^^^ reference scip-dotnet nuget System.Linq 7.0.0.0 Linq/Enumerable#Where().
+'                                                                               ^ definition local 7
+'                                                                                 documentation ```vb\nt As (F1 As Integer, F2 As Integer)\n```
+'                                                                                  ^ reference local 7
+'                                                                                    ^^ reference local 9
+          End Sub
+
+          Private Function MultipleInitializers() As Integer
+'                          ^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#MultipleInitializers().
+'                                               documentation ```vb\nPrivate Function Statements.MultipleInitializers() As Integer\n```
+              Dim a As Integer = 1, b As Integer = 2
+'                 ^ definition local 10
+'                   documentation ```vb\na As Integer\n```
+'                                   ^ definition local 11
+'                                     documentation ```vb\nb As Integer\n```
+              Return a + b
+'                    ^ reference local 10
+'                        ^ reference local 11
+          End Function
+
+          Class MyDisposable
+'               ^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#MyDisposable#
+'                            documentation ```vb\nClass MyDisposable\n```
+'                            relationship implementation scip-dotnet nuget System.Runtime 7.0.0.0 System/IDisposable#
+              Implements IDisposable
+'                        ^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/IDisposable#
+
+              Private Sub Dispose() Implements IDisposable.Dispose
+'                         ^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#MyDisposable#Dispose().
+'                                 documentation ```vb\nPrivate Sub MyDisposable.Dispose()\n```
+'                                 relationship implementation reference scip-dotnet nuget System.Runtime 7.0.0.0 System/IDisposable#Dispose().
+'                                              ^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/IDisposable#
+'                                                          ^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/IDisposable#Dispose().
+                  Throw New NotImplementedException()
+'                           ^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/NotImplementedException#
+              End Sub
+          End Class
+
+          Private Function [Using]() As MyDisposable
+'                          ^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Using().
+'                                  documentation ```vb\nPrivate Function Statements.Using() As MyDisposable\n```
+'                                       ^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Statements#MyDisposable#
+              Dim b = New MyDisposable()
+'                 ^ definition local 12
+'                   documentation ```vb\nb As Class MyDisposable\n```
+'                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Statements#MyDisposable#
+
+              Using a = b
+'                   ^ definition local 13
+'                     documentation ```vb\na As Class MyDisposable\n```
+'                       ^ reference local 12
+                  Return a
+'                        ^ reference local 13
+              End Using
+          End Function
+
+          Private Function MultipleUsing() As Long
+'                          ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#MultipleUsing().
+'                                        documentation ```vb\nPrivate Function Statements.MultipleUsing() As Long\n```
+              Using a As Stream = File.OpenRead("a"), b As Stream = File.OpenRead("a")
+'                   ^ definition local 14
+'                     documentation ```vb\na As Class Stream\n```
+'                        ^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 IO/Stream#
+'                                 ^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 IO/File#
+'                                      ^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 IO/File#OpenRead().
+'                                                     ^ definition local 15
+'                                                       documentation ```vb\nb As Class Stream\n```
+'                                                          ^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 IO/Stream#
+'                                                                   ^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 IO/File#
+'                                                                        ^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 IO/File#OpenRead().
+                  Return a.Length + b.Length
+'                        ^ reference local 14
+'                          ^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 IO/Stream#Length.
+'                                   ^ reference local 15
+'                                     ^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 IO/Stream#Length.
+              End Using
+          End Function
+
+          Private Function Foreach() As Integer
+'                          ^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Foreach().
+'                                  documentation ```vb\nPrivate Function Statements.Foreach() As Integer\n```
+          Dim y = New Integer() {1}
+'             ^ definition local 16
+'               documentation ```vb\ny As Integer()\n```
+              Dim z = 0
+'                 ^ definition local 17
+'                   documentation ```vb\nz As Integer\n```
+
+              For Each x As Integer In y
+'                      ^ definition local 18
+'                        documentation ```vb\nx As Integer\n```
+'                                      ^ reference local 16
+                  z += x
+'                 ^ reference local 17
+'                      ^ reference local 18
+              Next
+
+              Return z
+'                    ^ reference local 17
+          End Function
+
+      End Class
+  End Namespace

--- a/snapshots/output-net7.0/syntax/VBMain/Structs.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Structs.vb
@@ -1,0 +1,31 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Structs
+'                  ^^^^^^^ definition scip-dotnet nuget . . VBMain/Structs#
+'                          documentation ```vb\nClass Structs\n```
+          Structure BasicStruct
+'                   ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Structs#BasicStruct#
+'                               documentation ```vb\nStructure BasicStruct\n```
+              Public Property1 As Integer
+'                    ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Structs#BasicStruct#Property1.
+'                              documentation ```vb\nPublic BasicStruct.Property1 As Integer\n```
+
+              Public Sub New(ByVal field1 As Integer)
+'                        ^^^ definition scip-dotnet nuget . . VBMain/Structs#BasicStruct#`.ctor`(+1).
+'                            documentation ```vb\nPublic Sub BasicStruct.New(field1 As Integer)\n```
+'                                  ^^^^^^ definition scip-dotnet nuget . . VBMain/Structs#BasicStruct#`.ctor`(+1).(field1)
+'                                         documentation ```vb\nfield1 As Integer\n```
+                  Property1 = field1
+'                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Structs#BasicStruct#Property1.
+'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Structs#BasicStruct#`.ctor`(+1).(field1)
+              End Sub
+          End Structure
+      End Class
+  End Namespace


### PR DESCRIPTION
Previously, scip-dotnet only supported C#. This PR adds support for Visual Basic as well. We are able to reuse a lot of code from the C# indexer by extracting shared logic related to formatting symbols.