### PR TITLE
Make Parameters and TypeParameters local

### DIFF
--- a/ScipDotnet/ScipDocumentIndexer.cs
+++ b/ScipDotnet/ScipDocumentIndexer.cs
@@ -368,10 +368,12 @@ public class ScipDocumentIndexer
     {
         return sym.Kind == SymbolKind.Local ||
                sym.Kind == SymbolKind.RangeVariable ||
+               sym.Kind == SymbolKind.Parameter ||
+               sym.Kind == SymbolKind.TypeParameter ||
+               sym is IMethodSymbol { MethodKind: MethodKind.LocalFunction } ||
                // Anonymous classes/methods have empty names and can not be accessed outside their file.
                // The "global namespace" (parent of all namespaces) also has an empty name and should not
                // be treated as a local variable.
-               sym is IMethodSymbol { MethodKind: MethodKind.LocalFunction } ||
                (sym.Name.Equals("") && sym.Kind != SymbolKind.Namespace);
     }
 }

--- a/snapshots/output-net6.0/syntax/Main/Classes.cs
+++ b/snapshots/output-net6.0/syntax/Main/Classes.cs
@@ -21,7 +21,7 @@
       public Classes(int name)
 //           ^^^^^^^ definition scip-dotnet nuget . . Main/Classes#`.ctor`().
 //                   documentation ```cs\npublic Classes.Classes(int name)\n```
-//                       ^^^^ definition scip-dotnet nuget . . Main/Classes#`.ctor`().(name)
+//                       ^^^^ definition local 0
 //                            documentation ```cs\nint name\n```
       {
           Name = "name";
@@ -31,10 +31,10 @@
       public Classes(string name) => Name = name;
 //           ^^^^^^^ definition scip-dotnet nuget . . Main/Classes#`.ctor`(+1).
 //                   documentation ```cs\npublic Classes.Classes(string name)\n```
-//                          ^^^^ definition scip-dotnet nuget . . Main/Classes#`.ctor`(+1).(name)
+//                          ^^^^ definition local 1
 //                               documentation ```cs\nstring name\n```
 //                                   ^^^^ reference scip-dotnet nuget . . Main/Classes#Name.
-//                                          ^^^^ reference scip-dotnet nuget . . Main/Classes#`.ctor`(+1).(name)
+//                                          ^^^^ reference local 1
 
       ~Classes()
 //     ^^^^^^^ definition scip-dotnet nuget . . Main/Classes#Finalize().
@@ -60,7 +60,7 @@
       class TypeParameterClass<T>
 //          ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#TypeParameterClass#
 //                             documentation ```cs\nclass TypeParameterClass<T>\n```
-//                             ^ definition scip-dotnet nuget . . Main/Classes#TypeParameterClass#[T]
+//                             ^ definition local 2
 //                               documentation ```cs\nT\n```
       {
       }
@@ -68,9 +68,9 @@
       internal class InternalMultipleTypeParametersClass<T1, T2>
 //                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#InternalMultipleTypeParametersClass#
 //                                                       documentation ```cs\nclass InternalMultipleTypeParametersClass<T1, T2>\n```
-//                                                       ^^ definition scip-dotnet nuget . . Main/Classes#InternalMultipleTypeParametersClass#[T1]
+//                                                       ^^ definition local 3
 //                                                          documentation ```cs\nT1\n```
-//                                                           ^^ definition scip-dotnet nuget . . Main/Classes#InternalMultipleTypeParametersClass#[T2]
+//                                                           ^^ definition local 4
 //                                                              documentation ```cs\nT2\n```
       {
       }
@@ -78,83 +78,83 @@
       interface ICovariantContravariant<in T1, out T2>
 //              ^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#ICovariantContravariant#
 //                                      documentation ```cs\ninterface ICovariantContravariant<in T1, out T2>\n```
-//                                         ^^ definition scip-dotnet nuget . . Main/Classes#ICovariantContravariant#[T1]
+//                                         ^^ definition local 5
 //                                            documentation ```cs\nin T1\n```
-//                                                 ^^ definition scip-dotnet nuget . . Main/Classes#ICovariantContravariant#[T2]
+//                                                 ^^ definition local 6
 //                                                    documentation ```cs\nout T2\n```
       {
           public void Method1(T1 t1)
 //                    ^^^^^^^ definition scip-dotnet nuget . . Main/Classes#ICovariantContravariant#Method1().
 //                            documentation ```cs\nvoid ICovariantContravariant<in T1, out T2>.Method1(T1 t1)\n```
-//                            ^^ reference scip-dotnet nuget . . Main/Classes#ICovariantContravariant#[T1]
-//                               ^^ definition scip-dotnet nuget . . Main/Classes#ICovariantContravariant#Method1().(t1)
+//                            ^^ reference local 5
+//                               ^^ definition local 7
 //                                  documentation ```cs\nT1 t1\n```
           {
               Console.WriteLine(t1);
-//                              ^^ reference scip-dotnet nuget . . Main/Classes#ICovariantContravariant#Method1().(t1)
+//                              ^^ reference local 7
           }
 
           public T2? Method2()
-//               ^^ reference scip-dotnet nuget . . Main/Classes#ICovariantContravariant#[T2]
+//               ^^ reference local 6
 //                   ^^^^^^^ definition scip-dotnet nuget . . Main/Classes#ICovariantContravariant#Method2().
 //                           documentation ```cs\nT2? ICovariantContravariant<in T1, out T2>.Method2()\n```
           {
               return default(T2);
-//                           ^^ reference scip-dotnet nuget . . Main/Classes#ICovariantContravariant#[T2]
+//                           ^^ reference local 6
           }
       }
 
       public class StructConstraintClass<T> where T : struct
 //                 ^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#StructConstraintClass#
 //                                       documentation ```cs\nclass StructConstraintClass<T> where T : struct\n```
-//                                       ^ definition scip-dotnet nuget . . Main/Classes#StructConstraintClass#[T]
+//                                       ^ definition local 8
 //                                         documentation ```cs\nT\n```
-//                                                ^ reference scip-dotnet nuget . . Main/Classes#StructConstraintClass#[T]
+//                                                ^ reference local 8
       {
       }
 
       public class UnmanagedConstraintClass<T> where T : unmanaged
 //                 ^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#UnmanagedConstraintClass#
 //                                          documentation ```cs\nclass UnmanagedConstraintClass<T> where T : unmanaged\n```
-//                                          ^ definition scip-dotnet nuget . . Main/Classes#UnmanagedConstraintClass#[T]
+//                                          ^ definition local 9
 //                                            documentation ```cs\nT\n```
-//                                                   ^ reference scip-dotnet nuget . . Main/Classes#UnmanagedConstraintClass#[T]
+//                                                   ^ reference local 9
       {
       }
 
       public class ClassConstraintClass<T> where T : class
 //                 ^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#ClassConstraintClass#
 //                                      documentation ```cs\nclass ClassConstraintClass<T> where T : class\n```
-//                                      ^ definition scip-dotnet nuget . . Main/Classes#ClassConstraintClass#[T]
+//                                      ^ definition local 10
 //                                        documentation ```cs\nT\n```
-//                                               ^ reference scip-dotnet nuget . . Main/Classes#ClassConstraintClass#[T]
+//                                               ^ reference local 10
       {
       }
 
       public class NonNullableConstraintClass<T> where T : notnull
 //                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#NonNullableConstraintClass#
 //                                            documentation ```cs\nclass NonNullableConstraintClass<T> where T : notnull\n```
-//                                            ^ definition scip-dotnet nuget . . Main/Classes#NonNullableConstraintClass#[T]
+//                                            ^ definition local 11
 //                                              documentation ```cs\nT\n```
-//                                                     ^ reference scip-dotnet nuget . . Main/Classes#NonNullableConstraintClass#[T]
+//                                                     ^ reference local 11
       {
       }
 
       public class NewConstraintClass<T> where T : new()
 //                 ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#NewConstraintClass#
 //                                    documentation ```cs\nclass NewConstraintClass<T> where T : new()\n```
-//                                    ^ definition scip-dotnet nuget . . Main/Classes#NewConstraintClass#[T]
+//                                    ^ definition local 12
 //                                      documentation ```cs\nT\n```
-//                                             ^ reference scip-dotnet nuget . . Main/Classes#NewConstraintClass#[T]
+//                                             ^ reference local 12
       {
       }
 
       public class TypeParameterConstraintClass<T> where T : SomeInterface
 //                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#TypeParameterConstraintClass#
 //                                              documentation ```cs\nclass TypeParameterConstraintClass<T> where T : SomeInterface\n```
-//                                              ^ definition scip-dotnet nuget . . Main/Classes#TypeParameterConstraintClass#[T]
+//                                              ^ definition local 13
 //                                                documentation ```cs\nT\n```
-//                                                       ^ reference scip-dotnet nuget . . Main/Classes#TypeParameterConstraintClass#[T]
+//                                                       ^ reference local 13
 //                                                           ^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/SomeInterface#
       {
       }
@@ -162,15 +162,15 @@
       private class MultipleTypeParameterConstraintsClass<T1, T2> where T1 : SomeInterface, SomeInterface2, new()
 //                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#MultipleTypeParameterConstraintsClass#
 //                                                        documentation ```cs\nclass MultipleTypeParameterConstraintsClass<T1, T2> where T1 : SomeInterface, SomeInterface2, new() where T2 : SomeInterface2\n```
-//                                                        ^^ definition scip-dotnet nuget . . Main/Classes#MultipleTypeParameterConstraintsClass#[T1]
+//                                                        ^^ definition local 14
 //                                                           documentation ```cs\nT1\n```
-//                                                            ^^ definition scip-dotnet nuget . . Main/Classes#MultipleTypeParameterConstraintsClass#[T2]
+//                                                            ^^ definition local 15
 //                                                               documentation ```cs\nT2\n```
-//                                                                      ^^ reference scip-dotnet nuget . . Main/Classes#MultipleTypeParameterConstraintsClass#[T1]
+//                                                                      ^^ reference local 14
 //                                                                           ^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/SomeInterface#
 //                                                                                          ^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/SomeInterface2#
           where T2 : SomeInterface2
-//              ^^ reference scip-dotnet nuget . . Main/Classes#MultipleTypeParameterConstraintsClass#[T2]
+//              ^^ reference local 15
 //                   ^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/SomeInterface2#
       {
       }
@@ -184,14 +184,14 @@
 //                       documentation ```cs\nprivate bool IndexClass.a\n```
 
           public bool this[int index]
-//                             ^^^^^ definition scip-dotnet nuget . . Main/Classes#IndexClass#`this[]`.(index)
+//                             ^^^^^ definition local 16
 //                                   documentation ```cs\nint index\n```
           {
               get { return a; }
 //                         ^ reference scip-dotnet nuget . . Main/Classes#IndexClass#a.
               set { a = value; }
 //                  ^ reference scip-dotnet nuget . . Main/Classes#IndexClass#a.
-//                      ^^^^^ reference scip-dotnet nuget . . Main/Classes#IndexClass#set_Item().(value)
+//                      ^^^^^ reference local 17
           }
       }
 

--- a/snapshots/output-net6.0/syntax/Main/Expressions.cs
+++ b/snapshots/output-net6.0/syntax/Main/Expressions.cs
@@ -201,14 +201,14 @@
 //                            documentation ```cs\npublic int IndexedClass.Property\n```
 
           public int this[int index]
-//                            ^^^^^ definition scip-dotnet nuget . . Main/Expressions#IndexedClass#`this[]`.(index)
+//                            ^^^^^ definition local 9
 //                                  documentation ```cs\nint index\n```
           {
               get { return Property; }
 //                         ^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#IndexedClass#Property.
               set { Property = value; }
 //                  ^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#IndexedClass#Property.
-//                             ^^^^^ reference scip-dotnet nuget . . Main/Expressions#IndexedClass#set_Item().(value)
+//                             ^^^^^ reference local 10
           }
       }
 
@@ -217,54 +217,54 @@
 //                                    documentation ```cs\nprivate void Expressions.AssignmentToLeftValueTypes()\n```
       {
           (var a, var b) = (1, 2);
-//             ^ definition local 9
+//             ^ definition local 11
 //               documentation ```cs\nvar a\n```
-//                    ^ definition local 10
+//                    ^ definition local 12
 //                      documentation ```cs\nvar b\n```
           a = 1;
-//        ^ reference local 9
+//        ^ reference local 11
           var c = new Struct { Property = 42 };
-//            ^ definition local 11
+//            ^ definition local 13
 //              documentation ```cs\nStruct c\n```
 //                    ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Struct#
 //                             ^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Struct#Property.
           c.Property = 1;
-//        ^ reference local 11
+//        ^ reference local 13
 //          ^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Struct#Property.
           var d = new IndexedClass();
-//            ^ definition local 12
+//            ^ definition local 14
 //              documentation ```cs\nIndexedClass d\n```
 //                    ^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#IndexedClass#
           d[b] = 1;
-//        ^ reference local 12
-//          ^ reference local 10
+//        ^ reference local 14
+//          ^ reference local 12
           (a, b) = (1, 2);
-//         ^ reference local 9
-//            ^ reference local 10
+//         ^ reference local 11
+//            ^ reference local 12
           var x = new IndexedClass
-//            ^ definition local 13
+//            ^ definition local 15
 //              documentation ```cs\nIndexedClass x\n```
 //                    ^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#IndexedClass#
           {
               Property = 1,
 //            ^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#IndexedClass#Property.
               [b] = 1
-//             ^ reference local 10
+//             ^ reference local 12
           };
           (a) = 1;
-//         ^ reference local 9
+//         ^ reference local 11
           unsafe
           {
               int myInt = 5;
-//                ^^^^^ definition local 14
+//                ^^^^^ definition local 16
 //                      documentation ```cs\nint myInt\n```
               int* p = &myInt;
-//                 ^ definition local 15
+//                 ^ definition local 17
 //                   documentation ```cs\nint* p\n```
-//                      ^^^^^ reference local 14
+//                      ^^^^^ reference local 16
               Console.WriteLine("myInt = {0}, *p = {1}", myInt, *p);
-//                                                       ^^^^^ reference local 14
-//                                                               ^ reference local 15
+//                                                       ^^^^^ reference local 16
+//                                                               ^ reference local 17
           }
       }
 
@@ -273,19 +273,19 @@
 //                           documentation ```cs\nprivate void Expressions.TernaryExpression()\n```
       {
           var x = true;
-//            ^ definition local 16
+//            ^ definition local 18
 //              documentation ```cs\nbool? x\n```
           var y = x ? "foo" : "bar";
-//            ^ definition local 17
+//            ^ definition local 19
 //              documentation ```cs\nstring? y\n```
-//                ^ reference local 16
+//                ^ reference local 18
           object z = true;
-//               ^ definition local 18
+//               ^ definition local 20
 //                 documentation ```cs\nobject z\n```
           var t = z is bool ? 42 : 41;
-//            ^ definition local 19
+//            ^ definition local 21
 //              documentation ```cs\nint? t\n```
-//                ^ reference local 18
+//                ^ reference local 20
       }
 
       class Cast
@@ -306,12 +306,12 @@
 //                    ^^^^ definition scip-dotnet nuget . . Main/Expressions#Cast#plus().
 //                         documentation ```cs\npublic Cast Cast.plus(Cast other)\n```
 //                         ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
-//                              ^^^^^ definition scip-dotnet nuget . . Main/Expressions#Cast#plus().(other)
+//                              ^^^^^ definition local 22
 //                                    documentation ```cs\nCast other\n```
           {
               nested = other;
 //            ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#nested.
-//                     ^^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#plus().(other)
+//                     ^^^^^ reference local 22
               return this;
           }
 
@@ -327,50 +327,50 @@
 //                        documentation ```cs\nprivate int Expressions.CastExpressions()\n```
       {
           object a = new Cast();
-//               ^ definition local 20
+//               ^ definition local 23
 //                 documentation ```cs\nobject a\n```
 //                       ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
           object b = new Cast();
-//               ^ definition local 21
+//               ^ definition local 24
 //                 documentation ```cs\nobject b\n```
 //                       ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
           Cast c = ((Cast)a).plus((Cast)b);
 //        ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
-//             ^ definition local 22
+//             ^ definition local 25
 //               documentation ```cs\nCast c\n```
 //                   ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
-//                        ^ reference local 20
+//                        ^ reference local 23
 //                           ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#plus().
 //                                 ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
-//                                      ^ reference local 21
+//                                      ^ reference local 24
           Cast d = (Cast)new object[] { a, b }[0];
 //        ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
-//             ^ definition local 23
+//             ^ definition local 26
 //               documentation ```cs\nCast d\n```
 //                  ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
-//                                      ^ reference local 20
-//                                         ^ reference local 21
+//                                      ^ reference local 23
+//                                         ^ reference local 24
           var e = (Cast.Cast2)(c.nested.nested2);
-//            ^ definition local 24
+//            ^ definition local 27
 //              documentation ```cs\nCast2? e\n```
 //                 ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
 //                      ^^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#Cast2#
-//                             ^ reference local 22
+//                             ^ reference local 25
 //                               ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#nested.
 //                                      ^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#nested2.
           var f = (Int32)(1);
-//            ^ definition local 25
+//            ^ definition local 28
 //              documentation ```cs\nInt32? f\n```
           var g = (Int32)(1);
-//            ^ definition local 26
+//            ^ definition local 29
 //              documentation ```cs\nInt32? g\n```
           var h = (Int32)((1));
-//            ^ definition local 27
+//            ^ definition local 30
 //              documentation ```cs\nInt32? h\n```
           return f + g + h;
-//               ^ reference local 25
-//                   ^ reference local 26
-//                       ^ reference local 27
+//               ^ reference local 28
+//                   ^ reference local 29
+//                       ^ reference local 30
       }
 
       object AnonymousObject()
@@ -378,20 +378,20 @@
 //                           documentation ```cs\nprivate object Expressions.AnonymousObject()\n```
       {
           var x = new { Helper = "" };
-//            ^ definition local 28
-//              documentation ```cs\n<anonymous type: string Helper>? x\n```
-//                      ^^^^^^ reference local 30
-          var y = new
 //            ^ definition local 31
+//              documentation ```cs\n<anonymous type: string Helper>? x\n```
+//                      ^^^^^^ reference local 33
+          var y = new
+//            ^ definition local 34
 //              documentation ```cs\n<anonymous type: AnonymousType <anonymous type: string Helper> x>? y\n```
           {
               x
-//            ^ reference local 28
+//            ^ reference local 31
           };
           return y.x.Helper;
-//               ^ reference local 31
-//                 ^ reference local 33
-//                   ^^^^^^ reference local 30
+//               ^ reference local 34
+//                 ^ reference local 36
+//                   ^^^^^^ reference local 33
       }
 
       class TargetType
@@ -401,7 +401,7 @@
           public TargetType(string name)
 //               ^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#TargetType#`.ctor`().
 //                          documentation ```cs\npublic TargetType.TargetType(string name)\n```
-//                                 ^^^^ definition scip-dotnet nuget . . Main/Expressions#TargetType#`.ctor`().(name)
+//                                 ^^^^ definition local 37
 //                                      documentation ```cs\nstring name\n```
           {
           }
@@ -414,10 +414,10 @@
       {
           TargetType x = new("x");
 //        ^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#TargetType#
-//                   ^ definition local 34
+//                   ^ definition local 38
 //                     documentation ```cs\nTargetType x\n```
           return x;
-//               ^ reference local 34
+//               ^ reference local 38
       }
 
       int Checked()
@@ -425,10 +425,10 @@
 //                documentation ```cs\nprivate int Expressions.Checked()\n```
       {
           var three = checked(1 + 2);
-//            ^^^^^ definition local 35
+//            ^^^^^ definition local 39
 //                  documentation ```cs\n? three\n```
           return three;
-//               ^^^^^ reference local 35
+//               ^^^^^ reference local 39
       }
 
       class ObjectCreationClass
@@ -444,12 +444,12 @@
 //               ^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#`.ctor`().
 //                                   documentation ```cs\npublic ObjectCreationClass.ObjectCreationClass(D field)\n```
 //                                   ^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#D#
-//                                     ^^^^^ definition scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#`.ctor`().(field)
+//                                     ^^^^^ definition local 40
 //                                           documentation ```cs\nD field\n```
           {
               this.field = field;
 //                 ^^^^^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#field.
-//                         ^^^^^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#`.ctor`().(field)
+//                         ^^^^^ reference local 40
           }
 
           public class D
@@ -459,9 +459,9 @@
               public D(int a, string b)
 //                   ^ definition scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#D#`.ctor`().
 //                     documentation ```cs\npublic D.D(int a, string b)\n```
-//                         ^ definition scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#D#`.ctor`().(a)
+//                         ^ definition local 41
 //                           documentation ```cs\nint a\n```
-//                                   ^ definition scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#D#`.ctor`().(b)
+//                                   ^ definition local 42
 //                                     documentation ```cs\nstring b\n```
               {
               }
@@ -473,28 +473,28 @@
 //                        documentation ```cs\nprivate void Expressions.ObjectCreation()\n```
       {
           var a = new ObjectCreationClass.D(1, "hi");
-//            ^ definition local 36
+//            ^ definition local 43
 //              documentation ```cs\nD? a\n```
 //                    ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#
 //                                        ^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#D#
           var b = new ObjectCreationClass(a)
-//            ^ definition local 37
+//            ^ definition local 44
 //              documentation ```cs\nObjectCreationClass? b\n```
 //                    ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#
-//                                        ^ reference local 36
+//                                        ^ reference local 43
           {
               field = a,
 //            ^^^^^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#field.
-//                    ^ reference local 36
+//                    ^ reference local 43
           };
           b = new ObjectCreationClass(a);
-//        ^ reference local 37
+//        ^ reference local 44
 //                ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#
-//                                    ^ reference local 36
+//                                    ^ reference local 43
           b = new ObjectCreationClass(a) { };
-//        ^ reference local 37
+//        ^ reference local 44
 //                ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#
-//                                    ^ reference local 36
+//                                    ^ reference local 43
       }
 
       class NamedParametersClass
@@ -511,33 +511,33 @@
           public NamedParametersClass(int a, string b)
 //               ^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#NamedParametersClass#`.ctor`().
 //                                    documentation ```cs\npublic NamedParametersClass.NamedParametersClass(int a, string b)\n```
-//                                        ^ definition scip-dotnet nuget . . Main/Expressions#NamedParametersClass#`.ctor`().(a)
+//                                        ^ definition local 45
 //                                          documentation ```cs\nint a\n```
-//                                                  ^ definition scip-dotnet nuget . . Main/Expressions#NamedParametersClass#`.ctor`().(b)
+//                                                  ^ definition local 46
 //                                                    documentation ```cs\nstring b\n```
           {
               A = a;
 //            ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#A.
-//                ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#`.ctor`().(a)
+//                ^ reference local 45
               B = b;
 //            ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#B.
-//                ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#`.ctor`().(b)
+//                ^ reference local 46
           }
 
           public void Update(int a, string b)
 //                    ^^^^^^ definition scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().
 //                           documentation ```cs\npublic void NamedParametersClass.Update(int a, string b)\n```
-//                               ^ definition scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().(a)
+//                               ^ definition local 47
 //                                 documentation ```cs\nint a\n```
-//                                         ^ definition scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().(b)
+//                                         ^ definition local 48
 //                                           documentation ```cs\nstring b\n```
           {
               A = a;
 //            ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#A.
-//                ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().(a)
+//                ^ reference local 47
               B = b;
 //            ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#B.
-//                ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().(b)
+//                ^ reference local 48
           }
       }
 
@@ -547,18 +547,18 @@
 //                                         documentation ```cs\nprivate NamedParametersClass Expressions.NamedParameters()\n```
       {
           var a = new NamedParametersClass(b: "hi", a: 1);
-//            ^ definition local 38
+//            ^ definition local 49
 //              documentation ```cs\nNamedParametersClass? a\n```
 //                    ^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#
-//                                         ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#`.ctor`().(b)
-//                                                  ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#`.ctor`().(a)
+//                                         ^ reference local 46
+//                                                  ^ reference local 45
           a.Update(b: "foo", a: 42);
-//        ^ reference local 38
+//        ^ reference local 49
 //          ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().
-//                 ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().(b)
-//                           ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().(a)
+//                 ^ reference local 48
+//                           ^ reference local 47
           return a;
-//               ^ reference local 38
+//               ^ reference local 49
       }
 
       Func<int, int> AnonymousFunction()
@@ -566,19 +566,19 @@
 //                                     documentation ```cs\nprivate Func<int, int> Expressions.AnonymousFunction()\n```
       {
           var d = delegate (int _, int _) { return 42; };
-//            ^ definition local 39
+//            ^ definition local 50
 //              documentation ```cs\nFunc<int, int, int>? d\n```
-//                              ^ definition local 41
+//                              ^ definition local 51
 //                                documentation ```cs\nint _\n```
-//                                     ^ definition local 42
+//                                     ^ definition local 52
 //                                       documentation ```cs\nint _\n```
           return delegate (int a) { return a + d.Invoke(a, a); };
-//                             ^ definition local 44
+//                             ^ definition local 53
 //                               documentation ```cs\nint a\n```
-//                                         ^ reference local 44
-//                                             ^ reference local 39
-//                                                      ^ reference local 44
-//                                                         ^ reference local 44
+//                                         ^ reference local 53
+//                                             ^ reference local 50
+//                                                      ^ reference local 53
+//                                                         ^ reference local 53
       }
 
       class Lambda
@@ -589,7 +589,7 @@
 //                      ^^^^ definition scip-dotnet nuget . . Main/Expressions#Lambda#func().
 //                           documentation ```cs\npublic string Lambda.func(Lambda x)\n```
 //                           ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#
-//                                  ^ definition scip-dotnet nuget . . Main/Expressions#Lambda#func().(x)
+//                                  ^ definition local 54
 //                                    documentation ```cs\nLambda x\n```
           {
               return "";
@@ -601,31 +601,31 @@
 //                           documentation ```cs\nprivate void Expressions.LambdaExpressions()\n```
       {
           var a = (string x) => x + 1;
-//            ^ definition local 45
+//            ^ definition local 55
 //              documentation ```cs\nFunc<string, >? a\n```
-//                        ^ definition local 47
+//                        ^ definition local 56
 //                          documentation ```cs\nstring x\n```
-//                              ^ reference local 47
+//                              ^ reference local 56
           var b = (Lambda a, Lambda b) => { return a.func(b); };
-//            ^ definition local 48
+//            ^ definition local 57
 //              documentation ```cs\nFunc<Lambda, Lambda, string>? b\n```
 //                 ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#
-//                        ^ definition local 50
+//                        ^ definition local 58
 //                          documentation ```cs\nLambda a\n```
 //                           ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#
-//                                  ^ definition local 51
+//                                  ^ definition local 59
 //                                    documentation ```cs\nLambda b\n```
-//                                                 ^ reference local 50
+//                                                 ^ reference local 58
 //                                                   ^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#func().
-//                                                        ^ reference local 51
+//                                                        ^ reference local 59
           var c = string (Lambda a, Lambda _) => { return "hi"; };
-//            ^ definition local 52
+//            ^ definition local 60
 //              documentation ```cs\nFunc<Lambda, Lambda, string>? c\n```
 //                        ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#
-//                               ^ definition local 54
+//                               ^ definition local 61
 //                                 documentation ```cs\nLambda a\n```
 //                                  ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#
-//                                         ^ definition local 55
+//                                         ^ definition local 62
 //                                           documentation ```cs\nLambda _\n```
       }
 
@@ -634,7 +634,7 @@
 //                          documentation ```cs\nprivate void Expressions.TupleExpressions()\n```
       {
           var a = (1, 2, "");
-//            ^ definition local 56
+//            ^ definition local 63
 //              documentation ```cs\n(int, int, string)? a\n```
       }
 
@@ -643,25 +643,25 @@
 //                       documentation ```cs\nprivate void Expressions.ArrayCreation()\n```
       {
           var a = new[,] { { 1, 1 }, { 2, 2 }, { 3, 3 } };
-//            ^ definition local 57
+//            ^ definition local 64
 //              documentation ```cs\nint[*,*]? a\n```
           Span<int> b = stackalloc[] { 1, 2, 3 };
-//                  ^ definition local 58
+//                  ^ definition local 65
 //                    documentation ```cs\nSpan<int> b\n```
           Span<int> c = stackalloc int[] { 1, 2, 3 };
-//                  ^ definition local 59
+//                  ^ definition local 66
 //                    documentation ```cs\nSpan<int> c\n```
           var d = new int[3] { 1, 2, 3 };
-//            ^ definition local 60
+//            ^ definition local 67
 //              documentation ```cs\nint[]? d\n```
           var e = new byte[,] { { 1, 2 }, { 2, 3 } };
-//            ^ definition local 61
+//            ^ definition local 68
 //              documentation ```cs\nbyte[*,*]? e\n```
           var f = new int[3, 2] { { 1, 1 }, { 2, 2 }, { 3, 3 } };
-//            ^ definition local 62
+//            ^ definition local 69
 //              documentation ```cs\nint[*,*]? f\n```
           var g = new (string b, string c)[3];
-//            ^ definition local 63
+//            ^ definition local 70
 //              documentation ```cs\n(string b, string c)[]? g\n```
       }
 
@@ -670,12 +670,12 @@
 //                 documentation ```cs\nprivate void Expressions.MakeRef()\n```
       {
           var g = "";
-//            ^ definition local 64
+//            ^ definition local 71
 //              documentation ```cs\nstring? g\n```
           var a = __makeref(g);
-//            ^ definition local 65
+//            ^ definition local 72
 //              documentation ```cs\nTypedReference? a\n```
-//                          ^ reference local 64
+//                          ^ reference local 71
       }
 
       void SizeOf()
@@ -683,7 +683,7 @@
 //                documentation ```cs\nprivate void Expressions.SizeOf()\n```
       {
           var a = sizeof(int);
-//            ^ definition local 66
+//            ^ definition local 73
 //              documentation ```cs\nint? a\n```
       }
 
@@ -692,16 +692,16 @@
 //                documentation ```cs\nprivate void Expressions.TypeOf()\n```
       {
           var a = typeof(int);
-//            ^ definition local 67
+//            ^ definition local 74
 //              documentation ```cs\nType? a\n```
           var b = typeof(List<string>.Enumerator);
-//            ^ definition local 68
+//            ^ definition local 75
 //              documentation ```cs\nType? b\n```
           var c = typeof(Dictionary<,>);
-//            ^ definition local 69
+//            ^ definition local 76
 //              documentation ```cs\nType? c\n```
           var d = typeof(Tuple<,,,>);
-//            ^ definition local 70
+//            ^ definition local 77
 //              documentation ```cs\nType? d\n```
       }
 
@@ -749,12 +749,12 @@
 //                documentation ```cs\nprivate void Expressions.Switch()\n```
       {
           int some = 42;
-//            ^^^^ definition local 71
+//            ^^^^ definition local 78
 //                 documentation ```cs\nint some\n```
           var a = some switch
-//            ^ definition local 72
+//            ^ definition local 79
 //              documentation ```cs\nstring? a\n```
-//                ^^^^ reference local 71
+//                ^^^^ reference local 78
           {
               1 => "one",
               2 => "two",
@@ -762,25 +762,25 @@
           };
           IAnimal dog = new Dog();
 //        ^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#IAnimal#
-//                ^^^ definition local 73
+//                ^^^ definition local 80
 //                    documentation ```cs\nIAnimal dog\n```
 //                          ^^^ reference scip-dotnet nuget . . Main/Expressions#Dog#
           var b = dog switch
-//            ^ definition local 74
+//            ^ definition local 81
 //              documentation ```cs\n? b\n```
-//                ^^^ reference local 73
+//                ^^^ reference local 80
           {
               Cat c => c.Sound(),
 //            ^^^ reference scip-dotnet nuget . . Main/Expressions#Cat#
-//                ^ definition local 75
+//                ^ definition local 82
 //                  documentation ```cs\nCat c\n```
-//                     ^ reference local 75
+//                     ^ reference local 82
 //                       ^^^^^ reference scip-dotnet nuget . . Main/Expressions#Cat#Sound().
               Dog c => c.Sound(),
 //            ^^^ reference scip-dotnet nuget . . Main/Expressions#Dog#
-//                ^ definition local 76
+//                ^ definition local 83
 //                  documentation ```cs\nDog c\n```
-//                     ^ reference local 76
+//                     ^ reference local 83
 //                       ^^^^^ reference scip-dotnet nuget . . Main/Expressions#Dog#Sound().
               _ => throw new ArgumentOutOfRangeException()
           };
@@ -791,7 +791,7 @@
 //                    documentation ```cs\nprivate void Expressions.Dictionary()\n```
       {
           var a = new Dictionary<string, int> { ["a"] = 65 };
-//            ^ definition local 77
+//            ^ definition local 84
 //              documentation ```cs\nDictionary<string, int>? a\n```
       }
 
@@ -800,29 +800,29 @@
 //            documentation ```cs\nprivate void Expressions.Is()\n```
       {
           object s = "s";
-//               ^ definition local 78
+//               ^ definition local 85
 //                 documentation ```cs\nobject s\n```
           if (s is string s2)
-//            ^ reference local 78
-//                        ^^ definition local 79
+//            ^ reference local 85
+//                        ^^ definition local 86
 //                           documentation ```cs\nstring s2\n```
           {
               Console.WriteLine(s2);
-//                              ^^ reference local 79
+//                              ^^ reference local 86
           }
 
           var c = s is "test";
-//            ^ definition local 80
+//            ^ definition local 87
 //              documentation ```cs\nbool? c\n```
-//                ^ reference local 78
+//                ^ reference local 85
           var a = s is int.MaxValue;
-//            ^ definition local 81
+//            ^ definition local 88
 //              documentation ```cs\nbool? a\n```
-//                ^ reference local 78
+//                ^ reference local 85
           var d = s is nameof(a);
-//            ^ definition local 82
+//            ^ definition local 89
 //              documentation ```cs\nbool? d\n```
-//                ^ reference local 78
-//                            ^ reference local 81
+//                ^ reference local 85
+//                            ^ reference local 88
       }
   }

--- a/snapshots/output-net6.0/syntax/Main/Fields.cs
+++ b/snapshots/output-net6.0/syntax/Main/Fields.cs
@@ -27,27 +27,27 @@
           public Fields1(long field2, long field3, Tuple<char, int?> field4, int field1)
 //               ^^^^^^^ definition scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().
 //                       documentation ```cs\npublic Fields1.Fields1(long field2, long field3, Tuple<char, int?> field4, int field1)\n```
-//                            ^^^^^^ definition scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field2)
+//                            ^^^^^^ definition local 0
 //                                   documentation ```cs\nlong field2\n```
-//                                         ^^^^^^ definition scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field3)
+//                                         ^^^^^^ definition local 1
 //                                                documentation ```cs\nlong field3\n```
-//                                                                   ^^^^^^ definition scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field4)
+//                                                                   ^^^^^^ definition local 2
 //                                                                          documentation ```cs\nTuple<char, int?> field4\n```
-//                                                                               ^^^^^^ definition scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field1)
+//                                                                               ^^^^^^ definition local 3
 //                                                                                      documentation ```cs\nint field1\n```
           {
               Property2 = field2;
 //            ^^^^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#Property2.
-//                        ^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field2)
+//                        ^^^^^^ reference local 0
               Property3 = field3;
 //            ^^^^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#Property3.
-//                        ^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field3)
+//                        ^^^^^^ reference local 1
               Property4 = field4;
 //            ^^^^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#Property4.
-//                        ^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field4)
+//                        ^^^^^^ reference local 2
               Property1 = field1;
 //            ^^^^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#Property1.
-//                        ^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field1)
+//                        ^^^^^^ reference local 3
           }
       }
 

--- a/snapshots/output-net6.0/syntax/Main/GlobalAttributes.cs
+++ b/snapshots/output-net6.0/syntax/Main/GlobalAttributes.cs
@@ -18,7 +18,7 @@
           public AuthorAttribute(string name)
 //               ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/GlobalAttributes#AuthorAttribute#`.ctor`().
 //                               documentation ```cs\npublic AuthorAttribute.AuthorAttribute(string name)\n```
-//                                      ^^^^ definition scip-dotnet nuget . . Main/GlobalAttributes#AuthorAttribute#`.ctor`().(name)
+//                                      ^^^^ definition local 0
 //                                           documentation ```cs\nstring name\n```
           {
           }
@@ -62,13 +62,13 @@
       public class InnerClass<[Author("ClassTypeParameter")] T>
 //                 ^^^^^^^^^^ definition scip-dotnet nuget . . Main/GlobalAttributes#InnerClass#
 //                            documentation ```cs\nclass InnerClass<T>\n```
-//                                                           ^ definition scip-dotnet nuget . . Main/GlobalAttributes#InnerClass#[T]
+//                                                           ^ definition local 1
 //                                                             documentation ```cs\nT\n```
       {
           void Method<[Author("MethodTypeParameter")] T2>()
 //             ^^^^^^ definition scip-dotnet nuget . . Main/GlobalAttributes#InnerClass#Method().
 //                    documentation ```cs\nprivate void InnerClass<T>.Method<T2>()\n```
-//                                                    ^^ definition scip-dotnet nuget . . Main/GlobalAttributes#InnerClass#Method().[T2]
+//                                                    ^^ definition local 2
 //                                                       documentation ```cs\nT2\n```
           {
           }

--- a/snapshots/output-net6.0/syntax/Main/Interfaces.cs
+++ b/snapshots/output-net6.0/syntax/Main/Interfaces.cs
@@ -57,12 +57,12 @@
           void Input(string a);
 //             ^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IMethods#Input().
 //                   documentation ```cs\nvoid IMethods.Input(string a)\n```
-//                          ^ definition scip-dotnet nuget . . Main/Interfaces#IMethods#Input().(a)
+//                          ^ definition local 0
 //                            documentation ```cs\nstring a\n```
           int InputOutput(string a);
 //            ^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IMethods#InputOutput().
 //                        documentation ```cs\nint IMethods.InputOutput(string a)\n```
-//                               ^ definition scip-dotnet nuget . . Main/Interfaces#IMethods#InputOutput().(a)
+//                               ^ definition local 1
 //                                 documentation ```cs\nstring a\n```
       };
 
@@ -80,7 +80,7 @@
 //                     documentation ```cs\ninterface IIndex\n```
       {
           bool this[int index] { get; set; }
-//                      ^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IIndex#`this[]`.(index)
+//                      ^^^^^ definition local 2
 //                            documentation ```cs\nint index\n```
       }
 
@@ -91,11 +91,11 @@
           void Log(string message)
 //             ^^^ definition scip-dotnet nuget . . Main/Interfaces#IDefault#Log().
 //                 documentation ```cs\nvoid IDefault.Log(string message)\n```
-//                        ^^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IDefault#Log().(message)
+//                        ^^^^^^^ definition local 3
 //                                documentation ```cs\nstring message\n```
           {
               Console.WriteLine(message);
-//                              ^^^^^^^ reference scip-dotnet nuget . . Main/Interfaces#IDefault#Log().(message)
+//                              ^^^^^^^ reference local 3
           }
       }
 
@@ -113,15 +113,15 @@
       public interface IGetNext<T> where T : IGetNext<T>
 //                     ^^^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IGetNext#
 //                              documentation ```cs\ninterface IGetNext<T> where T : IGetNext<T>\n```
-//                              ^ definition scip-dotnet nuget . . Main/Interfaces#IGetNext#[T]
+//                              ^ definition local 4
 //                                documentation ```cs\nT\n```
-//                                       ^ reference scip-dotnet nuget . . Main/Interfaces#IGetNext#[T]
-//                                                    ^ reference scip-dotnet nuget . . Main/Interfaces#IGetNext#[T]
+//                                       ^ reference local 4
+//                                                    ^ reference local 4
       {
           static IGetNext<T> operator ++(IGetNext<T> other)
-//                        ^ reference scip-dotnet nuget . . Main/Interfaces#IGetNext#[T]
-//                                                ^ reference scip-dotnet nuget . . Main/Interfaces#IGetNext#[T]
-//                                                   ^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IGetNext#op_Increment().(other)
+//                        ^ reference local 4
+//                                                ^ reference local 4
+//                                                   ^^^^^ definition local 5
 //                                                         documentation ```cs\nIGetNext<T> other\n```
           {
               throw new NotImplementedException();
@@ -132,14 +132,14 @@
 //                      ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#ITypeParameter#
 //                                     documentation ```cs\ninterface ITypeParameter<T1, T2> where T1 : IOne where T2 : IThree\n```
 //                                     relationship implementation scip-dotnet nuget . . Main/Interfaces#ITwo#
-//                                     ^^ definition scip-dotnet nuget . . Main/Interfaces#ITypeParameter#[T1]
+//                                     ^^ definition local 6
 //                                        documentation ```cs\nT1\n```
-//                                         ^^ definition scip-dotnet nuget . . Main/Interfaces#ITypeParameter#[T2]
+//                                         ^^ definition local 7
 //                                            documentation ```cs\nT2\n```
 //                                               ^^^^ reference scip-dotnet nuget . . Main/Interfaces#ITwo#
-//                                                          ^^ reference scip-dotnet nuget . . Main/Interfaces#ITypeParameter#[T1]
+//                                                          ^^ reference local 6
 //                                                               ^^^^ reference scip-dotnet nuget . . Main/Interfaces#IOne#
-//                                                                          ^^ reference scip-dotnet nuget . . Main/Interfaces#ITypeParameter#[T2]
+//                                                                          ^^ reference local 7
 //                                                                               ^^^^^^ reference scip-dotnet nuget . . Main/Interfaces#IThree#
       {
       }

--- a/snapshots/output-net6.0/syntax/Main/Methods.cs
+++ b/snapshots/output-net6.0/syntax/Main/Methods.cs
@@ -11,82 +11,82 @@
       int SingleParameter(int b)
 //        ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#SingleParameter().
 //                        documentation ```cs\nprivate int Methods.SingleParameter(int b)\n```
-//                            ^ definition scip-dotnet nuget . . Main/Methods#SingleParameter().(b)
+//                            ^ definition local 0
 //                              documentation ```cs\nint b\n```
       {
           return b;
-//               ^ reference scip-dotnet nuget . . Main/Methods#SingleParameter().(b)
+//               ^ reference local 0
       }
 
       int TwoParameters(int a, int b)
 //        ^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#TwoParameters().
 //                      documentation ```cs\nprivate int Methods.TwoParameters(int a, int b)\n```
-//                          ^ definition scip-dotnet nuget . . Main/Methods#TwoParameters().(a)
+//                          ^ definition local 1
 //                            documentation ```cs\nint a\n```
-//                                 ^ definition scip-dotnet nuget . . Main/Methods#TwoParameters().(b)
+//                                 ^ definition local 2
 //                                   documentation ```cs\nint b\n```
       {
           return a + b;
-//               ^ reference scip-dotnet nuget . . Main/Methods#TwoParameters().(a)
-//                   ^ reference scip-dotnet nuget . . Main/Methods#TwoParameters().(b)
+//               ^ reference local 1
+//                   ^ reference local 2
       }
 
       int Overload1(int a)
 //        ^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#Overload1().
 //                  documentation ```cs\nprivate int Methods.Overload1(int a)\n```
-//                      ^ definition scip-dotnet nuget . . Main/Methods#Overload1().(a)
+//                      ^ definition local 3
 //                        documentation ```cs\nint a\n```
       {
           return a;
-//               ^ reference scip-dotnet nuget . . Main/Methods#Overload1().(a)
+//               ^ reference local 3
       }
 
       int Overload1(int a, int b)
 //        ^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#Overload1(+1).
 //                  documentation ```cs\nprivate int Methods.Overload1(int a, int b)\n```
-//                      ^ definition scip-dotnet nuget . . Main/Methods#Overload1(+1).(a)
+//                      ^ definition local 4
 //                        documentation ```cs\nint a\n```
-//                             ^ definition scip-dotnet nuget . . Main/Methods#Overload1(+1).(b)
+//                             ^ definition local 5
 //                               documentation ```cs\nint b\n```
       {
           return a + b;
-//               ^ reference scip-dotnet nuget . . Main/Methods#Overload1(+1).(a)
-//                   ^ reference scip-dotnet nuget . . Main/Methods#Overload1(+1).(b)
+//               ^ reference local 4
+//                   ^ reference local 5
       }
 
       T Generic<T>(T param)
-//    ^ reference scip-dotnet nuget . . Main/Methods#Generic().[T]
+//    ^ reference local 6
 //      ^^^^^^^ definition scip-dotnet nuget . . Main/Methods#Generic().
 //              documentation ```cs\nprivate T Methods.Generic<T>(T param)\n```
-//              ^ definition scip-dotnet nuget . . Main/Methods#Generic().[T]
+//              ^ definition local 6
 //                documentation ```cs\nT\n```
-//                 ^ reference scip-dotnet nuget . . Main/Methods#Generic().[T]
-//                   ^^^^^ definition scip-dotnet nuget . . Main/Methods#Generic().(param)
+//                 ^ reference local 6
+//                   ^^^^^ definition local 7
 //                         documentation ```cs\nT param\n```
       {
           return param;
-//               ^^^^^ reference scip-dotnet nuget . . Main/Methods#Generic().(param)
+//               ^^^^^ reference local 7
       }
 
       T GenericConstraint<T>(T param) where T : new()
-//    ^ reference scip-dotnet nuget . . Main/Methods#GenericConstraint().[T]
+//    ^ reference local 8
 //      ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#GenericConstraint().
 //                        documentation ```cs\nprivate T Methods.GenericConstraint<T>(T param) where T : new()\n```
-//                        ^ definition scip-dotnet nuget . . Main/Methods#GenericConstraint().[T]
+//                        ^ definition local 8
 //                          documentation ```cs\nT\n```
-//                           ^ reference scip-dotnet nuget . . Main/Methods#GenericConstraint().[T]
-//                             ^^^^^ definition scip-dotnet nuget . . Main/Methods#GenericConstraint().(param)
+//                           ^ reference local 8
+//                             ^^^^^ definition local 9
 //                                   documentation ```cs\nT param\n```
-//                                          ^ reference scip-dotnet nuget . . Main/Methods#GenericConstraint().[T]
+//                                          ^ reference local 8
       {
           return param;
-//               ^^^^^ reference scip-dotnet nuget . . Main/Methods#GenericConstraint().(param)
+//               ^^^^^ reference local 9
       }
 
       void DefaultParameter(int a = 5)
 //         ^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#DefaultParameter().
 //                          documentation ```cs\nprivate void Methods.DefaultParameter([int a = 5])\n```
-//                              ^ definition scip-dotnet nuget . . Main/Methods#DefaultParameter().(a)
+//                              ^ definition local 10
 //                                documentation ```cs\n[int a = 5]\n```
       {
       }
@@ -94,21 +94,21 @@
       int DefaultParameterOverload(int a = 5)
 //        ^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#DefaultParameterOverload().
 //                                 documentation ```cs\nprivate int Methods.DefaultParameterOverload([int a = 5])\n```
-//                                     ^ definition scip-dotnet nuget . . Main/Methods#DefaultParameterOverload().(a)
+//                                     ^ definition local 11
 //                                       documentation ```cs\n[int a = 5]\n```
       {
           return DefaultParameterOverload(a, a);
 //               ^^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Methods#DefaultParameterOverload(+1).
-//                                        ^ reference scip-dotnet nuget . . Main/Methods#DefaultParameterOverload().(a)
-//                                           ^ reference scip-dotnet nuget . . Main/Methods#DefaultParameterOverload().(a)
+//                                        ^ reference local 11
+//                                           ^ reference local 11
       }
 
       int DefaultParameterOverload(int a, int b)
 //        ^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#DefaultParameterOverload(+1).
 //                                 documentation ```cs\nprivate int Methods.DefaultParameterOverload(int a, int b)\n```
-//                                     ^ definition scip-dotnet nuget . . Main/Methods#DefaultParameterOverload(+1).(a)
+//                                     ^ definition local 12
 //                                       documentation ```cs\nint a\n```
-//                                            ^ definition scip-dotnet nuget . . Main/Methods#DefaultParameterOverload(+1).(b)
+//                                            ^ definition local 13
 //                                              documentation ```cs\nint b\n```
       {
           return DefaultParameterOverload();
@@ -160,11 +160,11 @@
           public int Method(int parameter)
 //                   ^^^^^^ definition scip-dotnet nuget . . Main/Methods#InheritedOverloads2#Method().
 //                          documentation ```cs\npublic int InheritedOverloads2.Method(int parameter)\n```
-//                              ^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#InheritedOverloads2#Method().(parameter)
+//                              ^^^^^^^^^ definition local 14
 //                                        documentation ```cs\nint parameter\n```
           {
               return parameter;
-//                   ^^^^^^^^^ reference scip-dotnet nuget . . Main/Methods#InheritedOverloads2#Method().(parameter)
+//                   ^^^^^^^^^ reference local 14
           }
       }
 
@@ -178,11 +178,11 @@
           public string Method(string parameter)
 //                      ^^^^^^ definition scip-dotnet nuget . . Main/Methods#InheritedOverloads3#Method().
 //                             documentation ```cs\npublic string InheritedOverloads3.Method(string parameter)\n```
-//                                    ^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#InheritedOverloads3#Method().(parameter)
+//                                    ^^^^^^^^^ definition local 15
 //                                              documentation ```cs\nstring parameter\n```
           {
               return parameter;
-//                   ^^^^^^^^^ reference scip-dotnet nuget . . Main/Methods#InheritedOverloads3#Method().(parameter)
+//                   ^^^^^^^^^ reference local 15
           }
       }
 
@@ -219,25 +219,25 @@
 //                                  documentation ```cs\npublic static void LocalFunction.Method()\n```
           {
               var myWorld = GetWorld();
-//                ^^^^^^^ definition local 0
+//                ^^^^^^^ definition local 16
 //                        documentation ```cs\nstring? myWorld\n```
-//                          ^^^^^^^^ reference local 1
+//                          ^^^^^^^^ reference local 17
               SayHi(myWorld);
-//            ^^^^^ reference local 2
-//                  ^^^^^^^ reference local 0
+//            ^^^^^ reference local 18
+//                  ^^^^^^^ reference local 16
 
               string GetWorld() => "world";
-//                   ^^^^^^^^ definition local 1
+//                   ^^^^^^^^ definition local 17
 //                            documentation ```cs\nstring GetWorld()\n```
 
               void SayHi(string world)
-//                 ^^^^^ definition local 2
+//                 ^^^^^ definition local 18
 //                       documentation ```cs\nvoid SayHi(string world)\n```
-//                              ^^^^^ definition local 3
+//                              ^^^^^ definition local 19
 //                                    documentation ```cs\nstring world\n```
               {
                   Console.WriteLine($"Hello {world}!");
-//                                           ^^^^^ reference local 3
+//                                           ^^^^^ reference local 19
               }
           }
       }

--- a/snapshots/output-net6.0/syntax/Main/Operators.cs
+++ b/snapshots/output-net6.0/syntax/Main/Operators.cs
@@ -14,7 +14,7 @@
       {
           public static int operator +(PlusMinus a)
 //                                     ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#PlusMinus#
-//                                               ^ definition scip-dotnet nuget . . Main/Operators#PlusMinus#op_UnaryPlus().(a)
+//                                               ^ definition local 0
 //                                                 documentation ```cs\nPlusMinus a\n```
           {
               return 0;
@@ -22,10 +22,10 @@
 
           public static int operator +(PlusMinus a, PlusMinus b)
 //                                     ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#PlusMinus#
-//                                               ^ definition scip-dotnet nuget . . Main/Operators#PlusMinus#op_Addition().(a)
+//                                               ^ definition local 1
 //                                                 documentation ```cs\nPlusMinus a\n```
 //                                                  ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#PlusMinus#
-//                                                            ^ definition scip-dotnet nuget . . Main/Operators#PlusMinus#op_Addition().(b)
+//                                                            ^ definition local 2
 //                                                              documentation ```cs\nPlusMinus b\n```
           {
               return 0;
@@ -33,7 +33,7 @@
 
           public static int operator -(PlusMinus a)
 //                                     ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#PlusMinus#
-//                                               ^ definition scip-dotnet nuget . . Main/Operators#PlusMinus#op_UnaryNegation().(a)
+//                                               ^ definition local 3
 //                                                 documentation ```cs\nPlusMinus a\n```
           {
               return 0;
@@ -48,7 +48,7 @@
 //                       ^^^^^^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#Equals().
 //                              documentation ```cs\nprotected bool TrueFalse.Equals(TrueFalse other)\n```
 //                              ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
-//                                        ^^^^^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#Equals().(other)
+//                                        ^^^^^ definition local 4
 //                                              documentation ```cs\nTrueFalse other\n```
           {
               throw new NotImplementedException();
@@ -57,19 +57,19 @@
           public override bool Equals(object? obj)
 //                             ^^^^^^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#Equals(+1).
 //                                    documentation ```cs\npublic override bool TrueFalse.Equals(object? obj)\n```
-//                                            ^^^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#Equals(+1).(obj)
+//                                            ^^^ definition local 5
 //                                                documentation ```cs\nobject? obj\n```
           {
               if (ReferenceEquals(null, obj)) return false;
-//                                      ^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#Equals(+1).(obj)
+//                                      ^^^ reference local 5
               if (ReferenceEquals(this, obj)) return true;
-//                                      ^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#Equals(+1).(obj)
+//                                      ^^^ reference local 5
               if (obj.GetType() != this.GetType()) return false;
-//                ^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#Equals(+1).(obj)
+//                ^^^ reference local 5
               return Equals((TrueFalse)obj);
 //                   ^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#Equals().
 //                           ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
-//                                     ^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#Equals(+1).(obj)
+//                                     ^^^ reference local 5
           }
 
           public override int GetHashCode()
@@ -81,7 +81,7 @@
 
           public static bool operator true(TrueFalse a)
 //                                         ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
-//                                                   ^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#op_True().(a)
+//                                                   ^ definition local 6
 //                                                     documentation ```cs\nTrueFalse a\n```
           {
               return true;
@@ -89,7 +89,7 @@
 
           public static bool operator false(TrueFalse a)
 //                                          ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
-//                                                    ^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#op_False().(a)
+//                                                    ^ definition local 7
 //                                                      documentation ```cs\nTrueFalse a\n```
           {
               return false;
@@ -97,10 +97,10 @@
 
           public static bool operator !=(TrueFalse a, TrueFalse b)
 //                                       ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
-//                                                 ^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#op_Inequality().(a)
+//                                                 ^ definition local 8
 //                                                   documentation ```cs\nTrueFalse a\n```
 //                                                    ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
-//                                                              ^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#op_Inequality().(b)
+//                                                              ^ definition local 9
 //                                                                documentation ```cs\nTrueFalse b\n```
           {
               return true;
@@ -108,10 +108,10 @@
 
           public static bool operator ==(TrueFalse a, TrueFalse b)
 //                                       ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
-//                                                 ^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#op_Equality().(a)
+//                                                 ^ definition local 10
 //                                                   documentation ```cs\nTrueFalse a\n```
 //                                                    ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
-//                                                              ^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#op_Equality().(b)
+//                                                              ^ definition local 11
 //                                                                documentation ```cs\nTrueFalse b\n```
           {
               return true;

--- a/snapshots/output-net6.0/syntax/Main/QuerySyntax.cs
+++ b/snapshots/output-net6.0/syntax/Main/QuerySyntax.cs
@@ -148,60 +148,60 @@
 //         ^^^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#JoinInto().
 //                  documentation ```cs\nprivate void QuerySyntax.JoinInto(List<Student> students1, List<Student> students2)\n```
 //                       ^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#Student#
-//                                ^^^^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#JoinInto().(students1)
+//                                ^^^^^^^^^ definition local 22
 //                                          documentation ```cs\nList<Student> students1\n```
 //                                                ^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#Student#
-//                                                         ^^^^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#JoinInto().(students2)
+//                                                         ^^^^^^^^^ definition local 23
 //                                                                   documentation ```cs\nList<Student> students2\n```
       {
           var innerGroupJoinQuery =
-//            ^^^^^^^^^^^^^^^^^^^ definition local 22
+//            ^^^^^^^^^^^^^^^^^^^ definition local 24
 //                                documentation ```cs\n? innerGroupJoinQuery\n```
               from student1 in students1
-//                 ^^^^^^^^ definition local 23
+//                 ^^^^^^^^ definition local 25
 //                          documentation ```cs\n? student1\n```
-//                             ^^^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#JoinInto().(students1)
+//                             ^^^^^^^^^ reference local 22
               join student2 in students2 on student1.ID equals student2.ID into studentGroup
-//                 ^^^^^^^^ definition local 24
+//                 ^^^^^^^^ definition local 26
 //                          documentation ```cs\n? student2\n```
-//                             ^^^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#JoinInto().(students2)
-//                                          ^^^^^^^^ reference local 23
-//                                                             ^^^^^^^^ reference local 24
-//                                                                              ^^^^^^^^^^^^ definition local 25
+//                             ^^^^^^^^^ reference local 23
+//                                          ^^^^^^^^ reference local 25
+//                                                             ^^^^^^^^ reference local 26
+//                                                                              ^^^^^^^^^^^^ definition local 27
 //                                                                                           documentation ```cs\n? studentGroup\n```
               select new { Student = student1.First, Students = studentGroup };
-//                         ^^^^^^^ reference local 27
-//                                   ^^^^^^^^ reference local 23
-//                                                   ^^^^^^^^ reference local 28
-//                                                              ^^^^^^^^^^^^ reference local 25
+//                         ^^^^^^^ reference local 29
+//                                   ^^^^^^^^ reference local 25
+//                                                   ^^^^^^^^ reference local 30
+//                                                              ^^^^^^^^^^^^ reference local 27
       }
 
       void Continuation(List<Student> students)
 //         ^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#Continuation().
 //                      documentation ```cs\nprivate void QuerySyntax.Continuation(List<Student> students)\n```
 //                           ^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#Student#
-//                                    ^^^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#Continuation().(students)
+//                                    ^^^^^^^^ definition local 31
 //                                             documentation ```cs\nList<Student> students\n```
       {
           var sortedGroups =
-//            ^^^^^^^^^^^^ definition local 29
+//            ^^^^^^^^^^^^ definition local 32
 //                         documentation ```cs\n? sortedGroups\n```
               from student in students
-//                 ^^^^^^^ definition local 30
+//                 ^^^^^^^ definition local 33
 //                         documentation ```cs\n? student\n```
-//                            ^^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#Continuation().(students)
+//                            ^^^^^^^^ reference local 31
               orderby student.Last, student.First
-//                    ^^^^^^^ reference local 30
-//                                  ^^^^^^^ reference local 30
+//                    ^^^^^^^ reference local 33
+//                                  ^^^^^^^ reference local 33
               group student by student.Last[0] into newGroup
-//                  ^^^^^^^ reference local 30
-//                             ^^^^^^^ reference local 30
-//                                                  ^^^^^^^^ definition local 31
+//                  ^^^^^^^ reference local 33
+//                             ^^^^^^^ reference local 33
+//                                                  ^^^^^^^^ definition local 34
 //                                                           documentation ```cs\n? newGroup\n```
               orderby newGroup.Key
-//                    ^^^^^^^^ reference local 31
+//                    ^^^^^^^^ reference local 34
               select newGroup;
-//                   ^^^^^^^^ reference local 31
+//                   ^^^^^^^^ reference local 34
       }
 
       private class Student

--- a/snapshots/output-net6.0/syntax/Main/Records.cs
+++ b/snapshots/output-net6.0/syntax/Main/Records.cs
@@ -42,9 +42,9 @@
 //                  ^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Records#TypeParameterConstraint#
 //                                          documentation ```cs\nrecord TypeParameterConstraint<T> where T : struct\n```
 //                                          relationship implementation scip-dotnet nuget Main 0.0.0.0 System/IEquatable#
-//                                          ^ definition scip-dotnet nuget . . Main/Records#TypeParameterConstraint#[T]
+//                                          ^ definition local 0
 //                                            documentation ```cs\nT\n```
-//                                                   ^ reference scip-dotnet nuget . . Main/Records#TypeParameterConstraint#[T]
+//                                                   ^ reference local 0
       {
       }
 
@@ -67,9 +67,9 @@
 //                  relationship implementation scip-dotnet nuget . . Main/Records#I1#
 //                  relationship implementation scip-dotnet nuget . . Main/Records#I2#
 //                  relationship implementation scip-dotnet nuget Main 0.0.0.0 System/IEquatable#
-//                         ^^^^^^^^^ definition scip-dotnet nuget . . Main/Records#Person#`.ctor`().(FirstName)
+//                         ^^^^^^^^^ definition local 1
 //                                   documentation ```cs\nstring FirstName\n```
-//                                           ^^^^^^^^ definition scip-dotnet nuget . . Main/Records#Person#`.ctor`().(LastName)
+//                                           ^^^^^^^^ definition local 2
 //                                                    documentation ```cs\nstring LastName\n```
 //                                                       ^^ reference scip-dotnet nuget . . Main/Records#I1#
 //                                                           ^^ reference scip-dotnet nuget . . Main/Records#I2#
@@ -77,10 +77,10 @@
           public Person(string FirstName) : this(FirstName, FirstName)
 //               ^^^^^^ definition scip-dotnet nuget . . Main/Records#Person#`.ctor`(+1).
 //                      documentation ```cs\npublic Person.Person(string FirstName)\n```
-//                             ^^^^^^^^^ definition scip-dotnet nuget . . Main/Records#Person#`.ctor`(+1).(FirstName)
+//                             ^^^^^^^^^ definition local 3
 //                                       documentation ```cs\nstring FirstName\n```
-//                                               ^^^^^^^^^ reference scip-dotnet nuget . . Main/Records#Person#`.ctor`(+1).(FirstName)
-//                                                          ^^^^^^^^^ reference scip-dotnet nuget . . Main/Records#Person#`.ctor`(+1).(FirstName)
+//                                               ^^^^^^^^^ reference local 3
+//                                                          ^^^^^^^^^ reference local 3
           {
           }
       };
@@ -93,15 +93,15 @@
 //                   relationship implementation scip-dotnet nuget . . Main/Records#I1#
 //                   relationship implementation scip-dotnet nuget . . Main/Records#I2#
 //                   relationship implementation scip-dotnet nuget Main 0.0.0.0 System/IEquatable#
-//                          ^^^^^^^^^ definition scip-dotnet nuget . . Main/Records#Teacher#`.ctor`().(FirstName)
+//                          ^^^^^^^^^ definition local 4
 //                                    documentation ```cs\nstring FirstName\n```
-//                                            ^^^^^^^^ definition scip-dotnet nuget . . Main/Records#Teacher#`.ctor`().(LastName)
+//                                            ^^^^^^^^ definition local 5
 //                                                     documentation ```cs\nstring LastName\n```
-//                                                             ^^^^^^^ definition scip-dotnet nuget . . Main/Records#Teacher#`.ctor`().(Subject)
+//                                                             ^^^^^^^ definition local 6
 //                                                                     documentation ```cs\nstring Subject\n```
 //                                                                        ^^^^^^ reference scip-dotnet nuget . . Main/Records#Person#
-//                                                                               ^^^^^^^^^ reference scip-dotnet nuget . . Main/Records#Teacher#`.ctor`().(FirstName)
-//                                                                                          ^^^^^^^^ reference scip-dotnet nuget . . Main/Records#Teacher#`.ctor`().(LastName)
+//                                                                               ^^^^^^^^^ reference local 4
+//                                                                                          ^^^^^^^^ reference local 5
 //                                                                                                     ^^ reference scip-dotnet nuget . . Main/Records#I1#
 //                                                                                                         ^^ reference scip-dotnet nuget . . Main/Records#I2#
 
@@ -110,11 +110,11 @@
 //                      documentation ```cs\nprivate void Records.UsingRecords()\n```
       {
           var person = new Person("a", "b");
-//            ^^^^^^ definition local 0
+//            ^^^^^^ definition local 7
 //                   documentation ```cs\nPerson? person\n```
 //                         ^^^^^^ reference scip-dotnet nuget . . Main/Records#Person#
           var teacher = new Teacher("a", "b", "c");
-//            ^^^^^^^ definition local 1
+//            ^^^^^^^ definition local 8
 //                    documentation ```cs\nTeacher? teacher\n```
 //                          ^^^^^^^ reference scip-dotnet nuget . . Main/Records#Teacher#
       }
@@ -123,7 +123,7 @@
 //           ^^ definition scip-dotnet nuget . . Main/Records#I3#
 //              documentation ```cs\nrecord I3<T>\n```
 //              relationship implementation scip-dotnet nuget Main 0.0.0.0 System/IEquatable#
-//              ^ definition scip-dotnet nuget . . Main/Records#I3#[T]
+//              ^ definition local 9
 //                documentation ```cs\nT\n```
 
       record Teacher2() : I3<Person>(), I1;

--- a/snapshots/output-net6.0/syntax/Main/Statements.cs
+++ b/snapshots/output-net6.0/syntax/Main/Statements.cs
@@ -57,9 +57,9 @@
 //           ^^^^^^^^ definition scip-dotnet nuget . . Main/Statements#Inferred#
 //                    documentation ```cs\nrecord Inferred\n```
 //                    relationship implementation scip-dotnet nuget Main 0.0.0.0 System/IEquatable#
-//                        ^^ definition scip-dotnet nuget . . Main/Statements#Inferred#`.ctor`().(F1)
+//                        ^^ definition local 5
 //                           documentation ```cs\nint F1\n```
-//                                ^^ definition scip-dotnet nuget . . Main/Statements#Inferred#`.ctor`().(F2)
+//                                ^^ definition local 6
 //                                   documentation ```cs\nint F2\n```
 
       void InferredTuples()
@@ -67,17 +67,17 @@
 //                        documentation ```cs\nprivate void Statements.InferredTuples()\n```
       {
           var list = new List<Inferred>();
-//            ^^^^ definition local 5
+//            ^^^^ definition local 7
 //                 documentation ```cs\nList<Inferred>? list\n```
 //                            ^^^^^^^^ reference scip-dotnet nuget . . Main/Statements#Inferred#
           var result = list.Select(c => (c.F1, c.F2)).Where(t => t.F2 == 1);
-//            ^^^^^^ definition local 6
+//            ^^^^^^ definition local 8
 //                   documentation ```cs\n? result\n```
-//                     ^^^^ reference local 5
-//                                 ^ definition local 8
+//                     ^^^^ reference local 7
+//                                 ^ definition local 9
 //                                   documentation ```cs\n c\n```
-//                                       ^ reference local 8
-//                                             ^ reference local 8
+//                                       ^ reference local 9
+//                                             ^ reference local 9
 //                                                          ^ definition local 10
 //                                                            documentation ```cs\n t\n```
 //                                                               ^ reference local 10
@@ -181,19 +181,19 @@
       void ForeachVariable(List<(int, int)> names)
 //         ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Statements#ForeachVariable().
 //                         documentation ```cs\nprivate void Statements.ForeachVariable(List<(int, int)> names)\n```
-//                                          ^^^^^ definition scip-dotnet nuget . . Main/Statements#ForeachVariable().(names)
+//                                          ^^^^^ definition local 22
 //                                                documentation ```cs\nList<(int, int)> names\n```
       {
           foreach ((int firstName, int lastName) in names)
-//                      ^^^^^^^^^ definition local 22
+//                      ^^^^^^^^^ definition local 23
 //                                documentation ```cs\nint firstName\n```
-//                                     ^^^^^^^^ definition local 23
+//                                     ^^^^^^^^ definition local 24
 //                                              documentation ```cs\nint lastName\n```
-//                                                  ^^^^^ reference scip-dotnet nuget . . Main/Statements#ForeachVariable().(names)
+//                                                  ^^^^^ reference local 22
           {
               Console.WriteLine($"FirstName:{firstName}, LastName:{lastName}");
-//                                           ^^^^^^^^^ reference local 22
-//                                                                 ^^^^^^^^ reference local 23
+//                                           ^^^^^^^^^ reference local 23
+//                                                                 ^^^^^^^^ reference local 24
           }
       }
   }

--- a/snapshots/output-net6.0/syntax/Main/Structs.cs
+++ b/snapshots/output-net6.0/syntax/Main/Structs.cs
@@ -19,12 +19,12 @@
           public BasicStruct(int field1)
 //               ^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Structs#BasicStruct#`.ctor`().
 //                           documentation ```cs\npublic BasicStruct.BasicStruct(int field1)\n```
-//                               ^^^^^^ definition scip-dotnet nuget . . Main/Structs#BasicStruct#`.ctor`().(field1)
+//                               ^^^^^^ definition local 0
 //                                      documentation ```cs\nint field1\n```
           {
               Property1 = field1;
 //            ^^^^^^^^^ reference scip-dotnet nuget . . Main/Structs#BasicStruct#Property1.
-//                        ^^^^^^ reference scip-dotnet nuget . . Main/Structs#BasicStruct#`.ctor`().(field1)
+//                        ^^^^^^ reference local 0
           }
       }
   }

--- a/snapshots/output-net6.0/syntax/VBMain/CaseInsensitive.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/CaseInsensitive.vb
@@ -6,10 +6,10 @@
           Public Sub DifferentCase(wEiRdCaSiNg As String)
 '                    ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/CaseInsensitive#DifferentCase().
 '                                  documentation ```vb\nPublic Sub CaseInsensitive.DifferentCase(wEiRdCaSiNg As String)\n```
-'                                  ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/CaseInsensitive#DifferentCase().(wEiRdCaSiNg)
+'                                  ^^^^^^^^^^^ definition local 0
 '                                              documentation ```vb\nwEiRdCaSiNg As String\n```
               Console.WriteLine(WeIrDcAsInG)
-'                               ^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/CaseInsensitive#DifferentCase().(wEiRdCaSiNg)
+'                               ^^^^^^^^^^^ reference local 0
           End Sub
       End Class
   End Namespace

--- a/snapshots/output-net6.0/syntax/VBMain/Classes.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Classes.vb
@@ -20,7 +20,7 @@
           Public Sub New(ByVal name As Integer)
 '                    ^^^ definition scip-dotnet nuget . . VBMain/Classes#`.ctor`().
 '                        documentation ```vb\nPublic Sub Classes.New(name As Integer)\n```
-'                              ^^^^ definition scip-dotnet nuget . . VBMain/Classes#`.ctor`().(name)
+'                              ^^^^ definition local 0
 '                                   documentation ```vb\nname As Integer\n```
               Me.Name = "name"
 '                ^^^^ reference scip-dotnet nuget . . VBMain/Classes#Name.
@@ -29,11 +29,11 @@
           Public Sub New(ByVal name As String)
 '                    ^^^ definition scip-dotnet nuget . . VBMain/Classes#`.ctor`(+1).
 '                        documentation ```vb\nPublic Sub Classes.New(name As String)\n```
-'                              ^^^^ definition scip-dotnet nuget . . VBMain/Classes#`.ctor`(+1).(name)
+'                              ^^^^ definition local 1
 '                                   documentation ```vb\nname As String\n```
               Me.Name = name
 '                ^^^^ reference scip-dotnet nuget . . VBMain/Classes#Name.
-'                       ^^^^ reference scip-dotnet nuget . . VBMain/Classes#`.ctor`(+1).(name)
+'                       ^^^^ reference local 1
           End Sub
 
           Protected Overrides Sub Finalize()
@@ -59,65 +59,65 @@
           Class TypeParameterClass(Of T)
 '               ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#TypeParameterClass#
 '                                  documentation ```vb\nClass TypeParameterClass(Of T)\n```
-'                                     ^ definition scip-dotnet nuget . . VBMain/Classes#TypeParameterClass#[T]
+'                                     ^ definition local 2
 '                                       documentation ```vb\nT\n```
           End Class
 
           Friend Class InternalMultipleTypeParametersClass(Of T1, T2)
 '                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#InternalMultipleTypeParametersClass#
 '                                                          documentation ```vb\nClass InternalMultipleTypeParametersClass(Of T1, T2)\n```
-'                                                             ^^ definition scip-dotnet nuget . . VBMain/Classes#InternalMultipleTypeParametersClass#[T1]
+'                                                             ^^ definition local 3
 '                                                                documentation ```vb\nT1\n```
-'                                                                 ^^ definition scip-dotnet nuget . . VBMain/Classes#InternalMultipleTypeParametersClass#[T2]
+'                                                                 ^^ definition local 4
 '                                                                    documentation ```vb\nT2\n```
           End Class
 
           Interface ICovariantContravariant(Of In T1, Out T2)
 '                   ^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#
 '                                           documentation ```vb\nInterface ICovariantContravariant(Of In T1, Out T2)\n```
-'                                                 ^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T1]
+'                                                 ^^ definition local 5
 '                                                    documentation ```vb\nIn T1\n```
-'                                                         ^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T2]
+'                                                         ^^ definition local 6
 '                                                            documentation ```vb\nOut T2\n```
               Sub Method1(ByVal t1 As T1)
 '                 ^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method1().
 '                         documentation ```vb\nSub ICovariantContravariant(Of In T1, Out T2).Method1(t1 As T1)\n```
-'                               ^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method1().(t1)
+'                               ^^ definition local 7
 '                                  documentation ```vb\nt1 As T1\n```
-'                                     ^^ reference scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T1]
+'                                     ^^ reference local 5
 
               Function Method2() As T2
 '                      ^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method2().
 '                              documentation ```vb\nFunction ICovariantContravariant(Of In T1, Out T2).Method2() As T2\n```
-'                                   ^^ reference scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T2]
+'                                   ^^ reference local 6
 
           End Interface
 
           Public Class StructConstraintClass(Of T As Structure)
 '                      ^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#StructConstraintClass#
 '                                            documentation ```vb\nClass StructConstraintClass(Of T As Structure)\n```
-'                                               ^ definition scip-dotnet nuget . . VBMain/Classes#StructConstraintClass#[T]
+'                                               ^ definition local 8
 '                                                 documentation ```vb\nT\n```
           End Class
 
           Public Class ClassConstraintClass(Of T As Class)
 '                      ^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ClassConstraintClass#
 '                                           documentation ```vb\nClass ClassConstraintClass(Of T As Class)\n```
-'                                              ^ definition scip-dotnet nuget . . VBMain/Classes#ClassConstraintClass#[T]
+'                                              ^ definition local 9
 '                                                documentation ```vb\nT\n```
           End Class
 
           Public Class NewConstraintClass(Of T As New)
 '                      ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#NewConstraintClass#
 '                                         documentation ```vb\nClass NewConstraintClass(Of T As New)\n```
-'                                            ^ definition scip-dotnet nuget . . VBMain/Classes#NewConstraintClass#[T]
+'                                            ^ definition local 10
 '                                              documentation ```vb\nT\n```
           End Class
 
           Public Class TypeParameterConstraintClass(Of T As SomeInterface)
 '                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#TypeParameterConstraintClass#
 '                                                   documentation ```vb\nClass TypeParameterConstraintClass(Of T As SomeInterface)\n```
-'                                                      ^ definition scip-dotnet nuget . . VBMain/Classes#TypeParameterConstraintClass#[T]
+'                                                      ^ definition local 11
 '                                                        documentation ```vb\nT\n```
 '                                                           ^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Classes#SomeInterface#
           End Class
@@ -125,11 +125,11 @@
           Private Class MultipleTypeParameterConstraintsClass(Of T1 As {SomeInterface, SomeInterface2, New}, T2 As SomeInterface2)
 '                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#MultipleTypeParameterConstraintsClass#
 '                                                             documentation ```vb\nClass MultipleTypeParameterConstraintsClass(Of T1 As {SomeInterface, SomeInterface2, New}, T2 As SomeInterface2)\n```
-'                                                                ^^ definition scip-dotnet nuget . . VBMain/Classes#MultipleTypeParameterConstraintsClass#[T1]
+'                                                                ^^ definition local 12
 '                                                                   documentation ```vb\nT1\n```
 '                                                                       ^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Classes#SomeInterface#
 '                                                                                      ^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Classes#SomeInterface2#
-'                                                                                                            ^^ definition scip-dotnet nuget . . VBMain/Classes#MultipleTypeParameterConstraintsClass#[T2]
+'                                                                                                            ^^ definition local 13
 '                                                                                                               documentation ```vb\nT2\n```
 '                                                                                                                  ^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Classes#SomeInterface2#
           End Class
@@ -144,18 +144,18 @@
               Default Public Property Item(ByVal index As Integer) As Boolean
 '                                     ^^^^ definition scip-dotnet nuget . . VBMain/Classes#IndexClass#Item.
 '                                          documentation ```vb\nPublic Default Property IndexClass.Item(index As Integer) As Boolean\n```
-'                                                ^^^^^ definition scip-dotnet nuget . . VBMain/Classes#IndexClass#Item.(index)
+'                                                ^^^^^ definition local 14
 '                                                      documentation ```vb\nindex As Integer\n```
                   Get
                       Return a
 '                            ^ reference scip-dotnet nuget . . VBMain/Classes#IndexClass#a.
                   End Get
                   Set(ByVal value As Boolean)
-'                           ^^^^^ definition scip-dotnet nuget . . VBMain/Classes#IndexClass#set_Item().(value)
+'                           ^^^^^ definition local 15
 '                                 documentation ```vb\nvalue As Boolean\n```
                       a = value
 '                     ^ reference scip-dotnet nuget . . VBMain/Classes#IndexClass#a.
-'                         ^^^^^ reference scip-dotnet nuget . . VBMain/Classes#IndexClass#set_Item().(value)
+'                         ^^^^^ reference local 15
                   End Set
               End Property
           End Class

--- a/snapshots/output-net6.0/syntax/VBMain/Events.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Events.vb
@@ -19,36 +19,36 @@
 '                                    documentation ```vb\nPublic Event Events.Event2 As EventHandler\n```
 
               AddHandler(ByVal value As EventHandler)
-'                              ^^^^^ definition scip-dotnet nuget . . VBMain/Events#add_Event2().(value)
+'                              ^^^^^ definition local 0
 '                                    documentation ```vb\nvalue As EventHandler\n```
                   EventHandlerList.Add(value)
 '                 ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Events#EventHandlerList.
-'                                      ^^^^^ reference scip-dotnet nuget . . VBMain/Events#add_Event2().(value)
+'                                      ^^^^^ reference local 0
               End AddHandler
 
               RemoveHandler(ByVal value As EventHandler)
-'                                 ^^^^^ definition scip-dotnet nuget . . VBMain/Events#remove_Event2().(value)
+'                                 ^^^^^ definition local 1
 '                                       documentation ```vb\nvalue As EventHandler\n```
                   EventHandlerList.Remove(value)
 '                 ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Events#EventHandlerList.
-'                                         ^^^^^ reference scip-dotnet nuget . . VBMain/Events#remove_Event2().(value)
+'                                         ^^^^^ reference local 1
               End RemoveHandler
 
               RaiseEvent(ByVal sender As Object, ByVal e As EventArgs)
-'                              ^^^^^^ definition scip-dotnet nuget . . VBMain/Events#raise_Event2().(sender)
+'                              ^^^^^^ definition local 2
 '                                     documentation ```vb\nsender As Object\n```
-'                                                      ^ definition scip-dotnet nuget . . VBMain/Events#raise_Event2().(e)
+'                                                      ^ definition local 3
 '                                                        documentation ```vb\ne As EventArgs\n```
                   For Each handler As EventHandler In EventHandlerList
-'                          ^^^^^^^ definition local 0
+'                          ^^^^^^^ definition local 4
 '                                  documentation ```vb\nhandler As EventHandler\n```
 '                                                     ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Events#EventHandlerList.
                       If handler IsNot Nothing Then
-'                        ^^^^^^^ reference local 0
+'                        ^^^^^^^ reference local 4
                           handler.BeginInvoke(sender, e, Nothing, Nothing)
-'                         ^^^^^^^ reference local 0
-'                                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Events#raise_Event2().(sender)
-'                                                     ^ reference scip-dotnet nuget . . VBMain/Events#raise_Event2().(e)
+'                         ^^^^^^^ reference local 4
+'                                             ^^^^^^ reference local 2
+'                                                     ^ reference local 3
                       End If
                   Next
               End RaiseEvent

--- a/snapshots/output-net6.0/syntax/VBMain/Expressions.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Expressions.vb
@@ -186,18 +186,18 @@
               Default Public Property Item(ByVal index As Integer) As Integer
 '                                     ^^^^ definition scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Item.
 '                                          documentation ```vb\nPublic Default Property IndexedClass.Item(index As Integer) As Integer\n```
-'                                                ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Item.(index)
+'                                                ^^^^^ definition local 9
 '                                                      documentation ```vb\nindex As Integer\n```
                   Get
                       Return [Property]
 '                            ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Property.
                   End Get
                   Set(ByVal value As Integer)
-'                           ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#IndexedClass#set_Item().(value)
+'                           ^^^^^ definition local 10
 '                                 documentation ```vb\nvalue As Integer\n```
                       [Property] = value
 '                     ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Property.
-'                                  ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#set_Item().(value)
+'                                  ^^^^^ reference local 10
                   End Set
               End Property
           End Structure
@@ -206,58 +206,58 @@
 '                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AssignmentToLeftValueTypes().
 '                                                documentation ```vb\nPrivate Sub Expressions.AssignmentToLeftValueTypes()\n```
               Dim E As (A As Integer, B As Integer) = (1, 2)
-'                 ^ definition local 9
+'                 ^ definition local 11
 '                   documentation ```vb\nE As (A As Integer, B As Integer)\n```
               Dim A = 1
-'                 ^ definition local 10
+'                 ^ definition local 12
 '                   documentation ```vb\nA As Integer\n```
               Dim C = New Struct With {
-'                 ^ definition local 11
+'                 ^ definition local 13
 '                   documentation ```vb\nC As Structure Struct\n```
 '                         ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Struct#
                   .[Property] = 42
 '                  ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Struct#Property.
               }
               C.[Property] = 1
-'             ^ reference local 11
+'             ^ reference local 13
 '               ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Struct#Property.
               Dim D = New IndexedClass()
-'                 ^ definition local 12
+'                 ^ definition local 14
 '                   documentation ```vb\nD As Structure IndexedClass\n```
 '                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#
               D(E.B) = 1
-'             ^ reference local 12
-'               ^ reference local 9
-'                 ^ reference local 14
+'             ^ reference local 14
+'               ^ reference local 11
+'                 ^ reference local 16
               Dim X = New IndexedClass With {
-'                 ^ definition local 15
+'                 ^ definition local 17
 '                   documentation ```vb\nX As Structure IndexedClass\n```
 '                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#
                   .[Property] = 1
 '                  ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Property.
               }
               E.A = 1
-'             ^ reference local 9
-'               ^ reference local 16
+'             ^ reference local 11
+'               ^ reference local 18
           End Sub
 
           Private Sub TernaryExpression()
 '                     ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#TernaryExpression().
 '                                       documentation ```vb\nPrivate Sub Expressions.TernaryExpression()\n```
               Dim X = True
-'                 ^ definition local 17
+'                 ^ definition local 19
 '                   documentation ```vb\nX As Boolean\n```
               Dim Y = If(X, "foo", "bar")
-'                 ^ definition local 18
+'                 ^ definition local 20
 '                   documentation ```vb\nY As Object\n```
-'                        ^ reference local 17
+'                        ^ reference local 19
               Dim Z As Object = True
-'                 ^ definition local 19
+'                 ^ definition local 21
 '                   documentation ```vb\nZ As Object\n```
               Dim T = If(TypeOf Z Is Boolean, 42, 41)
-'                 ^ definition local 20
+'                 ^ definition local 22
 '                   documentation ```vb\nT As Object\n```
-'                               ^ reference local 19
+'                               ^ reference local 21
           End Sub
 
           Class Cast
@@ -275,13 +275,13 @@
               Public Function Plus(ByVal other As Cast) As Cast
 '                             ^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Cast#Plus().
 '                                  documentation ```vb\nPublic Function Cast.Plus(other As Cast) As Cast\n```
-'                                        ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Cast#Plus().(other)
+'                                        ^^^^^ definition local 23
 '                                              documentation ```vb\nother As Cast\n```
 '                                                 ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
 '                                                          ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
                   Nested = other
 '                 ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Nested.
-'                          ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Plus().(other)
+'                          ^^^^^ reference local 23
                   Return Me
               End Function
 
@@ -295,66 +295,66 @@
 '                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#CastExpressions().
 '                                          documentation ```vb\nPrivate Function Expressions.CastExpressions() As Integer\n```
               Dim A As Object = New Cast()
-'                 ^ definition local 21
+'                 ^ definition local 24
 '                   documentation ```vb\nA As Object\n```
 '                                   ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
               Dim B As Object = New Cast()
-'                 ^ definition local 22
+'                 ^ definition local 25
 '                   documentation ```vb\nB As Object\n```
 '                                   ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
               Dim C As Cast = (CType(A, Cast)).Plus(CType(B, Cast))
-'                 ^ definition local 23
+'                 ^ definition local 26
 '                   documentation ```vb\nC As Class Cast\n```
 '                      ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
-'                                    ^ reference local 21
+'                                    ^ reference local 24
 '                                       ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
-'                                                         ^ reference local 22
+'                                                         ^ reference local 25
 '                                                            ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
               Dim D As Cast = CType(New Object() {A, B}(0), Cast)
-'                 ^ definition local 24
+'                 ^ definition local 27
 '                   documentation ```vb\nD As Class Cast\n```
 '                      ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
-'                                                 ^ reference local 21
-'                                                    ^ reference local 22
+'                                                 ^ reference local 24
+'                                                    ^ reference local 25
 '                                                           ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
               Dim E = CType((C.Nested.Nested2), Cast.Cast2)
-'                 ^ definition local 25
+'                 ^ definition local 28
 '                   documentation ```vb\nE As Class Cast2\n```
-'                            ^ reference local 23
+'                            ^ reference local 26
 '                              ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Nested.
 '                                     ^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Nested2.
 '                                               ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
 '                                                    ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Cast2#
               Dim F = CType((1), Int32)
-'                 ^ definition local 26
+'                 ^ definition local 29
 '                   documentation ```vb\nF As Int32\n```
               Dim G = CType((1), Int32)
-'                 ^ definition local 27
+'                 ^ definition local 30
 '                   documentation ```vb\nG As Int32\n```
               Dim H = CType(((1)), Int32)
-'                 ^ definition local 28
+'                 ^ definition local 31
 '                   documentation ```vb\nH As Int32\n```
               Return F + G + H
-'                    ^ reference local 26
-'                        ^ reference local 27
-'                            ^ reference local 28
+'                    ^ reference local 29
+'                        ^ reference local 30
+'                            ^ reference local 31
           End Function
 
           Private Function AnonymousObject() As Object
 '                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AnonymousObject().
 '                                          documentation ```vb\nPrivate Function Expressions.AnonymousObject() As Object\n```
               Dim X = New With {Key .Helper = ""}
-'                 ^ definition local 29
-'                   documentation ```vb\nX As AnonymousType <anonymous type: Key Helper As String>\n```
-'                                    ^^^^^^ reference local 31
-              Dim Y = New With {X}
 '                 ^ definition local 32
+'                   documentation ```vb\nX As AnonymousType <anonymous type: Key Helper As String>\n```
+'                                    ^^^^^^ reference local 34
+              Dim Y = New With {X}
+'                 ^ definition local 35
 '                   documentation ```vb\nY As AnonymousType <anonymous type: X As AnonymousType <anonymous type: Key Helper As String>>\n```
-'                               ^ reference local 29
+'                               ^ reference local 32
               Return Y.x.Helper
-'                    ^ reference local 32
-'                      ^ reference local 34
-'                        ^^^^^^ reference local 31
+'                    ^ reference local 35
+'                      ^ reference local 37
+'                        ^^^^^^ reference local 34
           End Function
 
           Class ObjectCreationClass
@@ -368,12 +368,12 @@
               Public Sub New(ByVal field As D)
 '                        ^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#`.ctor`().
 '                            documentation ```vb\nPublic Sub ObjectCreationClass.New(field As D)\n```
-'                                  ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#`.ctor`().(field)
+'                                  ^^^^^ definition local 38
 '                                        documentation ```vb\nfield As D\n```
 '                                           ^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#
                   Me.Field = field
 '                    ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#Field.
-'                            ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#`.ctor`().(field)
+'                            ^^^^^ reference local 38
               End Sub
 
               Public Class D
@@ -382,9 +382,9 @@
                   Public Sub New(ByVal a As Integer, ByVal b As String)
 '                            ^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#`.ctor`().
 '                                documentation ```vb\nPublic Sub D.New(a As Integer, b As String)\n```
-'                                      ^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#`.ctor`().(a)
+'                                      ^ definition local 39
 '                                        documentation ```vb\na As Integer\n```
-'                                                          ^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#`.ctor`().(b)
+'                                                          ^ definition local 40
 '                                                            documentation ```vb\nb As String\n```
                   End Sub
               End Class
@@ -394,23 +394,23 @@
 '                     ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreation().
 '                                    documentation ```vb\nPrivate Sub Expressions.ObjectCreation()\n```
               Dim A = New ObjectCreationClass.D(1, "hi")
-'                 ^ definition local 35
+'                 ^ definition local 41
 '                   documentation ```vb\nA As Class D\n```
 '                         ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#
 '                                             ^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#
               Dim B = New ObjectCreationClass(A) With {
-'                 ^ definition local 36
+'                 ^ definition local 42
 '                   documentation ```vb\nB As Class ObjectCreationClass\n```
 '                         ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#
-'                                             ^ reference local 35
+'                                             ^ reference local 41
                   .Field = A
 '                  ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#Field.
-'                          ^ reference local 35
+'                          ^ reference local 41
               }
               B = New ObjectCreationClass(A)
-'             ^ reference local 36
+'             ^ reference local 42
 '                     ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#
-'                                         ^ reference local 35
+'                                         ^ reference local 41
           End Sub
 
           Class NamedParametersClass
@@ -426,31 +426,31 @@
               Public Sub New(ByVal a As Integer, ByVal b As String)
 '                        ^^^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().
 '                            documentation ```vb\nPublic Sub NamedParametersClass.New(a As Integer, b As String)\n```
-'                                  ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(a)
+'                                  ^ definition local 43
 '                                    documentation ```vb\na As Integer\n```
-'                                                      ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(b)
+'                                                      ^ definition local 44
 '                                                        documentation ```vb\nb As String\n```
                   Me.A = a
 '                    ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#A.
-'                        ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(a)
+'                        ^ reference local 43
                   Me.B = b
 '                    ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#B.
-'                        ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(b)
+'                        ^ reference local 44
               End Sub
 
               Public Sub Update(ByVal a As Integer, ByVal b As String)
 '                        ^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().
 '                               documentation ```vb\nPublic Sub NamedParametersClass.Update(a As Integer, b As String)\n```
-'                                     ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(a)
+'                                     ^ definition local 45
 '                                       documentation ```vb\na As Integer\n```
-'                                                         ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(b)
+'                                                         ^ definition local 46
 '                                                           documentation ```vb\nb As String\n```
                   Me.A = a
 '                    ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#A.
-'                        ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(a)
+'                        ^ reference local 45
                   Me.B = b
 '                    ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#B.
-'                        ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(b)
+'                        ^ reference local 46
               End Sub
           End Class
 
@@ -459,32 +459,32 @@
 '                                          documentation ```vb\nPrivate Function Expressions.NamedParameters() As NamedParametersClass\n```
 '                                               ^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#
               Dim A = New NamedParametersClass(b:="hi", a:=1)
-'                 ^ definition local 37
+'                 ^ definition local 47
 '                   documentation ```vb\nA As Class NamedParametersClass\n```
 '                         ^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#
               A.Update(b:="foo", a:=42)
-'             ^ reference local 37
+'             ^ reference local 47
               Return A
-'                    ^ reference local 37
+'                    ^ reference local 47
           End Function
 
           Private Function AnonymousFunction() As Func(Of Integer, Integer)
 '                          ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AnonymousFunction().
 '                                            documentation ```vb\nPrivate Function Expressions.AnonymousFunction() As Func\n```
               Dim d = Function(ByVal __ As Integer, ByVal ___ As Integer) 42
-'                 ^ definition local 38
+'                 ^ definition local 48
 '                   documentation ```vb\nd As AnonymousType Function <generated method>(__ As Integer, ___ As Integer) As \n```
-'                                    ^^ definition local 40
+'                                    ^^ definition local 49
 '                                       documentation ```vb\n__ As Integer\n```
-'                                                         ^^^ definition local 41
+'                                                         ^^^ definition local 50
 '                                                             documentation ```vb\n___ As Integer\n```
               Return Function(ByVal a As Integer) a + d.Invoke(a, a)
-'                                   ^ definition local 43
+'                                   ^ definition local 51
 '                                     documentation ```vb\na As Integer\n```
-'                                                 ^ reference local 43
-'                                                     ^ reference local 38
-'                                                              ^ reference local 43
-'                                                                 ^ reference local 43
+'                                                 ^ reference local 51
+'                                                     ^ reference local 48
+'                                                              ^ reference local 51
+'                                                                 ^ reference local 51
           End Function
 
           Class Lambda
@@ -493,7 +493,7 @@
               Public Function func(ByVal x As Lambda) As String
 '                             ^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Lambda#func().
 '                                  documentation ```vb\nPublic Function Lambda.func(x As Lambda) As String\n```
-'                                        ^ definition scip-dotnet nuget . . VBMain/Expressions#Lambda#func().(x)
+'                                        ^ definition local 52
 '                                          documentation ```vb\nx As Lambda\n```
 '                                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
                   Return ""
@@ -504,30 +504,30 @@
 '                     ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#LambdaExpressions().
 '                                       documentation ```vb\nPrivate Sub Expressions.LambdaExpressions()\n```
               Dim a = Function(ByVal x As String) x & 1
-'                 ^ definition local 44
+'                 ^ definition local 53
 '                   documentation ```vb\na As AnonymousType Function <generated method>(x As String) As \n```
-'                                    ^ definition local 46
+'                                    ^ definition local 54
 '                                      documentation ```vb\nx As String\n```
-'                                                 ^ reference local 46
+'                                                 ^ reference local 54
               Dim b = Function(ByVal aa As Lambda, ByVal bb As Lambda) aa.func(bb)
-'                 ^ definition local 47
+'                 ^ definition local 55
 '                   documentation ```vb\nb As AnonymousType Function <generated method>(aa As Lambda, bb As Lambda) As \n```
-'                                    ^^ definition local 49
+'                                    ^^ definition local 56
 '                                       documentation ```vb\naa As Lambda\n```
 '                                          ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
-'                                                        ^^ definition local 50
+'                                                        ^^ definition local 57
 '                                                           documentation ```vb\nbb As Lambda\n```
 '                                                              ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
-'                                                                      ^^ reference local 49
+'                                                                      ^^ reference local 56
 '                                                                         ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#func().
-'                                                                              ^^ reference local 50
+'                                                                              ^^ reference local 57
               Dim c = Function(aaa As Lambda, __ As Lambda)
-'                 ^ definition local 51
+'                 ^ definition local 58
 '                   documentation ```vb\nc As AnonymousType Function <generated method>(aaa As Lambda, __ As Lambda) As \n```
-'                              ^^^ definition local 53
+'                              ^^^ definition local 59
 '                                  documentation ```vb\naaa As Lambda\n```
 '                                     ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
-'                                             ^^ definition local 54
+'                                             ^^ definition local 60
 '                                                documentation ```vb\n__ As Lambda\n```
 '                                                   ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
                           If True Then
@@ -540,7 +540,7 @@
 '                     ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#TupleExpression().
 '                                     documentation ```vb\nPrivate Sub Expressions.TupleExpression()\n```
               Dim A = (1, 2, "")
-'                 ^ definition local 55
+'                 ^ definition local 61
 '                   documentation ```vb\nA As (Integer, Integer, String)\n```
           End Sub
 
@@ -548,44 +548,44 @@
 '                     ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#ArrayCreation().
 '                                   documentation ```vb\nPrivate Sub Expressions.ArrayCreation()\n```
               Dim a = {
-'                 ^ definition local 56
+'                 ^ definition local 62
 '                   documentation ```vb\na As Object(*,*)\n```
               {1, 1},
               {2, 2},
               {3, 3}}
               Dim d = New Integer(2) {1, 2, 3}
-'                 ^ definition local 57
+'                 ^ definition local 63
 '                   documentation ```vb\nd As Integer()\n```
               Dim e = New Byte(,) {
-'                 ^ definition local 58
+'                 ^ definition local 64
 '                   documentation ```vb\ne As Byte(*,*)\n```
               {1, 2},
               {2, 3}}
               Dim f = New Integer(2, 1) {
-'                 ^ definition local 59
+'                 ^ definition local 65
 '                   documentation ```vb\nf As Integer(*,*)\n```
               {1, 1},
               {2, 2},
               {3, 3}}
 
               Dim numbers(4) As Integer
-'                 ^^^^^^^ definition local 60
+'                 ^^^^^^^ definition local 66
 '                         documentation ```vb\nnumbers As Integer()\n```
               Dim numbers2 = New Integer() {1, 2, 4, 8}
-'                 ^^^^^^^^ definition local 61
+'                 ^^^^^^^^ definition local 67
 '                          documentation ```vb\nnumbers2 As Integer()\n```
               ReDim Preserve numbers(15)
-'                            ^^^^^^^ reference local 60
+'                            ^^^^^^^ reference local 66
               ReDim numbers(15)
-'                   ^^^^^^^ reference local 60
+'                   ^^^^^^^ reference local 66
               Dim matrix(5, 5) As Double
-'                 ^^^^^^ definition local 62
+'                 ^^^^^^ definition local 68
 '                        documentation ```vb\nmatrix As Double(*,*)\n```
               Dim matrix2 = New Integer(,) {{1, 2, 3}, {2, 3, 4}, {3, 4, 5}, {4, 5, 6}}
-'                 ^^^^^^^ definition local 63
+'                 ^^^^^^^ definition local 69
 '                         documentation ```vb\nmatrix2 As Integer(*,*)\n```
               Dim sales()() As Double = New Double(11)() {}
-'                 ^^^^^ definition local 64
+'                 ^^^^^ definition local 70
 '                       documentation ```vb\nsales As Double()()\n```
           End Sub
 
@@ -593,16 +593,16 @@
 '                     ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#TypeOf().
 '                              documentation ```vb\nPrivate Sub Expressions.TypeOf()\n```
               Dim a = GetType(Integer)
-'                 ^ definition local 65
+'                 ^ definition local 71
 '                   documentation ```vb\na As Type\n```
               Dim b = GetType(List(Of String).Enumerator)
-'                 ^ definition local 66
+'                 ^ definition local 72
 '                   documentation ```vb\nb As Type\n```
               Dim c = GetType(Dictionary(Of,))
-'                 ^ definition local 67
+'                 ^ definition local 73
 '                   documentation ```vb\nc As Type\n```
               Dim d = GetType(Tuple(Of,,,))
-'                 ^ definition local 68
+'                 ^ definition local 74
 '                   documentation ```vb\nd As Type\n```
           End Sub
 
@@ -610,10 +610,10 @@
 '                     ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#SelectCase().
 '                                documentation ```vb\nPrivate Sub Expressions.SelectCase()\n```
               Dim Some = 42
-'                 ^^^^ definition local 69
+'                 ^^^^ definition local 75
 '                      documentation ```vb\nSome As Integer\n```
               Select Case Some
-'                         ^^^^ reference local 69
+'                         ^^^^ reference local 75
                   Case 1
                       Debug.WriteLine("One")
                   Case 2
@@ -627,7 +627,7 @@
 '                     ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Dictionary().
 '                                documentation ```vb\nPrivate Sub Expressions.Dictionary()\n```
               Dim A = New Dictionary(Of String, Integer) From {{1, "Test1"}, {2, "Test1"}}
-'                 ^ definition local 70
+'                 ^ definition local 76
 '                   documentation ```vb\nA As Dictionary\n```
           End Sub
 

--- a/snapshots/output-net6.0/syntax/VBMain/Fields.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Fields.vb
@@ -24,26 +24,26 @@
               Public Sub New(ByVal field2 As Long, ByVal field3 As Long, ByVal field4 As Tuple(Of Char, Integer?), ByVal field1 As Integer)
 '                        ^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().
 '                            documentation ```vb\nPublic Sub Fields1.New(field2 As Long, field3 As Long, field4 As Tuple, field1 As Integer)\n```
-'                                  ^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field2)
+'                                  ^^^^^^ definition local 0
 '                                         documentation ```vb\nfield2 As Long\n```
-'                                                        ^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field3)
+'                                                        ^^^^^^ definition local 1
 '                                                               documentation ```vb\nfield3 As Long\n```
-'                                                                              ^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field4)
+'                                                                              ^^^^^^ definition local 2
 '                                                                                     documentation ```vb\nfield4 As Tuple\n```
-'                                                                                                                        ^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field1)
+'                                                                                                                        ^^^^^^ definition local 3
 '                                                                                                                               documentation ```vb\nfield1 As Integer\n```
                   Property2 = field2
 '                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#Property2.
-'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field2)
+'                             ^^^^^^ reference local 0
                   Property3 = field3
 '                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#Property3.
-'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field3)
+'                             ^^^^^^ reference local 1
                   Property4 = field4
 '                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#Property4.
-'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field4)
+'                             ^^^^^^ reference local 2
                   Property1 = field1
 '                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#Property1.
-'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field1)
+'                             ^^^^^^ reference local 3
               End Sub
           End Class
       End Class

--- a/snapshots/output-net6.0/syntax/VBMain/GlobalAttributes.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/GlobalAttributes.vb
@@ -19,7 +19,7 @@
               Public Sub New(ByVal name As String)
 '                        ^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#AuthorAttribute#`.ctor`().
 '                            documentation ```vb\nPublic Sub AuthorAttribute.New(name As String)\n```
-'                                  ^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#AuthorAttribute#`.ctor`().(name)
+'                                  ^^^^ definition local 0
 '                                       documentation ```vb\nname As String\n```
               End Sub
           End Class
@@ -57,12 +57,12 @@
           Public Class InnerClass(Of T)
 '                      ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#InnerClass#
 '                                 documentation ```vb\nClass InnerClass(Of T)\n```
-'                                    ^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#InnerClass#[T]
+'                                    ^ definition local 1
 '                                      documentation ```vb\nT\n```
               Private Sub Method(Of T2)()
 '                         ^^^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#InnerClass#Method().
 '                                documentation ```vb\nPrivate Sub InnerClass(Of T).Method(Of T2)()\n```
-'                                   ^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#InnerClass#Method().[T2]
+'                                   ^^ definition local 2
 '                                      documentation ```vb\nT2\n```
               End Sub
           End Class

--- a/snapshots/output-net6.0/syntax/VBMain/Interfaces.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Interfaces.vb
@@ -50,12 +50,12 @@
               Sub Input(ByVal a As String)
 '                 ^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#Input().
 '                       documentation ```vb\nSub IMethods.Input(a As String)\n```
-'                             ^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#Input().(a)
+'                             ^ definition local 0
 '                               documentation ```vb\na As String\n```
               Function InputOutput(ByVal a As String) As Integer
 '                      ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#InputOutput().
 '                                  documentation ```vb\nFunction IMethods.InputOutput(a As String) As Integer\n```
-'                                        ^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#InputOutput().(a)
+'                                        ^ definition local 1
 '                                          documentation ```vb\na As String\n```
           End Interface
 
@@ -73,7 +73,7 @@
               Default Property Item(ByVal index As Integer) As Boolean
 '                              ^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IIndex#Item.
 '                                   documentation ```vb\nDefault Property IIndex.Item(index As Integer) As Boolean\n```
-'                                         ^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IIndex#Item.(index)
+'                                         ^^^^^ definition local 2
 '                                               documentation ```vb\nindex As Integer\n```
           End Interface
 

--- a/snapshots/output-net6.0/syntax/VBMain/Methods.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Methods.vb
@@ -9,94 +9,94 @@
           Private Function SingleParameter(ByVal b As Integer) As Integer
 '                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#SingleParameter().
 '                                          documentation ```vb\nPrivate Function Methods.SingleParameter(b As Integer) As Integer\n```
-'                                                ^ definition scip-dotnet nuget . . VBMain/Methods#SingleParameter().(b)
+'                                                ^ definition local 0
 '                                                  documentation ```vb\nb As Integer\n```
               Return b
-'                    ^ reference scip-dotnet nuget . . VBMain/Methods#SingleParameter().(b)
+'                    ^ reference local 0
           End Function
 
           Private Function TwoParameters(ByVal a As Integer, ByVal b As Integer) As Integer
 '                          ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#TwoParameters().
 '                                        documentation ```vb\nPrivate Function Methods.TwoParameters(a As Integer, b As Integer) As Integer\n```
-'                                              ^ definition scip-dotnet nuget . . VBMain/Methods#TwoParameters().(a)
+'                                              ^ definition local 1
 '                                                documentation ```vb\na As Integer\n```
-'                                                                  ^ definition scip-dotnet nuget . . VBMain/Methods#TwoParameters().(b)
+'                                                                  ^ definition local 2
 '                                                                    documentation ```vb\nb As Integer\n```
               Return a + b
-'                    ^ reference scip-dotnet nuget . . VBMain/Methods#TwoParameters().(a)
-'                        ^ reference scip-dotnet nuget . . VBMain/Methods#TwoParameters().(b)
+'                    ^ reference local 1
+'                        ^ reference local 2
           End Function
 
           Private Function Overload1(ByVal a As Integer) As Integer
 '                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#Overload1().
 '                                    documentation ```vb\nPrivate Function Methods.Overload1(a As Integer) As Integer\n```
-'                                          ^ definition scip-dotnet nuget . . VBMain/Methods#Overload1().(a)
+'                                          ^ definition local 3
 '                                            documentation ```vb\na As Integer\n```
               Return a
-'                    ^ reference scip-dotnet nuget . . VBMain/Methods#Overload1().(a)
+'                    ^ reference local 3
           End Function
 
           Private Function Overload1(ByVal a As Integer, ByVal b As Integer) As Integer
 '                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#Overload1(+1).
 '                                    documentation ```vb\nPrivate Function Methods.Overload1(a As Integer, b As Integer) As Integer\n```
-'                                          ^ definition scip-dotnet nuget . . VBMain/Methods#Overload1(+1).(a)
+'                                          ^ definition local 4
 '                                            documentation ```vb\na As Integer\n```
-'                                                              ^ definition scip-dotnet nuget . . VBMain/Methods#Overload1(+1).(b)
+'                                                              ^ definition local 5
 '                                                                documentation ```vb\nb As Integer\n```
               Return a + b
-'                    ^ reference scip-dotnet nuget . . VBMain/Methods#Overload1(+1).(a)
-'                        ^ reference scip-dotnet nuget . . VBMain/Methods#Overload1(+1).(b)
+'                    ^ reference local 4
+'                        ^ reference local 5
           End Function
 
           Private Function Generic(Of T)(ByVal param As T) As T
 '                          ^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#Generic().
 '                                  documentation ```vb\nPrivate Function Methods.Generic(Of T)(param As T) As T\n```
-'                                     ^ definition scip-dotnet nuget . . VBMain/Methods#Generic().[T]
+'                                     ^ definition local 6
 '                                       documentation ```vb\nT\n```
-'                                              ^^^^^ definition scip-dotnet nuget . . VBMain/Methods#Generic().(param)
+'                                              ^^^^^ definition local 7
 '                                                    documentation ```vb\nparam As T\n```
-'                                                       ^ reference scip-dotnet nuget . . VBMain/Methods#Generic().[T]
-'                                                             ^ reference scip-dotnet nuget . . VBMain/Methods#Generic().[T]
+'                                                       ^ reference local 6
+'                                                             ^ reference local 6
               Return param
-'                    ^^^^^ reference scip-dotnet nuget . . VBMain/Methods#Generic().(param)
+'                    ^^^^^ reference local 7
           End Function
 
           Private Function GenericConstraint(Of T As New)(ByVal param As T) As T
 '                          ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#GenericConstraint().
 '                                            documentation ```vb\nPrivate Function Methods.GenericConstraint(Of T As New)(param As T) As T\n```
-'                                               ^ definition scip-dotnet nuget . . VBMain/Methods#GenericConstraint().[T]
+'                                               ^ definition local 8
 '                                                 documentation ```vb\nT\n```
-'                                                               ^^^^^ definition scip-dotnet nuget . . VBMain/Methods#GenericConstraint().(param)
+'                                                               ^^^^^ definition local 9
 '                                                                     documentation ```vb\nparam As T\n```
-'                                                                        ^ reference scip-dotnet nuget . . VBMain/Methods#GenericConstraint().[T]
-'                                                                              ^ reference scip-dotnet nuget . . VBMain/Methods#GenericConstraint().[T]
+'                                                                        ^ reference local 8
+'                                                                              ^ reference local 8
               Return param
-'                    ^^^^^ reference scip-dotnet nuget . . VBMain/Methods#GenericConstraint().(param)
+'                    ^^^^^ reference local 9
           End Function
 
           Private Sub DefaultParameter(ByVal Optional a As Integer = 5)
 '                     ^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameter().
 '                                      documentation ```vb\nPrivate Sub Methods.DefaultParameter([a As Integer = 5])\n```
-'                                                     ^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameter().(a)
+'                                                     ^ definition local 10
 '                                                       documentation ```vb\n[a As Integer = 5]\n```
           End Sub
 
           Private Function DefaultParameterOverload(ByVal Optional a As Integer = 5) As Integer
 '                          ^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload().
 '                                                   documentation ```vb\nPrivate Function Methods.DefaultParameterOverload([a As Integer = 5]) As Integer\n```
-'                                                                  ^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload().(a)
+'                                                                  ^ definition local 11
 '                                                                    documentation ```vb\n[a As Integer = 5]\n```
               Return DefaultParameterOverload(a, a)
-'                                             ^ reference scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload().(a)
-'                                                ^ reference scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload().(a)
+'                                             ^ reference local 11
+'                                                ^ reference local 11
           End Function
 
           Private Function DefaultParameterOverload(ByVal a As Integer, ByVal b As Integer) As Integer
 '                          ^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload(+1).
 '                                                   documentation ```vb\nPrivate Function Methods.DefaultParameterOverload(a As Integer, b As Integer) As Integer\n```
-'                                                         ^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload(+1).(a)
+'                                                         ^ definition local 12
 '                                                           documentation ```vb\na As Integer\n```
-'                                                                             ^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload(+1).(b)
+'                                                                             ^ definition local 13
 '                                                                               documentation ```vb\nb As Integer\n```
               Return DefaultParameterOverload()
           End Function
@@ -146,10 +146,10 @@
               Public Function Method(ByVal parameter As Integer) As Integer
 '                             ^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#Method().
 '                                    documentation ```vb\nPublic Function InheritedOverloads2.Method(parameter As Integer) As Integer\n```
-'                                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#Method().(parameter)
+'                                          ^^^^^^^^^ definition local 14
 '                                                    documentation ```vb\nparameter As Integer\n```
                   Return parameter
-'                        ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#Method().(parameter)
+'                        ^^^^^^^^^ reference local 14
               End Function
           End Class
 
@@ -164,10 +164,10 @@
               Public Function Method(ByVal parameter As String) As String
 '                             ^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#Method().
 '                                    documentation ```vb\nPublic Function InheritedOverloads3.Method(parameter As String) As String\n```
-'                                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#Method().(parameter)
+'                                          ^^^^^^^^^ definition local 15
 '                                                    documentation ```vb\nparameter As String\n```
                   Return parameter
-'                        ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#Method().(parameter)
+'                        ^^^^^^^^^ reference local 15
               End Function
           End Class
 
@@ -175,38 +175,38 @@
 '                           ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads().
 '                                              documentation ```vb\nPublic Shared Sub Methods.InheritedOverloads()\n```
               Dim a As InheritedOverloads1 = New InheritedOverloads1
-'                 ^ definition local 0
+'                 ^ definition local 16
 '                   documentation ```vb\na As Class InheritedOverloads1\n```
 '                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
 '                                                ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
               a.Method()
-'             ^ reference local 0
+'             ^ reference local 16
 '               ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#Method().
               Dim b As InheritedOverloads2 = New InheritedOverloads2
-'                 ^ definition local 1
+'                 ^ definition local 17
 '                   documentation ```vb\nb As Class InheritedOverloads2\n```
 '                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
 '                                                ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
               DirectCast(b, InheritedOverloads1).Method()
-'                        ^ reference local 1
+'                        ^ reference local 17
 '                           ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
 '                                                ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#Method().
               b.Method(42)
-'             ^ reference local 1
+'             ^ reference local 17
               Dim c As InheritedOverloads3 = New InheritedOverloads3
-'                 ^ definition local 2
+'                 ^ definition local 18
 '                   documentation ```vb\nc As Class InheritedOverloads3\n```
 '                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#
 '                                                ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#
               DirectCast(c, InheritedOverloads1).Method()
-'                        ^ reference local 2
+'                        ^ reference local 18
 '                           ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
 '                                                ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#Method().
               DirectCast(c, InheritedOverloads2).Method(42)
-'                        ^ reference local 2
+'                        ^ reference local 18
 '                           ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
               c.Method("42")
-'             ^ reference local 2
+'             ^ reference local 18
           End Sub
       End Class
   End Namespace

--- a/snapshots/output-net6.0/syntax/VBMain/Modules.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Modules.vb
@@ -9,16 +9,16 @@
           Private Function [Function](ByVal b As Integer) As Integer
 '                          ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Modules#Function().
 '                                     documentation ```vb\nPrivate Function Modules.Function(b As Integer) As Integer\n```
-'                                           ^ definition scip-dotnet nuget . . VBMain/Modules#Function().(b)
+'                                           ^ definition local 0
 '                                             documentation ```vb\nb As Integer\n```
               Return b
-'                    ^ reference scip-dotnet nuget . . VBMain/Modules#Function().(b)
+'                    ^ reference local 0
           End Function
 
           Private Sub [Sub](ByVal Optional a As Integer = 5)
 '                     ^^^^^ definition scip-dotnet nuget . . VBMain/Modules#Sub().
 '                           documentation ```vb\nPrivate Sub Modules.Sub([a As Integer = 5])\n```
-'                                          ^ definition scip-dotnet nuget . . VBMain/Modules#Sub().(a)
+'                                          ^ definition local 1
 '                                            documentation ```vb\n[a As Integer = 5]\n```
           End Sub
 

--- a/snapshots/output-net6.0/syntax/VBMain/Operators.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Operators.vb
@@ -10,24 +10,24 @@
 '                      ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#
 '                                documentation ```vb\nClass PlusMinus\n```
               Public Shared Operator +(A As PlusMinus)
-'                                      ^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#op_UnaryPlus().(A)
+'                                      ^ definition local 0
 '                                        documentation ```vb\nA As PlusMinus\n```
 '                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#PlusMinus#
                   Return 0
               End Operator
 
               Public Shared Operator +(A As PlusMinus, B As PlusMinus)
-'                                      ^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#op_Addition().(A)
+'                                      ^ definition local 1
 '                                        documentation ```vb\nA As PlusMinus\n```
 '                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#PlusMinus#
-'                                                      ^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#op_Addition().(B)
+'                                                      ^ definition local 2
 '                                                        documentation ```vb\nB As PlusMinus\n```
 '                                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#PlusMinus#
                   Return 0
               End Operator
 
               Public Shared Operator -(A As PlusMinus)
-'                                      ^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#op_UnaryNegation().(A)
+'                                      ^ definition local 3
 '                                        documentation ```vb\nA As PlusMinus\n```
 '                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#PlusMinus#
                   Return 0
@@ -38,34 +38,34 @@
 '                      ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#
 '                                documentation ```vb\nClass TrueFalse\n```
               Public Shared Operator IsTrue(A As TrueFalse) As Boolean
-'                                           ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_True().(A)
+'                                           ^ definition local 4
 '                                             documentation ```vb\nA As TrueFalse\n```
 '                                                ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
                   Return True
               End Operator
 
               Public Shared Operator IsFalse(A As TrueFalse) As Boolean
-'                                            ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_False().(A)
+'                                            ^ definition local 5
 '                                              documentation ```vb\nA As TrueFalse\n```
 '                                                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
                   Return False
               End Operator
 
               Public Shared Operator =(A As TrueFalse, B As TrueFalse) As Boolean
-'                                      ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_Equality().(A)
+'                                      ^ definition local 6
 '                                        documentation ```vb\nA As TrueFalse\n```
 '                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
-'                                                      ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_Equality().(B)
+'                                                      ^ definition local 7
 '                                                        documentation ```vb\nB As TrueFalse\n```
 '                                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
                   Return True
               End Operator
 
               Public Shared Operator <>(A As TrueFalse, B As TrueFalse) As Boolean
-'                                       ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_Inequality().(A)
+'                                       ^ definition local 8
 '                                         documentation ```vb\nA As TrueFalse\n```
 '                                            ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
-'                                                       ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_Inequality().(B)
+'                                                       ^ definition local 9
 '                                                         documentation ```vb\nB As TrueFalse\n```
 '                                                            ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
                   Return True
@@ -74,16 +74,16 @@
               Public Overrides Function Equals(obj As Object) As Boolean
 '                                       ^^^^^^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().
 '                                              documentation ```vb\nPublic Overrides Function TrueFalse.Equals(obj As Object) As Boolean\n```
-'                                              ^^^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+'                                              ^^^ definition local 10
 '                                                  documentation ```vb\nobj As Object\n```
                   If ReferenceEquals(Nothing, obj) Then Return False
-'                                             ^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+'                                             ^^^ reference local 10
                   If ReferenceEquals(Me, obj) Then Return True
-'                                        ^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+'                                        ^^^ reference local 10
                   If obj.GetType() <> Me.GetType() Then Return False
-'                    ^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+'                    ^^^ reference local 10
                   Return Equals(CType(obj, TrueFalse))
-'                                     ^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+'                                     ^^^ reference local 10
 '                                          ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
               End Function
 

--- a/snapshots/output-net6.0/syntax/VBMain/Program.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Program.vb
@@ -4,7 +4,7 @@
       Sub Main(args As String())
 '         ^^^^ definition scip-dotnet nuget . . VBMain/Program#Main().
 '              documentation ```vb\nPublic Sub Program.Main(args As String())\n```
-'              ^^^^ definition scip-dotnet nuget . . VBMain/Program#Main().(args)
+'              ^^^^ definition local 0
 '                   documentation ```vb\nargs As String()\n```
 
           Console.WriteLine("Hello, World!")

--- a/snapshots/output-net6.0/syntax/VBMain/Properties.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Properties.vb
@@ -14,7 +14,7 @@
 '                                    ^^^^^ definition scip-dotnet nuget . . VBMain/Properties#Set.
 '                                          documentation ```vb\nPrivate WriteOnly Property Properties.Set As Char\n```
               Set(ByVal value As Char)
-'                       ^^^^^ definition scip-dotnet nuget . . VBMain/Properties#set_Set().(value)
+'                       ^^^^^ definition local 0
 '                             documentation ```vb\nvalue As Char\n```
                   Throw New NotImplementedException()
               End Set

--- a/snapshots/output-net6.0/syntax/VBMain/QuerySyntax.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/QuerySyntax.vb
@@ -135,22 +135,22 @@
           Private Sub Into(Students As List(Of Student))
 '                     ^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Into().
 '                          documentation ```vb\nPrivate Sub QuerySyntax.Into(Students As List)\n```
-'                          ^^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Into().(Students)
+'                          ^^^^^^^^ definition local 23
 '                                   documentation ```vb\nStudents As List\n```
 '                                              ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Student#
               Dim sortedGroups = From student In Students Order By student.Last, student.First Group student By student.Last Into newGroup = Group Order By newGroup
-'                 ^^^^^^^^^^^^ definition local 23
+'                 ^^^^^^^^^^^^ definition local 24
 '                              documentation ```vb\nsortedGroups As \n```
-'                                     ^^^^^^^ definition local 24
+'                                     ^^^^^^^ definition local 25
 '                                             documentation ```vb\nstudent As \n```
-'                                                ^^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Into().(Students)
-'                                                                  ^^^^^^^ reference local 24
-'                                                                                ^^^^^^^ reference local 24
-'                                                                                                    ^^^^^^^ reference local 24
-'                                                                                                               ^^^^^^^ reference local 24
-'                                                                                                                                 ^^^^^^^^ definition local 25
+'                                                ^^^^^^^^ reference local 23
+'                                                                  ^^^^^^^ reference local 25
+'                                                                                ^^^^^^^ reference local 25
+'                                                                                                    ^^^^^^^ reference local 25
+'                                                                                                               ^^^^^^^ reference local 25
+'                                                                                                                                 ^^^^^^^^ definition local 26
 '                                                                                                                                          documentation ```vb\nnewGroup As \n```
-'                                                                                                                                                           ^^^^^^^^ reference local 25
+'                                                                                                                                                           ^^^^^^^^ reference local 26
           End Sub
 
           Private Class Student

--- a/snapshots/output-net6.0/syntax/VBMain/Statements.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Statements.vb
@@ -53,26 +53,26 @@
 '                 ^^^^^^ definition local 3
 '                        documentation ```vb\nResult As \n```
 '                          ^^^^ reference local 2
-'                                               ^ definition local 5
+'                                               ^ definition local 4
 '                                                 documentation ```vb\nc As Object\n```
-'                                                   ^ reference local 5
-'                                                         ^ reference local 5
-'                                                                               ^ definition local 7
+'                                                   ^ reference local 4
+'                                                         ^ reference local 4
+'                                                                               ^ definition local 5
 '                                                                                 documentation ```vb\nt As Object\n```
-'                                                                                  ^ reference local 7
+'                                                                                  ^ reference local 5
           End Sub
 
           Private Function MultipleInitializers() As Integer
 '                          ^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#MultipleInitializers().
 '                                               documentation ```vb\nPrivate Function Statements.MultipleInitializers() As Integer\n```
               Dim a As Integer = 1, b As Integer = 2
-'                 ^ definition local 8
+'                 ^ definition local 6
 '                   documentation ```vb\na As Integer\n```
-'                                   ^ definition local 9
+'                                   ^ definition local 7
 '                                     documentation ```vb\nb As Integer\n```
               Return a + b
-'                    ^ reference local 8
-'                        ^ reference local 9
+'                    ^ reference local 6
+'                        ^ reference local 7
           End Function
 
           Class MyDisposable
@@ -93,16 +93,16 @@
 '                                  documentation ```vb\nPrivate Function Statements.Using() As MyDisposable\n```
 '                                       ^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Statements#MyDisposable#
               Dim b = New MyDisposable()
-'                 ^ definition local 10
+'                 ^ definition local 8
 '                   documentation ```vb\nb As Class MyDisposable\n```
 '                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Statements#MyDisposable#
 
               Using a = b
-'                   ^ definition local 11
+'                   ^ definition local 9
 '                     documentation ```vb\na As Class MyDisposable\n```
-'                       ^ reference local 10
+'                       ^ reference local 8
                   Return a
-'                        ^ reference local 11
+'                        ^ reference local 9
               End Using
           End Function
 
@@ -110,13 +110,13 @@
 '                          ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#MultipleUsing().
 '                                        documentation ```vb\nPrivate Function Statements.MultipleUsing() As Long\n```
               Using a As Stream = File.OpenRead("a"), b As Stream = File.OpenRead("a")
-'                   ^ definition local 12
+'                   ^ definition local 10
 '                     documentation ```vb\na As Stream\n```
-'                                                     ^ definition local 13
+'                                                     ^ definition local 11
 '                                                       documentation ```vb\nb As Stream\n```
                   Return a.Length + b.Length
-'                        ^ reference local 12
-'                                   ^ reference local 13
+'                        ^ reference local 10
+'                                   ^ reference local 11
               End Using
           End Function
 
@@ -124,23 +124,23 @@
 '                          ^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Foreach().
 '                                  documentation ```vb\nPrivate Function Statements.Foreach() As Integer\n```
               Dim y = New Integer() {1}
-'                 ^ definition local 14
+'                 ^ definition local 12
 '                   documentation ```vb\ny As Integer()\n```
               Dim z = 0
-'                 ^ definition local 15
+'                 ^ definition local 13
 '                   documentation ```vb\nz As Integer\n```
 
               For Each x As Integer In y
-'                      ^ definition local 16
+'                      ^ definition local 14
 '                        documentation ```vb\nx As Integer\n```
-'                                      ^ reference local 14
+'                                      ^ reference local 12
                   z += x
-'                 ^ reference local 15
-'                      ^ reference local 16
+'                 ^ reference local 13
+'                      ^ reference local 14
               Next
 
               Return z
-'                    ^ reference local 15
+'                    ^ reference local 13
           End Function
 
       End Class

--- a/snapshots/output-net6.0/syntax/VBMain/Structs.vb
+++ b/snapshots/output-net6.0/syntax/VBMain/Structs.vb
@@ -16,11 +16,11 @@
               Public Sub New(ByVal field1 As Integer)
 '                        ^^^ definition scip-dotnet nuget . . VBMain/Structs#BasicStruct#`.ctor`(+1).
 '                            documentation ```vb\nPublic Sub BasicStruct.New(field1 As Integer)\n```
-'                                  ^^^^^^ definition scip-dotnet nuget . . VBMain/Structs#BasicStruct#`.ctor`(+1).(field1)
+'                                  ^^^^^^ definition local 0
 '                                         documentation ```vb\nfield1 As Integer\n```
                   Property1 = field1
 '                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Structs#BasicStruct#Property1.
-'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Structs#BasicStruct#`.ctor`(+1).(field1)
+'                             ^^^^^^ reference local 0
               End Sub
           End Structure
       End Class

--- a/snapshots/output-net7.0/syntax/Main/Classes.cs
+++ b/snapshots/output-net7.0/syntax/Main/Classes.cs
@@ -25,7 +25,7 @@
       public Classes(int name)
 //           ^^^^^^^ definition scip-dotnet nuget . . Main/Classes#`.ctor`().
 //                   documentation ```cs\npublic Classes.Classes(int name)\n```
-//                       ^^^^ definition scip-dotnet nuget . . Main/Classes#`.ctor`().(name)
+//                       ^^^^ definition local 0
 //                            documentation ```cs\nint name\n```
       {
           Name = "name";
@@ -35,10 +35,10 @@
       public Classes(string name) => Name = name;
 //           ^^^^^^^ definition scip-dotnet nuget . . Main/Classes#`.ctor`(+1).
 //                   documentation ```cs\npublic Classes.Classes(string name)\n```
-//                          ^^^^ definition scip-dotnet nuget . . Main/Classes#`.ctor`(+1).(name)
+//                          ^^^^ definition local 1
 //                               documentation ```cs\nstring name\n```
 //                                   ^^^^ reference scip-dotnet nuget . . Main/Classes#Name.
-//                                          ^^^^ reference scip-dotnet nuget . . Main/Classes#`.ctor`(+1).(name)
+//                                          ^^^^ reference local 1
 
       ~Classes()
 //     ^^^^^^^ definition scip-dotnet nuget . . Main/Classes#Finalize().
@@ -66,7 +66,7 @@
       class TypeParameterClass<T>
 //          ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#TypeParameterClass#
 //                             documentation ```cs\nclass TypeParameterClass<T>\n```
-//                             ^ definition scip-dotnet nuget . . Main/Classes#TypeParameterClass#[T]
+//                             ^ definition local 2
 //                               documentation ```cs\nT\n```
       {
       }
@@ -74,9 +74,9 @@
       internal class InternalMultipleTypeParametersClass<T1, T2>
 //                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#InternalMultipleTypeParametersClass#
 //                                                       documentation ```cs\nclass InternalMultipleTypeParametersClass<T1, T2>\n```
-//                                                       ^^ definition scip-dotnet nuget . . Main/Classes#InternalMultipleTypeParametersClass#[T1]
+//                                                       ^^ definition local 3
 //                                                          documentation ```cs\nT1\n```
-//                                                           ^^ definition scip-dotnet nuget . . Main/Classes#InternalMultipleTypeParametersClass#[T2]
+//                                                           ^^ definition local 4
 //                                                              documentation ```cs\nT2\n```
       {
       }
@@ -84,85 +84,85 @@
       interface ICovariantContravariant<in T1, out T2>
 //              ^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#ICovariantContravariant#
 //                                      documentation ```cs\ninterface ICovariantContravariant<in T1, out T2>\n```
-//                                         ^^ definition scip-dotnet nuget . . Main/Classes#ICovariantContravariant#[T1]
+//                                         ^^ definition local 5
 //                                            documentation ```cs\nin T1\n```
-//                                                 ^^ definition scip-dotnet nuget . . Main/Classes#ICovariantContravariant#[T2]
+//                                                 ^^ definition local 6
 //                                                    documentation ```cs\nout T2\n```
       {
           public void Method1(T1 t1)
 //                    ^^^^^^^ definition scip-dotnet nuget . . Main/Classes#ICovariantContravariant#Method1().
 //                            documentation ```cs\nvoid ICovariantContravariant<in T1, out T2>.Method1(T1 t1)\n```
-//                            ^^ reference scip-dotnet nuget . . Main/Classes#ICovariantContravariant#[T1]
-//                               ^^ definition scip-dotnet nuget . . Main/Classes#ICovariantContravariant#Method1().(t1)
+//                            ^^ reference local 5
+//                               ^^ definition local 7
 //                                  documentation ```cs\nT1 t1\n```
           {
               Console.WriteLine(t1);
 //            ^^^^^^^ reference scip-dotnet nuget System.Console 7.0.0.0 System/Console#
 //                    ^^^^^^^^^ reference scip-dotnet nuget System.Console 7.0.0.0 System/Console#WriteLine(+9).
-//                              ^^ reference scip-dotnet nuget . . Main/Classes#ICovariantContravariant#Method1().(t1)
+//                              ^^ reference local 7
           }
 
           public T2? Method2()
-//               ^^ reference scip-dotnet nuget . . Main/Classes#ICovariantContravariant#[T2]
+//               ^^ reference local 6
 //                   ^^^^^^^ definition scip-dotnet nuget . . Main/Classes#ICovariantContravariant#Method2().
 //                           documentation ```cs\nT2? ICovariantContravariant<in T1, out T2>.Method2()\n```
           {
               return default(T2);
-//                           ^^ reference scip-dotnet nuget . . Main/Classes#ICovariantContravariant#[T2]
+//                           ^^ reference local 6
           }
       }
 
       public class StructConstraintClass<T> where T : struct
 //                 ^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#StructConstraintClass#
 //                                       documentation ```cs\nclass StructConstraintClass<T> where T : struct\n```
-//                                       ^ definition scip-dotnet nuget . . Main/Classes#StructConstraintClass#[T]
+//                                       ^ definition local 8
 //                                         documentation ```cs\nT\n```
-//                                                ^ reference scip-dotnet nuget . . Main/Classes#StructConstraintClass#[T]
+//                                                ^ reference local 8
       {
       }
 
       public class UnmanagedConstraintClass<T> where T : unmanaged
 //                 ^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#UnmanagedConstraintClass#
 //                                          documentation ```cs\nclass UnmanagedConstraintClass<T> where T : unmanaged\n```
-//                                          ^ definition scip-dotnet nuget . . Main/Classes#UnmanagedConstraintClass#[T]
+//                                          ^ definition local 9
 //                                            documentation ```cs\nT\n```
-//                                                   ^ reference scip-dotnet nuget . . Main/Classes#UnmanagedConstraintClass#[T]
+//                                                   ^ reference local 9
       {
       }
 
       public class ClassConstraintClass<T> where T : class
 //                 ^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#ClassConstraintClass#
 //                                      documentation ```cs\nclass ClassConstraintClass<T> where T : class\n```
-//                                      ^ definition scip-dotnet nuget . . Main/Classes#ClassConstraintClass#[T]
+//                                      ^ definition local 10
 //                                        documentation ```cs\nT\n```
-//                                               ^ reference scip-dotnet nuget . . Main/Classes#ClassConstraintClass#[T]
+//                                               ^ reference local 10
       {
       }
 
       public class NonNullableConstraintClass<T> where T : notnull
 //                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#NonNullableConstraintClass#
 //                                            documentation ```cs\nclass NonNullableConstraintClass<T> where T : notnull\n```
-//                                            ^ definition scip-dotnet nuget . . Main/Classes#NonNullableConstraintClass#[T]
+//                                            ^ definition local 11
 //                                              documentation ```cs\nT\n```
-//                                                     ^ reference scip-dotnet nuget . . Main/Classes#NonNullableConstraintClass#[T]
+//                                                     ^ reference local 11
       {
       }
 
       public class NewConstraintClass<T> where T : new()
 //                 ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#NewConstraintClass#
 //                                    documentation ```cs\nclass NewConstraintClass<T> where T : new()\n```
-//                                    ^ definition scip-dotnet nuget . . Main/Classes#NewConstraintClass#[T]
+//                                    ^ definition local 12
 //                                      documentation ```cs\nT\n```
-//                                             ^ reference scip-dotnet nuget . . Main/Classes#NewConstraintClass#[T]
+//                                             ^ reference local 12
       {
       }
 
       public class TypeParameterConstraintClass<T> where T : SomeInterface
 //                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#TypeParameterConstraintClass#
 //                                              documentation ```cs\nclass TypeParameterConstraintClass<T> where T : SomeInterface\n```
-//                                              ^ definition scip-dotnet nuget . . Main/Classes#TypeParameterConstraintClass#[T]
+//                                              ^ definition local 13
 //                                                documentation ```cs\nT\n```
-//                                                       ^ reference scip-dotnet nuget . . Main/Classes#TypeParameterConstraintClass#[T]
+//                                                       ^ reference local 13
 //                                                           ^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/SomeInterface#
       {
       }
@@ -170,15 +170,15 @@
       private class MultipleTypeParameterConstraintsClass<T1, T2> where T1 : SomeInterface, SomeInterface2, new()
 //                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#MultipleTypeParameterConstraintsClass#
 //                                                        documentation ```cs\nclass MultipleTypeParameterConstraintsClass<T1, T2> where T1 : SomeInterface, SomeInterface2, new() where T2 : SomeInterface2\n```
-//                                                        ^^ definition scip-dotnet nuget . . Main/Classes#MultipleTypeParameterConstraintsClass#[T1]
+//                                                        ^^ definition local 14
 //                                                           documentation ```cs\nT1\n```
-//                                                            ^^ definition scip-dotnet nuget . . Main/Classes#MultipleTypeParameterConstraintsClass#[T2]
+//                                                            ^^ definition local 15
 //                                                               documentation ```cs\nT2\n```
-//                                                                      ^^ reference scip-dotnet nuget . . Main/Classes#MultipleTypeParameterConstraintsClass#[T1]
+//                                                                      ^^ reference local 14
 //                                                                           ^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/SomeInterface#
 //                                                                                          ^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/SomeInterface2#
           where T2 : SomeInterface2
-//              ^^ reference scip-dotnet nuget . . Main/Classes#MultipleTypeParameterConstraintsClass#[T2]
+//              ^^ reference local 15
 //                   ^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/SomeInterface2#
       {
       }
@@ -192,14 +192,14 @@
 //                       documentation ```cs\nprivate bool IndexClass.a\n```
 
           public bool this[int index]
-//                             ^^^^^ definition scip-dotnet nuget . . Main/Classes#IndexClass#`this[]`.(index)
+//                             ^^^^^ definition local 16
 //                                   documentation ```cs\nint index\n```
           {
               get { return a; }
 //                         ^ reference scip-dotnet nuget . . Main/Classes#IndexClass#a.
               set { a = value; }
 //                  ^ reference scip-dotnet nuget . . Main/Classes#IndexClass#a.
-//                      ^^^^^ reference scip-dotnet nuget . . Main/Classes#IndexClass#set_Item().(value)
+//                      ^^^^^ reference local 17
           }
       }
 

--- a/snapshots/output-net7.0/syntax/Main/Expressions.cs
+++ b/snapshots/output-net7.0/syntax/Main/Expressions.cs
@@ -205,14 +205,14 @@
 //                            documentation ```cs\npublic int IndexedClass.Property\n```
 
           public int this[int index]
-//                            ^^^^^ definition scip-dotnet nuget . . Main/Expressions#IndexedClass#`this[]`.(index)
+//                            ^^^^^ definition local 9
 //                                  documentation ```cs\nint index\n```
           {
               get { return Property; }
 //                         ^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#IndexedClass#Property.
               set { Property = value; }
 //                  ^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#IndexedClass#Property.
-//                             ^^^^^ reference scip-dotnet nuget . . Main/Expressions#IndexedClass#set_Item().(value)
+//                             ^^^^^ reference local 10
           }
       }
 
@@ -221,56 +221,56 @@
 //                                    documentation ```cs\nprivate void Expressions.AssignmentToLeftValueTypes()\n```
       {
           (var a, var b) = (1, 2);
-//             ^ definition local 9
+//             ^ definition local 11
 //               documentation ```cs\nint a\n```
-//                    ^ definition local 10
+//                    ^ definition local 12
 //                      documentation ```cs\nint b\n```
           a = 1;
-//        ^ reference local 9
+//        ^ reference local 11
           var c = new Struct { Property = 42 };
-//            ^ definition local 11
+//            ^ definition local 13
 //              documentation ```cs\nStruct c\n```
 //                    ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Struct#
 //                             ^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Struct#Property.
           c.Property = 1;
-//        ^ reference local 11
+//        ^ reference local 13
 //          ^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Struct#Property.
           var d = new IndexedClass();
-//            ^ definition local 12
+//            ^ definition local 14
 //              documentation ```cs\nIndexedClass d\n```
 //                    ^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#IndexedClass#
           d[b] = 1;
-//        ^ reference local 12
-//          ^ reference local 10
+//        ^ reference local 14
+//          ^ reference local 12
           (a, b) = (1, 2);
-//         ^ reference local 9
-//            ^ reference local 10
+//         ^ reference local 11
+//            ^ reference local 12
           var x = new IndexedClass
-//            ^ definition local 13
+//            ^ definition local 15
 //              documentation ```cs\nIndexedClass x\n```
 //                    ^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#IndexedClass#
           {
               Property = 1,
 //            ^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#IndexedClass#Property.
               [b] = 1
-//             ^ reference local 10
+//             ^ reference local 12
           };
           (a) = 1;
-//         ^ reference local 9
+//         ^ reference local 11
           unsafe
           {
               int myInt = 5;
-//                ^^^^^ definition local 14
+//                ^^^^^ definition local 16
 //                      documentation ```cs\nint myInt\n```
               int* p = &myInt;
-//                 ^ definition local 15
+//                 ^ definition local 17
 //                   documentation ```cs\nint* p\n```
-//                      ^^^^^ reference local 14
+//                      ^^^^^ reference local 16
               Console.WriteLine("myInt = {0}, *p = {1}", myInt, *p);
 //            ^^^^^^^ reference scip-dotnet nuget System.Console 7.0.0.0 System/Console#
 //                    ^^^^^^^^^ reference scip-dotnet nuget System.Console 7.0.0.0 System/Console#WriteLine(+13).
-//                                                       ^^^^^ reference local 14
-//                                                               ^ reference local 15
+//                                                       ^^^^^ reference local 16
+//                                                               ^ reference local 17
           }
       }
 
@@ -279,19 +279,19 @@
 //                           documentation ```cs\nprivate void Expressions.TernaryExpression()\n```
       {
           var x = true;
-//            ^ definition local 16
+//            ^ definition local 18
 //              documentation ```cs\nbool x\n```
           var y = x ? "foo" : "bar";
-//            ^ definition local 17
+//            ^ definition local 19
 //              documentation ```cs\nstring? y\n```
-//                ^ reference local 16
+//                ^ reference local 18
           object z = true;
-//               ^ definition local 18
+//               ^ definition local 20
 //                 documentation ```cs\nobject z\n```
           var t = z is bool ? 42 : 41;
-//            ^ definition local 19
+//            ^ definition local 21
 //              documentation ```cs\nint t\n```
-//                ^ reference local 18
+//                ^ reference local 20
       }
 
       class Cast
@@ -312,12 +312,12 @@
 //                    ^^^^ definition scip-dotnet nuget . . Main/Expressions#Cast#plus().
 //                         documentation ```cs\npublic Cast Cast.plus(Cast other)\n```
 //                         ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
-//                              ^^^^^ definition scip-dotnet nuget . . Main/Expressions#Cast#plus().(other)
+//                              ^^^^^ definition local 22
 //                                    documentation ```cs\nCast other\n```
           {
               nested = other;
 //            ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#nested.
-//                     ^^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#plus().(other)
+//                     ^^^^^ reference local 22
               return this;
           }
 
@@ -333,53 +333,53 @@
 //                        documentation ```cs\nprivate int Expressions.CastExpressions()\n```
       {
           object a = new Cast();
-//               ^ definition local 20
+//               ^ definition local 23
 //                 documentation ```cs\nobject a\n```
 //                       ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
           object b = new Cast();
-//               ^ definition local 21
+//               ^ definition local 24
 //                 documentation ```cs\nobject b\n```
 //                       ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
           Cast c = ((Cast)a).plus((Cast)b);
 //        ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
-//             ^ definition local 22
+//             ^ definition local 25
 //               documentation ```cs\nCast c\n```
 //                   ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
-//                        ^ reference local 20
+//                        ^ reference local 23
 //                           ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#plus().
 //                                 ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
-//                                      ^ reference local 21
+//                                      ^ reference local 24
           Cast d = (Cast)new object[] { a, b }[0];
 //        ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
-//             ^ definition local 23
+//             ^ definition local 26
 //               documentation ```cs\nCast d\n```
 //                  ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
-//                                      ^ reference local 20
-//                                         ^ reference local 21
+//                                      ^ reference local 23
+//                                         ^ reference local 24
           var e = (Cast.Cast2)(c.nested.nested2);
-//            ^ definition local 24
+//            ^ definition local 27
 //              documentation ```cs\nCast2? e\n```
 //                 ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
 //                      ^^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#Cast2#
-//                             ^ reference local 22
+//                             ^ reference local 25
 //                               ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#nested.
 //                                      ^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#nested2.
           var f = (Int32)(1);
-//            ^ definition local 25
+//            ^ definition local 28
 //              documentation ```cs\nint f\n```
 //                 ^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Int32#
           var g = (Int32)(1);
-//            ^ definition local 26
+//            ^ definition local 29
 //              documentation ```cs\nint g\n```
 //                 ^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Int32#
           var h = (Int32)((1));
-//            ^ definition local 27
+//            ^ definition local 30
 //              documentation ```cs\nint h\n```
 //                 ^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Int32#
           return f + g + h;
-//               ^ reference local 25
-//                   ^ reference local 26
-//                       ^ reference local 27
+//               ^ reference local 28
+//                   ^ reference local 29
+//                       ^ reference local 30
       }
 
       object AnonymousObject()
@@ -387,20 +387,20 @@
 //                           documentation ```cs\nprivate object Expressions.AnonymousObject()\n```
       {
           var x = new { Helper = "" };
-//            ^ definition local 28
-//              documentation ```cs\n<anonymous type: string Helper>? x\n```
-//                      ^^^^^^ reference local 30
-          var y = new
 //            ^ definition local 31
+//              documentation ```cs\n<anonymous type: string Helper>? x\n```
+//                      ^^^^^^ reference local 33
+          var y = new
+//            ^ definition local 34
 //              documentation ```cs\n<anonymous type: AnonymousType <anonymous type: string Helper> x>? y\n```
           {
               x
-//            ^ reference local 28
+//            ^ reference local 31
           };
           return y.x.Helper;
-//               ^ reference local 31
-//                 ^ reference local 33
-//                   ^^^^^^ reference local 30
+//               ^ reference local 34
+//                 ^ reference local 36
+//                   ^^^^^^ reference local 33
       }
 
       class TargetType
@@ -410,7 +410,7 @@
           public TargetType(string name)
 //               ^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#TargetType#`.ctor`().
 //                          documentation ```cs\npublic TargetType.TargetType(string name)\n```
-//                                 ^^^^ definition scip-dotnet nuget . . Main/Expressions#TargetType#`.ctor`().(name)
+//                                 ^^^^ definition local 37
 //                                      documentation ```cs\nstring name\n```
           {
           }
@@ -423,10 +423,10 @@
       {
           TargetType x = new("x");
 //        ^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#TargetType#
-//                   ^ definition local 34
+//                   ^ definition local 38
 //                     documentation ```cs\nTargetType x\n```
           return x;
-//               ^ reference local 34
+//               ^ reference local 38
       }
 
       int Checked()
@@ -434,10 +434,10 @@
 //                documentation ```cs\nprivate int Expressions.Checked()\n```
       {
           var three = checked(1 + 2);
-//            ^^^^^ definition local 35
+//            ^^^^^ definition local 39
 //                  documentation ```cs\nint three\n```
           return three;
-//               ^^^^^ reference local 35
+//               ^^^^^ reference local 39
       }
 
       class ObjectCreationClass
@@ -453,12 +453,12 @@
 //               ^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#`.ctor`().
 //                                   documentation ```cs\npublic ObjectCreationClass.ObjectCreationClass(D field)\n```
 //                                   ^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#D#
-//                                     ^^^^^ definition scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#`.ctor`().(field)
+//                                     ^^^^^ definition local 40
 //                                           documentation ```cs\nD field\n```
           {
               this.field = field;
 //                 ^^^^^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#field.
-//                         ^^^^^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#`.ctor`().(field)
+//                         ^^^^^ reference local 40
           }
 
           public class D
@@ -468,9 +468,9 @@
               public D(int a, string b)
 //                   ^ definition scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#D#`.ctor`().
 //                     documentation ```cs\npublic D.D(int a, string b)\n```
-//                         ^ definition scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#D#`.ctor`().(a)
+//                         ^ definition local 41
 //                           documentation ```cs\nint a\n```
-//                                   ^ definition scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#D#`.ctor`().(b)
+//                                   ^ definition local 42
 //                                     documentation ```cs\nstring b\n```
               {
               }
@@ -482,28 +482,28 @@
 //                        documentation ```cs\nprivate void Expressions.ObjectCreation()\n```
       {
           var a = new ObjectCreationClass.D(1, "hi");
-//            ^ definition local 36
+//            ^ definition local 43
 //              documentation ```cs\nD? a\n```
 //                    ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#
 //                                        ^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#D#
           var b = new ObjectCreationClass(a)
-//            ^ definition local 37
+//            ^ definition local 44
 //              documentation ```cs\nObjectCreationClass? b\n```
 //                    ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#
-//                                        ^ reference local 36
+//                                        ^ reference local 43
           {
               field = a,
 //            ^^^^^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#field.
-//                    ^ reference local 36
+//                    ^ reference local 43
           };
           b = new ObjectCreationClass(a);
-//        ^ reference local 37
+//        ^ reference local 44
 //                ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#
-//                                    ^ reference local 36
+//                                    ^ reference local 43
           b = new ObjectCreationClass(a) { };
-//        ^ reference local 37
+//        ^ reference local 44
 //                ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#
-//                                    ^ reference local 36
+//                                    ^ reference local 43
       }
 
       class NamedParametersClass
@@ -520,33 +520,33 @@
           public NamedParametersClass(int a, string b)
 //               ^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#NamedParametersClass#`.ctor`().
 //                                    documentation ```cs\npublic NamedParametersClass.NamedParametersClass(int a, string b)\n```
-//                                        ^ definition scip-dotnet nuget . . Main/Expressions#NamedParametersClass#`.ctor`().(a)
+//                                        ^ definition local 45
 //                                          documentation ```cs\nint a\n```
-//                                                  ^ definition scip-dotnet nuget . . Main/Expressions#NamedParametersClass#`.ctor`().(b)
+//                                                  ^ definition local 46
 //                                                    documentation ```cs\nstring b\n```
           {
               A = a;
 //            ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#A.
-//                ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#`.ctor`().(a)
+//                ^ reference local 45
               B = b;
 //            ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#B.
-//                ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#`.ctor`().(b)
+//                ^ reference local 46
           }
 
           public void Update(int a, string b)
 //                    ^^^^^^ definition scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().
 //                           documentation ```cs\npublic void NamedParametersClass.Update(int a, string b)\n```
-//                               ^ definition scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().(a)
+//                               ^ definition local 47
 //                                 documentation ```cs\nint a\n```
-//                                         ^ definition scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().(b)
+//                                         ^ definition local 48
 //                                           documentation ```cs\nstring b\n```
           {
               A = a;
 //            ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#A.
-//                ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().(a)
+//                ^ reference local 47
               B = b;
 //            ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#B.
-//                ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().(b)
+//                ^ reference local 48
           }
       }
 
@@ -556,18 +556,18 @@
 //                                         documentation ```cs\nprivate NamedParametersClass Expressions.NamedParameters()\n```
       {
           var a = new NamedParametersClass(b: "hi", a: 1);
-//            ^ definition local 38
+//            ^ definition local 49
 //              documentation ```cs\nNamedParametersClass? a\n```
 //                    ^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#
-//                                         ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#`.ctor`().(b)
-//                                                  ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#`.ctor`().(a)
+//                                         ^ reference local 46
+//                                                  ^ reference local 45
           a.Update(b: "foo", a: 42);
-//        ^ reference local 38
+//        ^ reference local 49
 //          ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().
-//                 ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().(b)
-//                           ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().(a)
+//                 ^ reference local 48
+//                           ^ reference local 47
           return a;
-//               ^ reference local 38
+//               ^ reference local 49
       }
 
       Func<int, int> AnonymousFunction()
@@ -575,20 +575,20 @@
 //                                     documentation ```cs\nprivate Func<int, int> Expressions.AnonymousFunction()\n```
       {
           var d = delegate (int _, int _) { return 42; };
-//            ^ definition local 39
+//            ^ definition local 50
 //              documentation ```cs\nFunc<int, int, int>? d\n```
-//                              ^ definition local 41
+//                              ^ definition local 51
 //                                documentation ```cs\nint _\n```
-//                                     ^ definition local 42
+//                                     ^ definition local 52
 //                                       documentation ```cs\nint _\n```
           return delegate (int a) { return a + d.Invoke(a, a); };
-//                             ^ definition local 44
+//                             ^ definition local 53
 //                               documentation ```cs\nint a\n```
-//                                         ^ reference local 44
-//                                             ^ reference local 39
+//                                         ^ reference local 53
+//                                             ^ reference local 50
 //                                               ^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Func#Invoke().
-//                                                      ^ reference local 44
-//                                                         ^ reference local 44
+//                                                      ^ reference local 53
+//                                                         ^ reference local 53
       }
 
       class Lambda
@@ -599,7 +599,7 @@
 //                      ^^^^ definition scip-dotnet nuget . . Main/Expressions#Lambda#func().
 //                           documentation ```cs\npublic string Lambda.func(Lambda x)\n```
 //                           ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#
-//                                  ^ definition scip-dotnet nuget . . Main/Expressions#Lambda#func().(x)
+//                                  ^ definition local 54
 //                                    documentation ```cs\nLambda x\n```
           {
               return "";
@@ -611,31 +611,31 @@
 //                           documentation ```cs\nprivate void Expressions.LambdaExpressions()\n```
       {
           var a = (string x) => x + 1;
-//            ^ definition local 45
+//            ^ definition local 55
 //              documentation ```cs\nFunc<string, string>? a\n```
-//                        ^ definition local 47
+//                        ^ definition local 56
 //                          documentation ```cs\nstring x\n```
-//                              ^ reference local 47
+//                              ^ reference local 56
           var b = (Lambda a, Lambda b) => { return a.func(b); };
-//            ^ definition local 48
+//            ^ definition local 57
 //              documentation ```cs\nFunc<Lambda, Lambda, string>? b\n```
 //                 ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#
-//                        ^ definition local 50
+//                        ^ definition local 58
 //                          documentation ```cs\nLambda a\n```
 //                           ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#
-//                                  ^ definition local 51
+//                                  ^ definition local 59
 //                                    documentation ```cs\nLambda b\n```
-//                                                 ^ reference local 50
+//                                                 ^ reference local 58
 //                                                   ^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#func().
-//                                                        ^ reference local 51
+//                                                        ^ reference local 59
           var c = string (Lambda a, Lambda _) => { return "hi"; };
-//            ^ definition local 52
+//            ^ definition local 60
 //              documentation ```cs\nFunc<Lambda, Lambda, string>? c\n```
 //                        ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#
-//                               ^ definition local 54
+//                               ^ definition local 61
 //                                 documentation ```cs\nLambda a\n```
 //                                  ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#
-//                                         ^ definition local 55
+//                                         ^ definition local 62
 //                                           documentation ```cs\nLambda _\n```
       }
 
@@ -644,7 +644,7 @@
 //                          documentation ```cs\nprivate void Expressions.TupleExpressions()\n```
       {
           var a = (1, 2, "");
-//            ^ definition local 56
+//            ^ definition local 63
 //              documentation ```cs\n(int, int, string) a\n```
       }
 
@@ -653,25 +653,25 @@
 //                       documentation ```cs\nprivate void Expressions.ArrayCreation()\n```
       {
           var a = new[,] { { 1, 1 }, { 2, 2 }, { 3, 3 } };
-//            ^ definition local 57
+//            ^ definition local 64
 //              documentation ```cs\nint[*,*]? a\n```
           Span<int> b = stackalloc[] { 1, 2, 3 };
-//                  ^ definition local 58
+//                  ^ definition local 65
 //                    documentation ```cs\nSpan<int> b\n```
           Span<int> c = stackalloc int[] { 1, 2, 3 };
-//                  ^ definition local 59
+//                  ^ definition local 66
 //                    documentation ```cs\nSpan<int> c\n```
           var d = new int[3] { 1, 2, 3 };
-//            ^ definition local 60
+//            ^ definition local 67
 //              documentation ```cs\nint[]? d\n```
           var e = new byte[,] { { 1, 2 }, { 2, 3 } };
-//            ^ definition local 61
+//            ^ definition local 68
 //              documentation ```cs\nbyte[*,*]? e\n```
           var f = new int[3, 2] { { 1, 1 }, { 2, 2 }, { 3, 3 } };
-//            ^ definition local 62
+//            ^ definition local 69
 //              documentation ```cs\nint[*,*]? f\n```
           var g = new (string b, string c)[3];
-//            ^ definition local 63
+//            ^ definition local 70
 //              documentation ```cs\n(string b, string c)[]? g\n```
       }
 
@@ -680,12 +680,12 @@
 //                 documentation ```cs\nprivate void Expressions.MakeRef()\n```
       {
           var g = "";
-//            ^ definition local 64
+//            ^ definition local 71
 //              documentation ```cs\nstring? g\n```
           var a = __makeref(g);
-//            ^ definition local 65
+//            ^ definition local 72
 //              documentation ```cs\nTypedReference a\n```
-//                          ^ reference local 64
+//                          ^ reference local 71
       }
 
       void SizeOf()
@@ -693,7 +693,7 @@
 //                documentation ```cs\nprivate void Expressions.SizeOf()\n```
       {
           var a = sizeof(int);
-//            ^ definition local 66
+//            ^ definition local 73
 //              documentation ```cs\nint a\n```
       }
 
@@ -702,17 +702,17 @@
 //                documentation ```cs\nprivate void Expressions.TypeOf()\n```
       {
           var a = typeof(int);
-//            ^ definition local 67
+//            ^ definition local 74
 //              documentation ```cs\nType? a\n```
           var b = typeof(List<string>.Enumerator);
-//            ^ definition local 68
+//            ^ definition local 75
 //              documentation ```cs\nType? b\n```
 //                                    ^^^^^^^^^^ reference scip-dotnet nuget System.Collections 7.0.0.0 Generic/List#Enumerator#
           var c = typeof(Dictionary<,>);
-//            ^ definition local 69
+//            ^ definition local 76
 //              documentation ```cs\nType? c\n```
           var d = typeof(Tuple<,,,>);
-//            ^ definition local 70
+//            ^ definition local 77
 //              documentation ```cs\nType? d\n```
       }
 
@@ -760,12 +760,12 @@
 //                documentation ```cs\nprivate void Expressions.Switch()\n```
       {
           int some = 42;
-//            ^^^^ definition local 71
+//            ^^^^ definition local 78
 //                 documentation ```cs\nint some\n```
           var a = some switch
-//            ^ definition local 72
+//            ^ definition local 79
 //              documentation ```cs\nstring? a\n```
-//                ^^^^ reference local 71
+//                ^^^^ reference local 78
           {
               1 => "one",
               2 => "two",
@@ -773,25 +773,25 @@
           };
           IAnimal dog = new Dog();
 //        ^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#IAnimal#
-//                ^^^ definition local 73
+//                ^^^ definition local 80
 //                    documentation ```cs\nIAnimal dog\n```
 //                          ^^^ reference scip-dotnet nuget . . Main/Expressions#Dog#
           var b = dog switch
-//            ^ definition local 74
+//            ^ definition local 81
 //              documentation ```cs\nstring? b\n```
-//                ^^^ reference local 73
+//                ^^^ reference local 80
           {
               Cat c => c.Sound(),
 //            ^^^ reference scip-dotnet nuget . . Main/Expressions#Cat#
-//                ^ definition local 75
+//                ^ definition local 82
 //                  documentation ```cs\nCat c\n```
-//                     ^ reference local 75
+//                     ^ reference local 82
 //                       ^^^^^ reference scip-dotnet nuget . . Main/Expressions#Cat#Sound().
               Dog c => c.Sound(),
 //            ^^^ reference scip-dotnet nuget . . Main/Expressions#Dog#
-//                ^ definition local 76
+//                ^ definition local 83
 //                  documentation ```cs\nDog c\n```
-//                     ^ reference local 76
+//                     ^ reference local 83
 //                       ^^^^^ reference scip-dotnet nuget . . Main/Expressions#Dog#Sound().
               _ => throw new ArgumentOutOfRangeException()
 //                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/ArgumentOutOfRangeException#
@@ -803,7 +803,7 @@
 //                    documentation ```cs\nprivate void Expressions.Dictionary()\n```
       {
           var a = new Dictionary<string, int> { ["a"] = 65 };
-//            ^ definition local 77
+//            ^ definition local 84
 //              documentation ```cs\nDictionary<string, int>? a\n```
       }
 
@@ -812,32 +812,32 @@
 //            documentation ```cs\nprivate void Expressions.Is()\n```
       {
           object s = "s";
-//               ^ definition local 78
+//               ^ definition local 85
 //                 documentation ```cs\nobject s\n```
           if (s is string s2)
-//            ^ reference local 78
-//                        ^^ definition local 79
+//            ^ reference local 85
+//                        ^^ definition local 86
 //                           documentation ```cs\nstring s2\n```
           {
               Console.WriteLine(s2);
 //            ^^^^^^^ reference scip-dotnet nuget System.Console 7.0.0.0 System/Console#
 //                    ^^^^^^^^^ reference scip-dotnet nuget System.Console 7.0.0.0 System/Console#WriteLine(+11).
-//                              ^^ reference local 79
+//                              ^^ reference local 86
           }
 
           var c = s is "test";
-//            ^ definition local 80
+//            ^ definition local 87
 //              documentation ```cs\nbool c\n```
-//                ^ reference local 78
+//                ^ reference local 85
           var a = s is int.MaxValue;
-//            ^ definition local 81
+//            ^ definition local 88
 //              documentation ```cs\nbool a\n```
-//                ^ reference local 78
+//                ^ reference local 85
 //                         ^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Int32#MaxValue.
           var d = s is nameof(a);
-//            ^ definition local 82
+//            ^ definition local 89
 //              documentation ```cs\nbool d\n```
-//                ^ reference local 78
-//                            ^ reference local 81
+//                ^ reference local 85
+//                            ^ reference local 88
       }
   }

--- a/snapshots/output-net7.0/syntax/Main/Fields.cs
+++ b/snapshots/output-net7.0/syntax/Main/Fields.cs
@@ -32,27 +32,27 @@
           public Fields1(long field2, long field3, Tuple<char, int?> field4, int field1)
 //               ^^^^^^^ definition scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().
 //                       documentation ```cs\npublic Fields1.Fields1(long field2, long field3, Tuple<char, int?> field4, int field1)\n```
-//                            ^^^^^^ definition scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field2)
+//                            ^^^^^^ definition local 0
 //                                   documentation ```cs\nlong field2\n```
-//                                         ^^^^^^ definition scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field3)
+//                                         ^^^^^^ definition local 1
 //                                                documentation ```cs\nlong field3\n```
-//                                                                   ^^^^^^ definition scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field4)
+//                                                                   ^^^^^^ definition local 2
 //                                                                          documentation ```cs\nTuple<char, int?> field4\n```
-//                                                                               ^^^^^^ definition scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field1)
+//                                                                               ^^^^^^ definition local 3
 //                                                                                      documentation ```cs\nint field1\n```
           {
               Property2 = field2;
 //            ^^^^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#Property2.
-//                        ^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field2)
+//                        ^^^^^^ reference local 0
               Property3 = field3;
 //            ^^^^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#Property3.
-//                        ^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field3)
+//                        ^^^^^^ reference local 1
               Property4 = field4;
 //            ^^^^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#Property4.
-//                        ^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field4)
+//                        ^^^^^^ reference local 2
               Property1 = field1;
 //            ^^^^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#Property1.
-//                        ^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field1)
+//                        ^^^^^^ reference local 3
           }
       }
 

--- a/snapshots/output-net7.0/syntax/Main/GlobalAttributes.cs
+++ b/snapshots/output-net7.0/syntax/Main/GlobalAttributes.cs
@@ -29,7 +29,7 @@
           public AuthorAttribute(string name)
 //               ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/GlobalAttributes#AuthorAttribute#`.ctor`().
 //                               documentation ```cs\npublic AuthorAttribute.AuthorAttribute(string name)\n```
-//                                      ^^^^ definition scip-dotnet nuget . . Main/GlobalAttributes#AuthorAttribute#`.ctor`().(name)
+//                                      ^^^^ definition local 0
 //                                           documentation ```cs\nstring name\n```
           {
           }
@@ -83,14 +83,14 @@
 //                 ^^^^^^^^^^ definition scip-dotnet nuget . . Main/GlobalAttributes#InnerClass#
 //                            documentation ```cs\nclass InnerClass<T>\n```
 //                             ^^^^^^ reference scip-dotnet nuget . . Main/GlobalAttributes#AuthorAttribute#`.ctor`().
-//                                                           ^ definition scip-dotnet nuget . . Main/GlobalAttributes#InnerClass#[T]
+//                                                           ^ definition local 1
 //                                                             documentation ```cs\nT\n```
       {
           void Method<[Author("MethodTypeParameter")] T2>()
 //             ^^^^^^ definition scip-dotnet nuget . . Main/GlobalAttributes#InnerClass#Method().
 //                    documentation ```cs\nprivate void InnerClass<T>.Method<T2>()\n```
 //                     ^^^^^^ reference scip-dotnet nuget . . Main/GlobalAttributes#AuthorAttribute#`.ctor`().
-//                                                    ^^ definition scip-dotnet nuget . . Main/GlobalAttributes#InnerClass#Method().[T2]
+//                                                    ^^ definition local 2
 //                                                       documentation ```cs\nT2\n```
           {
           }

--- a/snapshots/output-net7.0/syntax/Main/Interfaces.cs
+++ b/snapshots/output-net7.0/syntax/Main/Interfaces.cs
@@ -61,12 +61,12 @@
           void Input(string a);
 //             ^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IMethods#Input().
 //                   documentation ```cs\nvoid IMethods.Input(string a)\n```
-//                          ^ definition scip-dotnet nuget . . Main/Interfaces#IMethods#Input().(a)
+//                          ^ definition local 0
 //                            documentation ```cs\nstring a\n```
           int InputOutput(string a);
 //            ^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IMethods#InputOutput().
 //                        documentation ```cs\nint IMethods.InputOutput(string a)\n```
-//                               ^ definition scip-dotnet nuget . . Main/Interfaces#IMethods#InputOutput().(a)
+//                               ^ definition local 1
 //                                 documentation ```cs\nstring a\n```
       };
 
@@ -84,7 +84,7 @@
 //                     documentation ```cs\ninterface IIndex\n```
       {
           bool this[int index] { get; set; }
-//                      ^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IIndex#`this[]`.(index)
+//                      ^^^^^ definition local 2
 //                            documentation ```cs\nint index\n```
       }
 
@@ -95,13 +95,13 @@
           void Log(string message)
 //             ^^^ definition scip-dotnet nuget . . Main/Interfaces#IDefault#Log().
 //                 documentation ```cs\nvoid IDefault.Log(string message)\n```
-//                        ^^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IDefault#Log().(message)
+//                        ^^^^^^^ definition local 3
 //                                documentation ```cs\nstring message\n```
           {
               Console.WriteLine(message);
 //            ^^^^^^^ reference scip-dotnet nuget System.Console 7.0.0.0 System/Console#
 //                    ^^^^^^^^^ reference scip-dotnet nuget System.Console 7.0.0.0 System/Console#WriteLine(+11).
-//                              ^^^^^^^ reference scip-dotnet nuget . . Main/Interfaces#IDefault#Log().(message)
+//                              ^^^^^^^ reference local 3
           }
       }
 
@@ -119,15 +119,15 @@
       public interface IGetNext<T> where T : IGetNext<T>
 //                     ^^^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IGetNext#
 //                              documentation ```cs\ninterface IGetNext<T> where T : IGetNext<T>\n```
-//                              ^ definition scip-dotnet nuget . . Main/Interfaces#IGetNext#[T]
+//                              ^ definition local 4
 //                                documentation ```cs\nT\n```
-//                                       ^ reference scip-dotnet nuget . . Main/Interfaces#IGetNext#[T]
-//                                                    ^ reference scip-dotnet nuget . . Main/Interfaces#IGetNext#[T]
+//                                       ^ reference local 4
+//                                                    ^ reference local 4
       {
           static IGetNext<T> operator ++(IGetNext<T> other)
-//                        ^ reference scip-dotnet nuget . . Main/Interfaces#IGetNext#[T]
-//                                                ^ reference scip-dotnet nuget . . Main/Interfaces#IGetNext#[T]
-//                                                   ^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IGetNext#op_Increment().(other)
+//                        ^ reference local 4
+//                                                ^ reference local 4
+//                                                   ^^^^^ definition local 5
 //                                                         documentation ```cs\nIGetNext<T> other\n```
           {
               throw new NotImplementedException();
@@ -139,14 +139,14 @@
 //                      ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#ITypeParameter#
 //                                     documentation ```cs\ninterface ITypeParameter<T1, T2> where T1 : IOne where T2 : IThree\n```
 //                                     relationship implementation scip-dotnet nuget . . Main/Interfaces#ITwo#
-//                                     ^^ definition scip-dotnet nuget . . Main/Interfaces#ITypeParameter#[T1]
+//                                     ^^ definition local 6
 //                                        documentation ```cs\nT1\n```
-//                                         ^^ definition scip-dotnet nuget . . Main/Interfaces#ITypeParameter#[T2]
+//                                         ^^ definition local 7
 //                                            documentation ```cs\nT2\n```
 //                                               ^^^^ reference scip-dotnet nuget . . Main/Interfaces#ITwo#
-//                                                          ^^ reference scip-dotnet nuget . . Main/Interfaces#ITypeParameter#[T1]
+//                                                          ^^ reference local 6
 //                                                               ^^^^ reference scip-dotnet nuget . . Main/Interfaces#IOne#
-//                                                                          ^^ reference scip-dotnet nuget . . Main/Interfaces#ITypeParameter#[T2]
+//                                                                          ^^ reference local 7
 //                                                                               ^^^^^^ reference scip-dotnet nuget . . Main/Interfaces#IThree#
       {
       }

--- a/snapshots/output-net7.0/syntax/Main/Methods.cs
+++ b/snapshots/output-net7.0/syntax/Main/Methods.cs
@@ -15,82 +15,82 @@
       int SingleParameter(int b)
 //        ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#SingleParameter().
 //                        documentation ```cs\nprivate int Methods.SingleParameter(int b)\n```
-//                            ^ definition scip-dotnet nuget . . Main/Methods#SingleParameter().(b)
+//                            ^ definition local 0
 //                              documentation ```cs\nint b\n```
       {
           return b;
-//               ^ reference scip-dotnet nuget . . Main/Methods#SingleParameter().(b)
+//               ^ reference local 0
       }
 
       int TwoParameters(int a, int b)
 //        ^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#TwoParameters().
 //                      documentation ```cs\nprivate int Methods.TwoParameters(int a, int b)\n```
-//                          ^ definition scip-dotnet nuget . . Main/Methods#TwoParameters().(a)
+//                          ^ definition local 1
 //                            documentation ```cs\nint a\n```
-//                                 ^ definition scip-dotnet nuget . . Main/Methods#TwoParameters().(b)
+//                                 ^ definition local 2
 //                                   documentation ```cs\nint b\n```
       {
           return a + b;
-//               ^ reference scip-dotnet nuget . . Main/Methods#TwoParameters().(a)
-//                   ^ reference scip-dotnet nuget . . Main/Methods#TwoParameters().(b)
+//               ^ reference local 1
+//                   ^ reference local 2
       }
 
       int Overload1(int a)
 //        ^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#Overload1().
 //                  documentation ```cs\nprivate int Methods.Overload1(int a)\n```
-//                      ^ definition scip-dotnet nuget . . Main/Methods#Overload1().(a)
+//                      ^ definition local 3
 //                        documentation ```cs\nint a\n```
       {
           return a;
-//               ^ reference scip-dotnet nuget . . Main/Methods#Overload1().(a)
+//               ^ reference local 3
       }
 
       int Overload1(int a, int b)
 //        ^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#Overload1(+1).
 //                  documentation ```cs\nprivate int Methods.Overload1(int a, int b)\n```
-//                      ^ definition scip-dotnet nuget . . Main/Methods#Overload1(+1).(a)
+//                      ^ definition local 4
 //                        documentation ```cs\nint a\n```
-//                             ^ definition scip-dotnet nuget . . Main/Methods#Overload1(+1).(b)
+//                             ^ definition local 5
 //                               documentation ```cs\nint b\n```
       {
           return a + b;
-//               ^ reference scip-dotnet nuget . . Main/Methods#Overload1(+1).(a)
-//                   ^ reference scip-dotnet nuget . . Main/Methods#Overload1(+1).(b)
+//               ^ reference local 4
+//                   ^ reference local 5
       }
 
       T Generic<T>(T param)
-//    ^ reference scip-dotnet nuget . . Main/Methods#Generic().[T]
+//    ^ reference local 6
 //      ^^^^^^^ definition scip-dotnet nuget . . Main/Methods#Generic().
 //              documentation ```cs\nprivate T Methods.Generic<T>(T param)\n```
-//              ^ definition scip-dotnet nuget . . Main/Methods#Generic().[T]
+//              ^ definition local 6
 //                documentation ```cs\nT\n```
-//                 ^ reference scip-dotnet nuget . . Main/Methods#Generic().[T]
-//                   ^^^^^ definition scip-dotnet nuget . . Main/Methods#Generic().(param)
+//                 ^ reference local 6
+//                   ^^^^^ definition local 7
 //                         documentation ```cs\nT param\n```
       {
           return param;
-//               ^^^^^ reference scip-dotnet nuget . . Main/Methods#Generic().(param)
+//               ^^^^^ reference local 7
       }
 
       T GenericConstraint<T>(T param) where T : new()
-//    ^ reference scip-dotnet nuget . . Main/Methods#GenericConstraint().[T]
+//    ^ reference local 8
 //      ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#GenericConstraint().
 //                        documentation ```cs\nprivate T Methods.GenericConstraint<T>(T param) where T : new()\n```
-//                        ^ definition scip-dotnet nuget . . Main/Methods#GenericConstraint().[T]
+//                        ^ definition local 8
 //                          documentation ```cs\nT\n```
-//                           ^ reference scip-dotnet nuget . . Main/Methods#GenericConstraint().[T]
-//                             ^^^^^ definition scip-dotnet nuget . . Main/Methods#GenericConstraint().(param)
+//                           ^ reference local 8
+//                             ^^^^^ definition local 9
 //                                   documentation ```cs\nT param\n```
-//                                          ^ reference scip-dotnet nuget . . Main/Methods#GenericConstraint().[T]
+//                                          ^ reference local 8
       {
           return param;
-//               ^^^^^ reference scip-dotnet nuget . . Main/Methods#GenericConstraint().(param)
+//               ^^^^^ reference local 9
       }
 
       void DefaultParameter(int a = 5)
 //         ^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#DefaultParameter().
 //                          documentation ```cs\nprivate void Methods.DefaultParameter([int a = 5])\n```
-//                              ^ definition scip-dotnet nuget . . Main/Methods#DefaultParameter().(a)
+//                              ^ definition local 10
 //                                documentation ```cs\n[int a = 5]\n```
       {
       }
@@ -98,21 +98,21 @@
       int DefaultParameterOverload(int a = 5)
 //        ^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#DefaultParameterOverload().
 //                                 documentation ```cs\nprivate int Methods.DefaultParameterOverload([int a = 5])\n```
-//                                     ^ definition scip-dotnet nuget . . Main/Methods#DefaultParameterOverload().(a)
+//                                     ^ definition local 11
 //                                       documentation ```cs\n[int a = 5]\n```
       {
           return DefaultParameterOverload(a, a);
 //               ^^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Methods#DefaultParameterOverload(+1).
-//                                        ^ reference scip-dotnet nuget . . Main/Methods#DefaultParameterOverload().(a)
-//                                           ^ reference scip-dotnet nuget . . Main/Methods#DefaultParameterOverload().(a)
+//                                        ^ reference local 11
+//                                           ^ reference local 11
       }
 
       int DefaultParameterOverload(int a, int b)
 //        ^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#DefaultParameterOverload(+1).
 //                                 documentation ```cs\nprivate int Methods.DefaultParameterOverload(int a, int b)\n```
-//                                     ^ definition scip-dotnet nuget . . Main/Methods#DefaultParameterOverload(+1).(a)
+//                                     ^ definition local 12
 //                                       documentation ```cs\nint a\n```
-//                                            ^ definition scip-dotnet nuget . . Main/Methods#DefaultParameterOverload(+1).(b)
+//                                            ^ definition local 13
 //                                              documentation ```cs\nint b\n```
       {
           return DefaultParameterOverload();
@@ -164,11 +164,11 @@
           public int Method(int parameter)
 //                   ^^^^^^ definition scip-dotnet nuget . . Main/Methods#InheritedOverloads2#Method().
 //                          documentation ```cs\npublic int InheritedOverloads2.Method(int parameter)\n```
-//                              ^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#InheritedOverloads2#Method().(parameter)
+//                              ^^^^^^^^^ definition local 14
 //                                        documentation ```cs\nint parameter\n```
           {
               return parameter;
-//                   ^^^^^^^^^ reference scip-dotnet nuget . . Main/Methods#InheritedOverloads2#Method().(parameter)
+//                   ^^^^^^^^^ reference local 14
           }
       }
 
@@ -182,11 +182,11 @@
           public string Method(string parameter)
 //                      ^^^^^^ definition scip-dotnet nuget . . Main/Methods#InheritedOverloads3#Method().
 //                             documentation ```cs\npublic string InheritedOverloads3.Method(string parameter)\n```
-//                                    ^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#InheritedOverloads3#Method().(parameter)
+//                                    ^^^^^^^^^ definition local 15
 //                                              documentation ```cs\nstring parameter\n```
           {
               return parameter;
-//                   ^^^^^^^^^ reference scip-dotnet nuget . . Main/Methods#InheritedOverloads3#Method().(parameter)
+//                   ^^^^^^^^^ reference local 15
           }
       }
 
@@ -223,27 +223,27 @@
 //                                  documentation ```cs\npublic static void LocalFunction.Method()\n```
           {
               var myWorld = GetWorld();
-//                ^^^^^^^ definition local 0
+//                ^^^^^^^ definition local 16
 //                        documentation ```cs\nstring? myWorld\n```
-//                          ^^^^^^^^ reference local 1
+//                          ^^^^^^^^ reference local 17
               SayHi(myWorld);
-//            ^^^^^ reference local 2
-//                  ^^^^^^^ reference local 0
+//            ^^^^^ reference local 18
+//                  ^^^^^^^ reference local 16
 
               string GetWorld() => "world";
-//                   ^^^^^^^^ definition local 1
+//                   ^^^^^^^^ definition local 17
 //                            documentation ```cs\nstring GetWorld()\n```
 
               void SayHi(string world)
-//                 ^^^^^ definition local 2
+//                 ^^^^^ definition local 18
 //                       documentation ```cs\nvoid SayHi(string world)\n```
-//                              ^^^^^ definition local 3
+//                              ^^^^^ definition local 19
 //                                    documentation ```cs\nstring world\n```
               {
                   Console.WriteLine($"Hello {world}!");
 //                ^^^^^^^ reference scip-dotnet nuget System.Console 7.0.0.0 System/Console#
 //                        ^^^^^^^^^ reference scip-dotnet nuget System.Console 7.0.0.0 System/Console#WriteLine(+11).
-//                                           ^^^^^ reference local 3
+//                                           ^^^^^ reference local 19
               }
           }
       }

--- a/snapshots/output-net7.0/syntax/Main/Operators.cs
+++ b/snapshots/output-net7.0/syntax/Main/Operators.cs
@@ -18,7 +18,7 @@
       {
           public static int operator +(PlusMinus a)
 //                                     ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#PlusMinus#
-//                                               ^ definition scip-dotnet nuget . . Main/Operators#PlusMinus#op_UnaryPlus().(a)
+//                                               ^ definition local 0
 //                                                 documentation ```cs\nPlusMinus a\n```
           {
               return 0;
@@ -26,10 +26,10 @@
 
           public static int operator +(PlusMinus a, PlusMinus b)
 //                                     ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#PlusMinus#
-//                                               ^ definition scip-dotnet nuget . . Main/Operators#PlusMinus#op_Addition().(a)
+//                                               ^ definition local 1
 //                                                 documentation ```cs\nPlusMinus a\n```
 //                                                  ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#PlusMinus#
-//                                                            ^ definition scip-dotnet nuget . . Main/Operators#PlusMinus#op_Addition().(b)
+//                                                            ^ definition local 2
 //                                                              documentation ```cs\nPlusMinus b\n```
           {
               return 0;
@@ -37,7 +37,7 @@
 
           public static int operator -(PlusMinus a)
 //                                     ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#PlusMinus#
-//                                               ^ definition scip-dotnet nuget . . Main/Operators#PlusMinus#op_UnaryNegation().(a)
+//                                               ^ definition local 3
 //                                                 documentation ```cs\nPlusMinus a\n```
           {
               return 0;
@@ -52,7 +52,7 @@
 //                       ^^^^^^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#Equals().
 //                              documentation ```cs\nprotected bool TrueFalse.Equals(TrueFalse other)\n```
 //                              ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
-//                                        ^^^^^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#Equals().(other)
+//                                        ^^^^^ definition local 4
 //                                              documentation ```cs\nTrueFalse other\n```
           {
               throw new NotImplementedException();
@@ -63,23 +63,23 @@
 //                             ^^^^^^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#Equals(+1).
 //                                    documentation ```cs\npublic override bool TrueFalse.Equals(object? obj)\n```
 //                                    relationship implementation reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Object#Equals().
-//                                            ^^^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#Equals(+1).(obj)
+//                                            ^^^ definition local 5
 //                                                documentation ```cs\nobject? obj\n```
           {
               if (ReferenceEquals(null, obj)) return false;
 //                ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Object#ReferenceEquals().
-//                                      ^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#Equals(+1).(obj)
+//                                      ^^^ reference local 5
               if (ReferenceEquals(this, obj)) return true;
 //                ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Object#ReferenceEquals().
-//                                      ^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#Equals(+1).(obj)
+//                                      ^^^ reference local 5
               if (obj.GetType() != this.GetType()) return false;
-//                ^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#Equals(+1).(obj)
+//                ^^^ reference local 5
 //                    ^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Object#GetType().
 //                                      ^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Object#GetType().
               return Equals((TrueFalse)obj);
 //                   ^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#Equals().
 //                           ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
-//                                     ^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#Equals(+1).(obj)
+//                                     ^^^ reference local 5
           }
 
           public override int GetHashCode()
@@ -93,7 +93,7 @@
 
           public static bool operator true(TrueFalse a)
 //                                         ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
-//                                                   ^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#op_True().(a)
+//                                                   ^ definition local 6
 //                                                     documentation ```cs\nTrueFalse a\n```
           {
               return true;
@@ -101,7 +101,7 @@
 
           public static bool operator false(TrueFalse a)
 //                                          ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
-//                                                    ^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#op_False().(a)
+//                                                    ^ definition local 7
 //                                                      documentation ```cs\nTrueFalse a\n```
           {
               return false;
@@ -109,10 +109,10 @@
 
           public static bool operator !=(TrueFalse a, TrueFalse b)
 //                                       ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
-//                                                 ^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#op_Inequality().(a)
+//                                                 ^ definition local 8
 //                                                   documentation ```cs\nTrueFalse a\n```
 //                                                    ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
-//                                                              ^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#op_Inequality().(b)
+//                                                              ^ definition local 9
 //                                                                documentation ```cs\nTrueFalse b\n```
           {
               return true;
@@ -120,10 +120,10 @@
 
           public static bool operator ==(TrueFalse a, TrueFalse b)
 //                                       ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
-//                                                 ^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#op_Equality().(a)
+//                                                 ^ definition local 10
 //                                                   documentation ```cs\nTrueFalse a\n```
 //                                                    ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
-//                                                              ^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#op_Equality().(b)
+//                                                              ^ definition local 11
 //                                                                documentation ```cs\nTrueFalse b\n```
           {
               return true;

--- a/snapshots/output-net7.0/syntax/Main/QuerySyntax.cs
+++ b/snapshots/output-net7.0/syntax/Main/QuerySyntax.cs
@@ -167,67 +167,67 @@
 //         ^^^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#JoinInto().
 //                  documentation ```cs\nprivate void QuerySyntax.JoinInto(List<Student> students1, List<Student> students2)\n```
 //                       ^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#Student#
-//                                ^^^^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#JoinInto().(students1)
+//                                ^^^^^^^^^ definition local 22
 //                                          documentation ```cs\nList<Student> students1\n```
 //                                                ^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#Student#
-//                                                         ^^^^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#JoinInto().(students2)
+//                                                         ^^^^^^^^^ definition local 23
 //                                                                   documentation ```cs\nList<Student> students2\n```
       {
           var innerGroupJoinQuery =
-//            ^^^^^^^^^^^^^^^^^^^ definition local 22
+//            ^^^^^^^^^^^^^^^^^^^ definition local 24
 //                                documentation ```cs\nIEnumerable<<anonymous type: string Student, interface IEnumerable<Student> Students>>? innerGroupJoinQuery\n```
               from student1 in students1
-//                 ^^^^^^^^ definition local 23
+//                 ^^^^^^^^ definition local 25
 //                          documentation ```cs\n? student1\n```
-//                             ^^^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#JoinInto().(students1)
+//                             ^^^^^^^^^ reference local 22
               join student2 in students2 on student1.ID equals student2.ID into studentGroup
-//                 ^^^^^^^^ definition local 24
+//                 ^^^^^^^^ definition local 26
 //                          documentation ```cs\n? student2\n```
-//                             ^^^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#JoinInto().(students2)
-//                                          ^^^^^^^^ reference local 23
+//                             ^^^^^^^^^ reference local 23
+//                                          ^^^^^^^^ reference local 25
 //                                                   ^^ reference scip-dotnet nuget . . Main/QuerySyntax#Student#ID.
-//                                                             ^^^^^^^^ reference local 24
+//                                                             ^^^^^^^^ reference local 26
 //                                                                      ^^ reference scip-dotnet nuget . . Main/QuerySyntax#Student#ID.
-//                                                                              ^^^^^^^^^^^^ definition local 25
+//                                                                              ^^^^^^^^^^^^ definition local 27
 //                                                                                           documentation ```cs\n? studentGroup\n```
               select new { Student = student1.First, Students = studentGroup };
-//                         ^^^^^^^ reference local 27
-//                                   ^^^^^^^^ reference local 23
+//                         ^^^^^^^ reference local 29
+//                                   ^^^^^^^^ reference local 25
 //                                            ^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#Student#First.
-//                                                   ^^^^^^^^ reference local 28
-//                                                              ^^^^^^^^^^^^ reference local 25
+//                                                   ^^^^^^^^ reference local 30
+//                                                              ^^^^^^^^^^^^ reference local 27
       }
 
       void Continuation(List<Student> students)
 //         ^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#Continuation().
 //                      documentation ```cs\nprivate void QuerySyntax.Continuation(List<Student> students)\n```
 //                           ^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#Student#
-//                                    ^^^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#Continuation().(students)
+//                                    ^^^^^^^^ definition local 31
 //                                             documentation ```cs\nList<Student> students\n```
       {
           var sortedGroups =
-//            ^^^^^^^^^^^^ definition local 29
+//            ^^^^^^^^^^^^ definition local 32
 //                         documentation ```cs\nIOrderedEnumerable<IGrouping<char, Student>>? sortedGroups\n```
               from student in students
-//                 ^^^^^^^ definition local 30
+//                 ^^^^^^^ definition local 33
 //                         documentation ```cs\n? student\n```
-//                            ^^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#Continuation().(students)
+//                            ^^^^^^^^ reference local 31
               orderby student.Last, student.First
-//                    ^^^^^^^ reference local 30
+//                    ^^^^^^^ reference local 33
 //                            ^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#Student#Last.
-//                                  ^^^^^^^ reference local 30
+//                                  ^^^^^^^ reference local 33
 //                                          ^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#Student#First.
               group student by student.Last[0] into newGroup
-//                  ^^^^^^^ reference local 30
-//                             ^^^^^^^ reference local 30
+//                  ^^^^^^^ reference local 33
+//                             ^^^^^^^ reference local 33
 //                                     ^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#Student#Last.
-//                                                  ^^^^^^^^ definition local 31
+//                                                  ^^^^^^^^ definition local 34
 //                                                           documentation ```cs\n? newGroup\n```
               orderby newGroup.Key
-//                    ^^^^^^^^ reference local 31
+//                    ^^^^^^^^ reference local 34
 //                             ^^^ reference scip-dotnet nuget System.Linq 7.0.0.0 Linq/IGrouping#Key.
               select newGroup;
-//                   ^^^^^^^^ reference local 31
+//                   ^^^^^^^^ reference local 34
       }
 
       private class Student

--- a/snapshots/output-net7.0/syntax/Main/Records.cs
+++ b/snapshots/output-net7.0/syntax/Main/Records.cs
@@ -46,9 +46,9 @@
 //                  ^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Records#TypeParameterConstraint#
 //                                          documentation ```cs\nrecord TypeParameterConstraint<T> where T : struct\n```
 //                                          relationship implementation scip-dotnet nuget System.Runtime 7.0.0.0 System/IEquatable#
-//                                          ^ definition scip-dotnet nuget . . Main/Records#TypeParameterConstraint#[T]
+//                                          ^ definition local 0
 //                                            documentation ```cs\nT\n```
-//                                                   ^ reference scip-dotnet nuget . . Main/Records#TypeParameterConstraint#[T]
+//                                                   ^ reference local 0
       {
       }
 
@@ -71,9 +71,9 @@
 //                  relationship implementation scip-dotnet nuget . . Main/Records#I1#
 //                  relationship implementation scip-dotnet nuget . . Main/Records#I2#
 //                  relationship implementation scip-dotnet nuget System.Runtime 7.0.0.0 System/IEquatable#
-//                         ^^^^^^^^^ definition scip-dotnet nuget . . Main/Records#Person#`.ctor`().(FirstName)
+//                         ^^^^^^^^^ definition local 1
 //                                   documentation ```cs\nstring FirstName\n```
-//                                           ^^^^^^^^ definition scip-dotnet nuget . . Main/Records#Person#`.ctor`().(LastName)
+//                                           ^^^^^^^^ definition local 2
 //                                                    documentation ```cs\nstring LastName\n```
 //                                                       ^^ reference scip-dotnet nuget . . Main/Records#I1#
 //                                                           ^^ reference scip-dotnet nuget . . Main/Records#I2#
@@ -81,10 +81,10 @@
           public Person(string FirstName) : this(FirstName, FirstName)
 //               ^^^^^^ definition scip-dotnet nuget . . Main/Records#Person#`.ctor`(+1).
 //                      documentation ```cs\npublic Person.Person(string FirstName)\n```
-//                             ^^^^^^^^^ definition scip-dotnet nuget . . Main/Records#Person#`.ctor`(+1).(FirstName)
+//                             ^^^^^^^^^ definition local 3
 //                                       documentation ```cs\nstring FirstName\n```
-//                                               ^^^^^^^^^ reference scip-dotnet nuget . . Main/Records#Person#`.ctor`(+1).(FirstName)
-//                                                          ^^^^^^^^^ reference scip-dotnet nuget . . Main/Records#Person#`.ctor`(+1).(FirstName)
+//                                               ^^^^^^^^^ reference local 3
+//                                                          ^^^^^^^^^ reference local 3
           {
           }
       };
@@ -97,15 +97,15 @@
 //                   relationship implementation scip-dotnet nuget . . Main/Records#I1#
 //                   relationship implementation scip-dotnet nuget . . Main/Records#I2#
 //                   relationship implementation scip-dotnet nuget System.Runtime 7.0.0.0 System/IEquatable#
-//                          ^^^^^^^^^ definition scip-dotnet nuget . . Main/Records#Teacher#`.ctor`().(FirstName)
+//                          ^^^^^^^^^ definition local 4
 //                                    documentation ```cs\nstring FirstName\n```
-//                                            ^^^^^^^^ definition scip-dotnet nuget . . Main/Records#Teacher#`.ctor`().(LastName)
+//                                            ^^^^^^^^ definition local 5
 //                                                     documentation ```cs\nstring LastName\n```
-//                                                             ^^^^^^^ definition scip-dotnet nuget . . Main/Records#Teacher#`.ctor`().(Subject)
+//                                                             ^^^^^^^ definition local 6
 //                                                                     documentation ```cs\nstring Subject\n```
 //                                                                        ^^^^^^ reference scip-dotnet nuget . . Main/Records#Person#
-//                                                                               ^^^^^^^^^ reference scip-dotnet nuget . . Main/Records#Teacher#`.ctor`().(FirstName)
-//                                                                                          ^^^^^^^^ reference scip-dotnet nuget . . Main/Records#Teacher#`.ctor`().(LastName)
+//                                                                               ^^^^^^^^^ reference local 4
+//                                                                                          ^^^^^^^^ reference local 5
 //                                                                                                     ^^ reference scip-dotnet nuget . . Main/Records#I1#
 //                                                                                                         ^^ reference scip-dotnet nuget . . Main/Records#I2#
 
@@ -114,11 +114,11 @@
 //                      documentation ```cs\nprivate void Records.UsingRecords()\n```
       {
           var person = new Person("a", "b");
-//            ^^^^^^ definition local 0
+//            ^^^^^^ definition local 7
 //                   documentation ```cs\nPerson? person\n```
 //                         ^^^^^^ reference scip-dotnet nuget . . Main/Records#Person#
           var teacher = new Teacher("a", "b", "c");
-//            ^^^^^^^ definition local 1
+//            ^^^^^^^ definition local 8
 //                    documentation ```cs\nTeacher? teacher\n```
 //                          ^^^^^^^ reference scip-dotnet nuget . . Main/Records#Teacher#
       }
@@ -127,7 +127,7 @@
 //           ^^ definition scip-dotnet nuget . . Main/Records#I3#
 //              documentation ```cs\nrecord I3<T>\n```
 //              relationship implementation scip-dotnet nuget System.Runtime 7.0.0.0 System/IEquatable#
-//              ^ definition scip-dotnet nuget . . Main/Records#I3#[T]
+//              ^ definition local 9
 //                documentation ```cs\nT\n```
 
       record Teacher2() : I3<Person>(), I1;

--- a/snapshots/output-net7.0/syntax/Main/Statements.cs
+++ b/snapshots/output-net7.0/syntax/Main/Statements.cs
@@ -66,9 +66,9 @@
 //           ^^^^^^^^ definition scip-dotnet nuget . . Main/Statements#Inferred#
 //                    documentation ```cs\nrecord Inferred\n```
 //                    relationship implementation scip-dotnet nuget System.Runtime 7.0.0.0 System/IEquatable#
-//                        ^^ definition scip-dotnet nuget . . Main/Statements#Inferred#`.ctor`().(F1)
+//                        ^^ definition local 5
 //                           documentation ```cs\nint F1\n```
-//                                ^^ definition scip-dotnet nuget . . Main/Statements#Inferred#`.ctor`().(F2)
+//                                ^^ definition local 6
 //                                   documentation ```cs\nint F2\n```
 
       void InferredTuples()
@@ -76,19 +76,19 @@
 //                        documentation ```cs\nprivate void Statements.InferredTuples()\n```
       {
           var list = new List<Inferred>();
-//            ^^^^ definition local 5
+//            ^^^^ definition local 7
 //                 documentation ```cs\nList<Inferred>? list\n```
 //                            ^^^^^^^^ reference scip-dotnet nuget . . Main/Statements#Inferred#
           var result = list.Select(c => (c.F1, c.F2)).Where(t => t.F2 == 1);
-//            ^^^^^^ definition local 6
+//            ^^^^^^ definition local 8
 //                   documentation ```cs\nIEnumerable<(int F1, int F2)>? result\n```
-//                     ^^^^ reference local 5
+//                     ^^^^ reference local 7
 //                          ^^^^^^ reference scip-dotnet nuget System.Linq 7.0.0.0 Linq/Enumerable#Select().
-//                                 ^ definition local 8
+//                                 ^ definition local 9
 //                                   documentation ```cs\nInferred c\n```
-//                                       ^ reference local 8
+//                                       ^ reference local 9
 //                                         ^^ reference scip-dotnet nuget . . Main/Statements#Inferred#F1.
-//                                             ^ reference local 8
+//                                             ^ reference local 9
 //                                               ^^ reference scip-dotnet nuget . . Main/Statements#Inferred#F2.
 //                                                    ^^^^^ reference scip-dotnet nuget System.Linq 7.0.0.0 Linq/Enumerable#Where().
 //                                                          ^ definition local 10
@@ -204,21 +204,21 @@
       void ForeachVariable(List<(int, int)> names)
 //         ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Statements#ForeachVariable().
 //                         documentation ```cs\nprivate void Statements.ForeachVariable(List<(int, int)> names)\n```
-//                                          ^^^^^ definition scip-dotnet nuget . . Main/Statements#ForeachVariable().(names)
+//                                          ^^^^^ definition local 22
 //                                                documentation ```cs\nList<(int, int)> names\n```
       {
           foreach ((int firstName, int lastName) in names)
-//                      ^^^^^^^^^ definition local 22
+//                      ^^^^^^^^^ definition local 23
 //                                documentation ```cs\nint firstName\n```
-//                                     ^^^^^^^^ definition local 23
+//                                     ^^^^^^^^ definition local 24
 //                                              documentation ```cs\nint lastName\n```
-//                                                  ^^^^^ reference scip-dotnet nuget . . Main/Statements#ForeachVariable().(names)
+//                                                  ^^^^^ reference local 22
           {
               Console.WriteLine($"FirstName:{firstName}, LastName:{lastName}");
 //            ^^^^^^^ reference scip-dotnet nuget System.Console 7.0.0.0 System/Console#
 //                    ^^^^^^^^^ reference scip-dotnet nuget System.Console 7.0.0.0 System/Console#WriteLine(+11).
-//                                           ^^^^^^^^^ reference local 22
-//                                                                 ^^^^^^^^ reference local 23
+//                                           ^^^^^^^^^ reference local 23
+//                                                                 ^^^^^^^^ reference local 24
           }
       }
   }

--- a/snapshots/output-net7.0/syntax/Main/Structs.cs
+++ b/snapshots/output-net7.0/syntax/Main/Structs.cs
@@ -23,12 +23,12 @@
           public BasicStruct(int field1)
 //               ^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Structs#BasicStruct#`.ctor`().
 //                           documentation ```cs\npublic BasicStruct.BasicStruct(int field1)\n```
-//                               ^^^^^^ definition scip-dotnet nuget . . Main/Structs#BasicStruct#`.ctor`().(field1)
+//                               ^^^^^^ definition local 0
 //                                      documentation ```cs\nint field1\n```
           {
               Property1 = field1;
 //            ^^^^^^^^^ reference scip-dotnet nuget . . Main/Structs#BasicStruct#Property1.
-//                        ^^^^^^ reference scip-dotnet nuget . . Main/Structs#BasicStruct#`.ctor`().(field1)
+//                        ^^^^^^ reference local 0
           }
       }
   }

--- a/snapshots/output-net7.0/syntax/VBMain/CaseInsensitive.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/CaseInsensitive.vb
@@ -6,12 +6,12 @@
           Public Sub DifferentCase(wEiRdCaSiNg As String)
 '                    ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/CaseInsensitive#DifferentCase().
 '                                  documentation ```vb\nPublic Sub CaseInsensitive.DifferentCase(wEiRdCaSiNg As String)\n```
-'                                  ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/CaseInsensitive#DifferentCase().(wEiRdCaSiNg)
+'                                  ^^^^^^^^^^^ definition local 0
 '                                              documentation ```vb\nwEiRdCaSiNg As String\n```
               Console.WriteLine(WeIrDcAsInG)
 '             ^^^^^^^ reference scip-dotnet nuget System.Console 7.0.0.0 System/Console#
 '                     ^^^^^^^^^ reference scip-dotnet nuget System.Console 7.0.0.0 System/Console#WriteLine(+11).
-'                               ^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/CaseInsensitive#DifferentCase().(wEiRdCaSiNg)
+'                               ^^^^^^^^^^^ reference local 0
           End Sub
       End Class
   End Namespace

--- a/snapshots/output-net7.0/syntax/VBMain/Classes.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Classes.vb
@@ -24,7 +24,7 @@
           Public Sub New(ByVal name As Integer)
 '                    ^^^ definition scip-dotnet nuget . . VBMain/Classes#`.ctor`().
 '                        documentation ```vb\nPublic Sub Classes.New(name As Integer)\n```
-'                              ^^^^ definition scip-dotnet nuget . . VBMain/Classes#`.ctor`().(name)
+'                              ^^^^ definition local 0
 '                                   documentation ```vb\nname As Integer\n```
               Me.Name = "name"
 '                ^^^^ reference scip-dotnet nuget . . VBMain/Classes#Name.
@@ -33,11 +33,11 @@
           Public Sub New(ByVal name As String)
 '                    ^^^ definition scip-dotnet nuget . . VBMain/Classes#`.ctor`(+1).
 '                        documentation ```vb\nPublic Sub Classes.New(name As String)\n```
-'                              ^^^^ definition scip-dotnet nuget . . VBMain/Classes#`.ctor`(+1).(name)
+'                              ^^^^ definition local 1
 '                                   documentation ```vb\nname As String\n```
               Me.Name = name
 '                ^^^^ reference scip-dotnet nuget . . VBMain/Classes#Name.
-'                       ^^^^ reference scip-dotnet nuget . . VBMain/Classes#`.ctor`(+1).(name)
+'                       ^^^^ reference local 1
           End Sub
 
           Protected Overrides Sub Finalize()
@@ -66,65 +66,65 @@
           Class TypeParameterClass(Of T)
 '               ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#TypeParameterClass#
 '                                  documentation ```vb\nClass TypeParameterClass(Of T)\n```
-'                                     ^ definition scip-dotnet nuget . . VBMain/Classes#TypeParameterClass#[T]
+'                                     ^ definition local 2
 '                                       documentation ```vb\nT\n```
           End Class
 
           Friend Class InternalMultipleTypeParametersClass(Of T1, T2)
 '                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#InternalMultipleTypeParametersClass#
 '                                                          documentation ```vb\nClass InternalMultipleTypeParametersClass(Of T1, T2)\n```
-'                                                             ^^ definition scip-dotnet nuget . . VBMain/Classes#InternalMultipleTypeParametersClass#[T1]
+'                                                             ^^ definition local 3
 '                                                                documentation ```vb\nT1\n```
-'                                                                 ^^ definition scip-dotnet nuget . . VBMain/Classes#InternalMultipleTypeParametersClass#[T2]
+'                                                                 ^^ definition local 4
 '                                                                    documentation ```vb\nT2\n```
           End Class
 
           Interface ICovariantContravariant(Of In T1, Out T2)
 '                   ^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#
 '                                           documentation ```vb\nInterface ICovariantContravariant(Of In T1, Out T2)\n```
-'                                                 ^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T1]
+'                                                 ^^ definition local 5
 '                                                    documentation ```vb\nIn T1\n```
-'                                                         ^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T2]
+'                                                         ^^ definition local 6
 '                                                            documentation ```vb\nOut T2\n```
               Sub Method1(ByVal t1 As T1)
 '                 ^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method1().
 '                         documentation ```vb\nSub ICovariantContravariant(Of In T1, Out T2).Method1(t1 As T1)\n```
-'                               ^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method1().(t1)
+'                               ^^ definition local 7
 '                                  documentation ```vb\nt1 As T1\n```
-'                                     ^^ reference scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T1]
+'                                     ^^ reference local 5
 
               Function Method2() As T2
 '                      ^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method2().
 '                              documentation ```vb\nFunction ICovariantContravariant(Of In T1, Out T2).Method2() As T2\n```
-'                                   ^^ reference scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#[T2]
+'                                   ^^ reference local 6
 
           End Interface
 
           Public Class StructConstraintClass(Of T As Structure)
 '                      ^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#StructConstraintClass#
 '                                            documentation ```vb\nClass StructConstraintClass(Of T As Structure)\n```
-'                                               ^ definition scip-dotnet nuget . . VBMain/Classes#StructConstraintClass#[T]
+'                                               ^ definition local 8
 '                                                 documentation ```vb\nT\n```
           End Class
 
           Public Class ClassConstraintClass(Of T As Class)
 '                      ^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ClassConstraintClass#
 '                                           documentation ```vb\nClass ClassConstraintClass(Of T As Class)\n```
-'                                              ^ definition scip-dotnet nuget . . VBMain/Classes#ClassConstraintClass#[T]
+'                                              ^ definition local 9
 '                                                documentation ```vb\nT\n```
           End Class
 
           Public Class NewConstraintClass(Of T As New)
 '                      ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#NewConstraintClass#
 '                                         documentation ```vb\nClass NewConstraintClass(Of T As New)\n```
-'                                            ^ definition scip-dotnet nuget . . VBMain/Classes#NewConstraintClass#[T]
+'                                            ^ definition local 10
 '                                              documentation ```vb\nT\n```
           End Class
 
           Public Class TypeParameterConstraintClass(Of T As SomeInterface)
 '                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#TypeParameterConstraintClass#
 '                                                   documentation ```vb\nClass TypeParameterConstraintClass(Of T As SomeInterface)\n```
-'                                                      ^ definition scip-dotnet nuget . . VBMain/Classes#TypeParameterConstraintClass#[T]
+'                                                      ^ definition local 11
 '                                                        documentation ```vb\nT\n```
 '                                                           ^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Classes#SomeInterface#
           End Class
@@ -132,11 +132,11 @@
           Private Class MultipleTypeParameterConstraintsClass(Of T1 As {SomeInterface, SomeInterface2, New}, T2 As SomeInterface2)
 '                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#MultipleTypeParameterConstraintsClass#
 '                                                             documentation ```vb\nClass MultipleTypeParameterConstraintsClass(Of T1 As {SomeInterface, SomeInterface2, New}, T2 As SomeInterface2)\n```
-'                                                                ^^ definition scip-dotnet nuget . . VBMain/Classes#MultipleTypeParameterConstraintsClass#[T1]
+'                                                                ^^ definition local 12
 '                                                                   documentation ```vb\nT1\n```
 '                                                                       ^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Classes#SomeInterface#
 '                                                                                      ^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Classes#SomeInterface2#
-'                                                                                                            ^^ definition scip-dotnet nuget . . VBMain/Classes#MultipleTypeParameterConstraintsClass#[T2]
+'                                                                                                            ^^ definition local 13
 '                                                                                                               documentation ```vb\nT2\n```
 '                                                                                                                  ^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Classes#SomeInterface2#
           End Class
@@ -151,18 +151,18 @@
               Default Public Property Item(ByVal index As Integer) As Boolean
 '                                     ^^^^ definition scip-dotnet nuget . . VBMain/Classes#IndexClass#Item.
 '                                          documentation ```vb\nPublic Default Property IndexClass.Item(index As Integer) As Boolean\n```
-'                                                ^^^^^ definition scip-dotnet nuget . . VBMain/Classes#IndexClass#Item.(index)
+'                                                ^^^^^ definition local 14
 '                                                      documentation ```vb\nindex As Integer\n```
                   Get
                       Return a
 '                            ^ reference scip-dotnet nuget . . VBMain/Classes#IndexClass#a.
                   End Get
                   Set(ByVal value As Boolean)
-'                           ^^^^^ definition scip-dotnet nuget . . VBMain/Classes#IndexClass#set_Item().(value)
+'                           ^^^^^ definition local 15
 '                                 documentation ```vb\nvalue As Boolean\n```
                       a = value
 '                     ^ reference scip-dotnet nuget . . VBMain/Classes#IndexClass#a.
-'                         ^^^^^ reference scip-dotnet nuget . . VBMain/Classes#IndexClass#set_Item().(value)
+'                         ^^^^^ reference local 15
                   End Set
               End Property
           End Class

--- a/snapshots/output-net7.0/syntax/VBMain/Events.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Events.vb
@@ -25,43 +25,43 @@
 '                                       ^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/EventHandler#
 
               AddHandler(ByVal value As EventHandler)
-'                              ^^^^^ definition scip-dotnet nuget . . VBMain/Events#add_Event2().(value)
+'                              ^^^^^ definition local 0
 '                                    documentation ```vb\nvalue As EventHandler\n```
 '                                       ^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/EventHandler#
                   EventHandlerList.Add(value)
 '                 ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Events#EventHandlerList.
 '                                  ^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 Collections/ArrayList#Add().
-'                                      ^^^^^ reference scip-dotnet nuget . . VBMain/Events#add_Event2().(value)
+'                                      ^^^^^ reference local 0
               End AddHandler
 
               RemoveHandler(ByVal value As EventHandler)
-'                                 ^^^^^ definition scip-dotnet nuget . . VBMain/Events#remove_Event2().(value)
+'                                 ^^^^^ definition local 1
 '                                       documentation ```vb\nvalue As EventHandler\n```
 '                                          ^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/EventHandler#
                   EventHandlerList.Remove(value)
 '                 ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Events#EventHandlerList.
 '                                  ^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 Collections/ArrayList#Remove().
-'                                         ^^^^^ reference scip-dotnet nuget . . VBMain/Events#remove_Event2().(value)
+'                                         ^^^^^ reference local 1
               End RemoveHandler
 
               RaiseEvent(ByVal sender As Object, ByVal e As EventArgs)
-'                              ^^^^^^ definition scip-dotnet nuget . . VBMain/Events#raise_Event2().(sender)
+'                              ^^^^^^ definition local 2
 '                                     documentation ```vb\nsender As Object\n```
-'                                                      ^ definition scip-dotnet nuget . . VBMain/Events#raise_Event2().(e)
+'                                                      ^ definition local 3
 '                                                        documentation ```vb\ne As EventArgs\n```
 '                                                           ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/EventArgs#
                   For Each handler As EventHandler In EventHandlerList
-'                          ^^^^^^^ definition local 0
+'                          ^^^^^^^ definition local 4
 '                                  documentation ```vb\nhandler As Delegate Sub EventHandler(sender As Object, e As EventArgs)\n```
 '                                     ^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/EventHandler#
 '                                                     ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Events#EventHandlerList.
                       If handler IsNot Nothing Then
-'                        ^^^^^^^ reference local 0
+'                        ^^^^^^^ reference local 4
                           handler.BeginInvoke(sender, e, Nothing, Nothing)
-'                         ^^^^^^^ reference local 0
+'                         ^^^^^^^ reference local 4
 '                                 ^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/EventHandler#BeginInvoke().
-'                                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Events#raise_Event2().(sender)
-'                                                     ^ reference scip-dotnet nuget . . VBMain/Events#raise_Event2().(e)
+'                                             ^^^^^^ reference local 2
+'                                                     ^ reference local 3
                       End If
                   Next
               End RaiseEvent

--- a/snapshots/output-net7.0/syntax/VBMain/Expressions.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Expressions.vb
@@ -190,18 +190,18 @@
               Default Public Property Item(ByVal index As Integer) As Integer
 '                                     ^^^^ definition scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Item.
 '                                          documentation ```vb\nPublic Default Property IndexedClass.Item(index As Integer) As Integer\n```
-'                                                ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Item.(index)
+'                                                ^^^^^ definition local 9
 '                                                      documentation ```vb\nindex As Integer\n```
                   Get
                       Return [Property]
 '                            ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Property.
                   End Get
                   Set(ByVal value As Integer)
-'                           ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#IndexedClass#set_Item().(value)
+'                           ^^^^^ definition local 10
 '                                 documentation ```vb\nvalue As Integer\n```
                       [Property] = value
 '                     ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Property.
-'                                  ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#set_Item().(value)
+'                                  ^^^^^ reference local 10
                   End Set
               End Property
           End Structure
@@ -210,58 +210,58 @@
 '                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AssignmentToLeftValueTypes().
 '                                                documentation ```vb\nPrivate Sub Expressions.AssignmentToLeftValueTypes()\n```
               Dim E As (A As Integer, B As Integer) = (1, 2)
-'                 ^ definition local 9
+'                 ^ definition local 11
 '                   documentation ```vb\nE As (A As Integer, B As Integer)\n```
               Dim A = 1
-'                 ^ definition local 10
+'                 ^ definition local 12
 '                   documentation ```vb\nA As Integer\n```
               Dim C = New Struct With {
-'                 ^ definition local 11
+'                 ^ definition local 13
 '                   documentation ```vb\nC As Structure Struct\n```
 '                         ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Struct#
                   .[Property] = 42
 '                  ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Struct#Property.
               }
               C.[Property] = 1
-'             ^ reference local 11
+'             ^ reference local 13
 '               ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Struct#Property.
               Dim D = New IndexedClass()
-'                 ^ definition local 12
+'                 ^ definition local 14
 '                   documentation ```vb\nD As Structure IndexedClass\n```
 '                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#
               D(E.B) = 1
-'             ^ reference local 12
-'               ^ reference local 9
-'                 ^ reference local 14
+'             ^ reference local 14
+'               ^ reference local 11
+'                 ^ reference local 16
               Dim X = New IndexedClass With {
-'                 ^ definition local 15
+'                 ^ definition local 17
 '                   documentation ```vb\nX As Structure IndexedClass\n```
 '                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#
                   .[Property] = 1
 '                  ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Property.
               }
               E.A = 1
-'             ^ reference local 9
-'               ^ reference local 16
+'             ^ reference local 11
+'               ^ reference local 18
           End Sub
 
           Private Sub TernaryExpression()
 '                     ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#TernaryExpression().
 '                                       documentation ```vb\nPrivate Sub Expressions.TernaryExpression()\n```
               Dim X = True
-'                 ^ definition local 17
+'                 ^ definition local 19
 '                   documentation ```vb\nX As Boolean\n```
               Dim Y = If(X, "foo", "bar")
-'                 ^ definition local 18
+'                 ^ definition local 20
 '                   documentation ```vb\nY As String\n```
-'                        ^ reference local 17
+'                        ^ reference local 19
               Dim Z As Object = True
-'                 ^ definition local 19
+'                 ^ definition local 21
 '                   documentation ```vb\nZ As Object\n```
               Dim T = If(TypeOf Z Is Boolean, 42, 41)
-'                 ^ definition local 20
+'                 ^ definition local 22
 '                   documentation ```vb\nT As Integer\n```
-'                               ^ reference local 19
+'                               ^ reference local 21
           End Sub
 
           Class Cast
@@ -279,13 +279,13 @@
               Public Function Plus(ByVal other As Cast) As Cast
 '                             ^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Cast#Plus().
 '                                  documentation ```vb\nPublic Function Cast.Plus(other As Cast) As Cast\n```
-'                                        ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Cast#Plus().(other)
+'                                        ^^^^^ definition local 23
 '                                              documentation ```vb\nother As Cast\n```
 '                                                 ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
 '                                                          ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
                   Nested = other
 '                 ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Nested.
-'                          ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Plus().(other)
+'                          ^^^^^ reference local 23
                   Return Me
               End Function
 
@@ -299,70 +299,70 @@
 '                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#CastExpressions().
 '                                          documentation ```vb\nPrivate Function Expressions.CastExpressions() As Integer\n```
               Dim A As Object = New Cast()
-'                 ^ definition local 21
+'                 ^ definition local 24
 '                   documentation ```vb\nA As Object\n```
 '                                   ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
               Dim B As Object = New Cast()
-'                 ^ definition local 22
+'                 ^ definition local 25
 '                   documentation ```vb\nB As Object\n```
 '                                   ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
               Dim C As Cast = (CType(A, Cast)).Plus(CType(B, Cast))
-'                 ^ definition local 23
+'                 ^ definition local 26
 '                   documentation ```vb\nC As Class Cast\n```
 '                      ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
-'                                    ^ reference local 21
+'                                    ^ reference local 24
 '                                       ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
 '                                              ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Plus().
-'                                                         ^ reference local 22
+'                                                         ^ reference local 25
 '                                                            ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
               Dim D As Cast = CType(New Object() {A, B}(0), Cast)
-'                 ^ definition local 24
+'                 ^ definition local 27
 '                   documentation ```vb\nD As Class Cast\n```
 '                      ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
-'                                                 ^ reference local 21
-'                                                    ^ reference local 22
+'                                                 ^ reference local 24
+'                                                    ^ reference local 25
 '                                                           ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
               Dim E = CType((C.Nested.Nested2), Cast.Cast2)
-'                 ^ definition local 25
+'                 ^ definition local 28
 '                   documentation ```vb\nE As Class Cast2\n```
-'                            ^ reference local 23
+'                            ^ reference local 26
 '                              ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Nested.
 '                                     ^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Nested2.
 '                                               ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
 '                                                    ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Cast2#
               Dim F = CType((1), Int32)
-'                 ^ definition local 26
+'                 ^ definition local 29
 '                   documentation ```vb\nF As Integer\n```
 '                                ^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Int32#
               Dim G = CType((1), Int32)
-'                 ^ definition local 27
+'                 ^ definition local 30
 '                   documentation ```vb\nG As Integer\n```
 '                                ^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Int32#
               Dim H = CType(((1)), Int32)
-'                 ^ definition local 28
+'                 ^ definition local 31
 '                   documentation ```vb\nH As Integer\n```
 '                                  ^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Int32#
               Return F + G + H
-'                    ^ reference local 26
-'                        ^ reference local 27
-'                            ^ reference local 28
+'                    ^ reference local 29
+'                        ^ reference local 30
+'                            ^ reference local 31
           End Function
 
           Private Function AnonymousObject() As Object
 '                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AnonymousObject().
 '                                          documentation ```vb\nPrivate Function Expressions.AnonymousObject() As Object\n```
               Dim X = New With {Key .Helper = ""}
-'                 ^ definition local 29
-'                   documentation ```vb\nX As AnonymousType <anonymous type: Key Helper As String>\n```
-'                                    ^^^^^^ reference local 31
-              Dim Y = New With {X}
 '                 ^ definition local 32
+'                   documentation ```vb\nX As AnonymousType <anonymous type: Key Helper As String>\n```
+'                                    ^^^^^^ reference local 34
+              Dim Y = New With {X}
+'                 ^ definition local 35
 '                   documentation ```vb\nY As AnonymousType <anonymous type: X As AnonymousType <anonymous type: Key Helper As String>>\n```
-'                               ^ reference local 29
+'                               ^ reference local 32
               Return Y.x.Helper
-'                    ^ reference local 32
-'                      ^ reference local 34
-'                        ^^^^^^ reference local 31
+'                    ^ reference local 35
+'                      ^ reference local 37
+'                        ^^^^^^ reference local 34
           End Function
 
           Class ObjectCreationClass
@@ -376,12 +376,12 @@
               Public Sub New(ByVal field As D)
 '                        ^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#`.ctor`().
 '                            documentation ```vb\nPublic Sub ObjectCreationClass.New(field As D)\n```
-'                                  ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#`.ctor`().(field)
+'                                  ^^^^^ definition local 38
 '                                        documentation ```vb\nfield As D\n```
 '                                           ^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#
                   Me.Field = field
 '                    ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#Field.
-'                            ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#`.ctor`().(field)
+'                            ^^^^^ reference local 38
               End Sub
 
               Public Class D
@@ -390,9 +390,9 @@
                   Public Sub New(ByVal a As Integer, ByVal b As String)
 '                            ^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#`.ctor`().
 '                                documentation ```vb\nPublic Sub D.New(a As Integer, b As String)\n```
-'                                      ^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#`.ctor`().(a)
+'                                      ^ definition local 39
 '                                        documentation ```vb\na As Integer\n```
-'                                                          ^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#`.ctor`().(b)
+'                                                          ^ definition local 40
 '                                                            documentation ```vb\nb As String\n```
                   End Sub
               End Class
@@ -402,23 +402,23 @@
 '                     ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreation().
 '                                    documentation ```vb\nPrivate Sub Expressions.ObjectCreation()\n```
               Dim A = New ObjectCreationClass.D(1, "hi")
-'                 ^ definition local 35
+'                 ^ definition local 41
 '                   documentation ```vb\nA As Class D\n```
 '                         ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#
 '                                             ^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#
               Dim B = New ObjectCreationClass(A) With {
-'                 ^ definition local 36
+'                 ^ definition local 42
 '                   documentation ```vb\nB As Class ObjectCreationClass\n```
 '                         ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#
-'                                             ^ reference local 35
+'                                             ^ reference local 41
                   .Field = A
 '                  ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#Field.
-'                          ^ reference local 35
+'                          ^ reference local 41
               }
               B = New ObjectCreationClass(A)
-'             ^ reference local 36
+'             ^ reference local 42
 '                     ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#
-'                                         ^ reference local 35
+'                                         ^ reference local 41
           End Sub
 
           Class NamedParametersClass
@@ -434,31 +434,31 @@
               Public Sub New(ByVal a As Integer, ByVal b As String)
 '                        ^^^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().
 '                            documentation ```vb\nPublic Sub NamedParametersClass.New(a As Integer, b As String)\n```
-'                                  ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(a)
+'                                  ^ definition local 43
 '                                    documentation ```vb\na As Integer\n```
-'                                                      ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(b)
+'                                                      ^ definition local 44
 '                                                        documentation ```vb\nb As String\n```
                   Me.A = a
 '                    ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#A.
-'                        ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(a)
+'                        ^ reference local 43
                   Me.B = b
 '                    ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#B.
-'                        ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(b)
+'                        ^ reference local 44
               End Sub
 
               Public Sub Update(ByVal a As Integer, ByVal b As String)
 '                        ^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().
 '                               documentation ```vb\nPublic Sub NamedParametersClass.Update(a As Integer, b As String)\n```
-'                                     ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(a)
+'                                     ^ definition local 45
 '                                       documentation ```vb\na As Integer\n```
-'                                                         ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(b)
+'                                                         ^ definition local 46
 '                                                           documentation ```vb\nb As String\n```
                   Me.A = a
 '                    ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#A.
-'                        ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(a)
+'                        ^ reference local 45
                   Me.B = b
 '                    ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#B.
-'                        ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(b)
+'                        ^ reference local 46
               End Sub
           End Class
 
@@ -467,38 +467,38 @@
 '                                          documentation ```vb\nPrivate Function Expressions.NamedParameters() As NamedParametersClass\n```
 '                                               ^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#
               Dim A = New NamedParametersClass(b:="hi", a:=1)
-'                 ^ definition local 37
+'                 ^ definition local 47
 '                   documentation ```vb\nA As Class NamedParametersClass\n```
 '                         ^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#
-'                                              ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(b)
-'                                                       ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(a)
+'                                              ^ reference local 44
+'                                                       ^ reference local 43
               A.Update(b:="foo", a:=42)
-'             ^ reference local 37
+'             ^ reference local 47
 '               ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().
-'                      ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(b)
-'                                ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(a)
+'                      ^ reference local 46
+'                                ^ reference local 45
               Return A
-'                    ^ reference local 37
+'                    ^ reference local 47
           End Function
 
           Private Function AnonymousFunction() As Func(Of Integer, Integer)
 '                          ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AnonymousFunction().
 '                                            documentation ```vb\nPrivate Function Expressions.AnonymousFunction() As Func(Of Integer, Integer)\n```
               Dim d = Function(ByVal __ As Integer, ByVal ___ As Integer) 42
-'                 ^ definition local 38
+'                 ^ definition local 48
 '                   documentation ```vb\nd As AnonymousType Function <generated method>(__ As Integer, ___ As Integer) As Integer\n```
-'                                    ^^ definition local 40
+'                                    ^^ definition local 49
 '                                       documentation ```vb\n__ As Integer\n```
-'                                                         ^^^ definition local 41
+'                                                         ^^^ definition local 50
 '                                                             documentation ```vb\n___ As Integer\n```
               Return Function(ByVal a As Integer) a + d.Invoke(a, a)
-'                                   ^ definition local 43
+'                                   ^ definition local 51
 '                                     documentation ```vb\na As Integer\n```
-'                                                 ^ reference local 43
-'                                                     ^ reference local 38
-'                                                       ^^^^^^ reference local 45
-'                                                              ^ reference local 43
-'                                                                 ^ reference local 43
+'                                                 ^ reference local 51
+'                                                     ^ reference local 48
+'                                                       ^^^^^^ reference local 53
+'                                                              ^ reference local 51
+'                                                                 ^ reference local 51
           End Function
 
           Class Lambda
@@ -507,7 +507,7 @@
               Public Function func(ByVal x As Lambda) As String
 '                             ^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Lambda#func().
 '                                  documentation ```vb\nPublic Function Lambda.func(x As Lambda) As String\n```
-'                                        ^ definition scip-dotnet nuget . . VBMain/Expressions#Lambda#func().(x)
+'                                        ^ definition local 54
 '                                          documentation ```vb\nx As Lambda\n```
 '                                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
                   Return ""
@@ -518,30 +518,30 @@
 '                     ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#LambdaExpressions().
 '                                       documentation ```vb\nPrivate Sub Expressions.LambdaExpressions()\n```
               Dim a = Function(ByVal x As String) x & 1
-'                 ^ definition local 46
+'                 ^ definition local 55
 '                   documentation ```vb\na As AnonymousType Function <generated method>(x As String) As String\n```
-'                                    ^ definition local 48
+'                                    ^ definition local 56
 '                                      documentation ```vb\nx As String\n```
-'                                                 ^ reference local 48
+'                                                 ^ reference local 56
               Dim b = Function(ByVal aa As Lambda, ByVal bb As Lambda) aa.func(bb)
-'                 ^ definition local 49
+'                 ^ definition local 57
 '                   documentation ```vb\nb As AnonymousType Function <generated method>(aa As Lambda, bb As Lambda) As String\n```
-'                                    ^^ definition local 51
+'                                    ^^ definition local 58
 '                                       documentation ```vb\naa As Lambda\n```
 '                                          ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
-'                                                        ^^ definition local 52
+'                                                        ^^ definition local 59
 '                                                           documentation ```vb\nbb As Lambda\n```
 '                                                              ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
-'                                                                      ^^ reference local 51
+'                                                                      ^^ reference local 58
 '                                                                         ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#func().
-'                                                                              ^^ reference local 52
+'                                                                              ^^ reference local 59
               Dim c = Function(aaa As Lambda, __ As Lambda)
-'                 ^ definition local 53
+'                 ^ definition local 60
 '                   documentation ```vb\nc As AnonymousType Function <generated method>(aaa As Lambda, __ As Lambda) As String\n```
-'                              ^^^ definition local 55
+'                              ^^^ definition local 61
 '                                  documentation ```vb\naaa As Lambda\n```
 '                                     ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
-'                                             ^^ definition local 56
+'                                             ^^ definition local 62
 '                                                documentation ```vb\n__ As Lambda\n```
 '                                                   ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
                           If True Then
@@ -554,7 +554,7 @@
 '                     ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#TupleExpression().
 '                                     documentation ```vb\nPrivate Sub Expressions.TupleExpression()\n```
               Dim A = (1, 2, "")
-'                 ^ definition local 57
+'                 ^ definition local 63
 '                   documentation ```vb\nA As (Integer, Integer, String)\n```
           End Sub
 
@@ -562,44 +562,44 @@
 '                     ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#ArrayCreation().
 '                                   documentation ```vb\nPrivate Sub Expressions.ArrayCreation()\n```
               Dim a = {
-'                 ^ definition local 58
+'                 ^ definition local 64
 '                   documentation ```vb\na As Integer(*,*)\n```
               {1, 1},
               {2, 2},
               {3, 3}}
               Dim d = New Integer(2) {1, 2, 3}
-'                 ^ definition local 59
+'                 ^ definition local 65
 '                   documentation ```vb\nd As Integer()\n```
               Dim e = New Byte(,) {
-'                 ^ definition local 60
+'                 ^ definition local 66
 '                   documentation ```vb\ne As Byte(*,*)\n```
               {1, 2},
               {2, 3}}
               Dim f = New Integer(2, 1) {
-'                 ^ definition local 61
+'                 ^ definition local 67
 '                   documentation ```vb\nf As Integer(*,*)\n```
               {1, 1},
               {2, 2},
               {3, 3}}
 
               Dim numbers(4) As Integer
-'                 ^^^^^^^ definition local 62
+'                 ^^^^^^^ definition local 68
 '                         documentation ```vb\nnumbers As Integer()\n```
               Dim numbers2 = New Integer() {1, 2, 4, 8}
-'                 ^^^^^^^^ definition local 63
+'                 ^^^^^^^^ definition local 69
 '                          documentation ```vb\nnumbers2 As Integer()\n```
               ReDim Preserve numbers(15)
-'                            ^^^^^^^ reference local 62
+'                            ^^^^^^^ reference local 68
               ReDim numbers(15)
-'                   ^^^^^^^ reference local 62
+'                   ^^^^^^^ reference local 68
               Dim matrix(5, 5) As Double
-'                 ^^^^^^ definition local 64
+'                 ^^^^^^ definition local 70
 '                        documentation ```vb\nmatrix As Double(*,*)\n```
               Dim matrix2 = New Integer(,) {{1, 2, 3}, {2, 3, 4}, {3, 4, 5}, {4, 5, 6}}
-'                 ^^^^^^^ definition local 65
+'                 ^^^^^^^ definition local 71
 '                         documentation ```vb\nmatrix2 As Integer(*,*)\n```
               Dim sales()() As Double = New Double(11)() {}
-'                 ^^^^^ definition local 66
+'                 ^^^^^ definition local 72
 '                       documentation ```vb\nsales As Double()()\n```
           End Sub
 
@@ -607,17 +607,17 @@
 '                     ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#TypeOf().
 '                              documentation ```vb\nPrivate Sub Expressions.TypeOf()\n```
               Dim a = GetType(Integer)
-'                 ^ definition local 67
+'                 ^ definition local 73
 '                   documentation ```vb\na As Class Type\n```
               Dim b = GetType(List(Of String).Enumerator)
-'                 ^ definition local 68
+'                 ^ definition local 74
 '                   documentation ```vb\nb As Class Type\n```
 '                                             ^^^^^^^^^^ reference scip-dotnet nuget System.Collections 7.0.0.0 Generic/List#Enumerator#
               Dim c = GetType(Dictionary(Of,))
-'                 ^ definition local 69
+'                 ^ definition local 75
 '                   documentation ```vb\nc As Class Type\n```
               Dim d = GetType(Tuple(Of,,,))
-'                 ^ definition local 70
+'                 ^ definition local 76
 '                   documentation ```vb\nd As Class Type\n```
           End Sub
 
@@ -625,10 +625,10 @@
 '                     ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#SelectCase().
 '                                documentation ```vb\nPrivate Sub Expressions.SelectCase()\n```
               Dim Some = 42
-'                 ^^^^ definition local 71
+'                 ^^^^ definition local 77
 '                      documentation ```vb\nSome As Integer\n```
               Select Case Some
-'                         ^^^^ reference local 71
+'                         ^^^^ reference local 77
                   Case 1
                       Debug.WriteLine("One")
 '                     ^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 Diagnostics/Debug#
@@ -648,7 +648,7 @@
 '                     ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Dictionary().
 '                                documentation ```vb\nPrivate Sub Expressions.Dictionary()\n```
               Dim A = New Dictionary(Of String, Integer) From {{1, "Test1"}, {2, "Test1"}}
-'                 ^ definition local 72
+'                 ^ definition local 78
 '                   documentation ```vb\nA As Class Dictionary(Of String, Integer)\n```
           End Sub
 

--- a/snapshots/output-net7.0/syntax/VBMain/Fields.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Fields.vb
@@ -29,26 +29,26 @@
               Public Sub New(ByVal field2 As Long, ByVal field3 As Long, ByVal field4 As Tuple(Of Char, Integer?), ByVal field1 As Integer)
 '                        ^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().
 '                            documentation ```vb\nPublic Sub Fields1.New(field2 As Long, field3 As Long, field4 As Tuple(Of Char, Integer?), field1 As Integer)\n```
-'                                  ^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field2)
+'                                  ^^^^^^ definition local 0
 '                                         documentation ```vb\nfield2 As Long\n```
-'                                                        ^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field3)
+'                                                        ^^^^^^ definition local 1
 '                                                               documentation ```vb\nfield3 As Long\n```
-'                                                                              ^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field4)
+'                                                                              ^^^^^^ definition local 2
 '                                                                                     documentation ```vb\nfield4 As Tuple(Of Char, Integer?)\n```
-'                                                                                                                        ^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field1)
+'                                                                                                                        ^^^^^^ definition local 3
 '                                                                                                                               documentation ```vb\nfield1 As Integer\n```
                   Property2 = field2
 '                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#Property2.
-'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field2)
+'                             ^^^^^^ reference local 0
                   Property3 = field3
 '                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#Property3.
-'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field3)
+'                             ^^^^^^ reference local 1
                   Property4 = field4
 '                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#Property4.
-'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field4)
+'                             ^^^^^^ reference local 2
                   Property1 = field1
 '                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#Property1.
-'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field1)
+'                             ^^^^^^ reference local 3
               End Sub
           End Class
       End Class

--- a/snapshots/output-net7.0/syntax/VBMain/GlobalAttributes.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/GlobalAttributes.vb
@@ -30,7 +30,7 @@
               Public Sub New(ByVal name As String)
 '                        ^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#AuthorAttribute#`.ctor`().
 '                            documentation ```vb\nPublic Sub AuthorAttribute.New(name As String)\n```
-'                                  ^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#AuthorAttribute#`.ctor`().(name)
+'                                  ^^^^ definition local 0
 '                                       documentation ```vb\nname As String\n```
               End Sub
           End Class
@@ -77,12 +77,12 @@
           Public Class InnerClass(Of T)
 '                      ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#InnerClass#
 '                                 documentation ```vb\nClass InnerClass(Of T)\n```
-'                                    ^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#InnerClass#[T]
+'                                    ^ definition local 1
 '                                      documentation ```vb\nT\n```
               Private Sub Method(Of T2)()
 '                         ^^^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#InnerClass#Method().
 '                                documentation ```vb\nPrivate Sub InnerClass(Of T).Method(Of T2)()\n```
-'                                   ^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#InnerClass#Method().[T2]
+'                                   ^^ definition local 2
 '                                      documentation ```vb\nT2\n```
               End Sub
           End Class

--- a/snapshots/output-net7.0/syntax/VBMain/Interfaces.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Interfaces.vb
@@ -54,12 +54,12 @@
               Sub Input(ByVal a As String)
 '                 ^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#Input().
 '                       documentation ```vb\nSub IMethods.Input(a As String)\n```
-'                             ^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#Input().(a)
+'                             ^ definition local 0
 '                               documentation ```vb\na As String\n```
               Function InputOutput(ByVal a As String) As Integer
 '                      ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#InputOutput().
 '                                  documentation ```vb\nFunction IMethods.InputOutput(a As String) As Integer\n```
-'                                        ^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#InputOutput().(a)
+'                                        ^ definition local 1
 '                                          documentation ```vb\na As String\n```
           End Interface
 
@@ -77,7 +77,7 @@
               Default Property Item(ByVal index As Integer) As Boolean
 '                              ^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IIndex#Item.
 '                                   documentation ```vb\nDefault Property IIndex.Item(index As Integer) As Boolean\n```
-'                                         ^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IIndex#Item.(index)
+'                                         ^^^^^ definition local 2
 '                                               documentation ```vb\nindex As Integer\n```
           End Interface
 

--- a/snapshots/output-net7.0/syntax/VBMain/Methods.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Methods.vb
@@ -13,95 +13,95 @@
           Private Function SingleParameter(ByVal b As Integer) As Integer
 '                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#SingleParameter().
 '                                          documentation ```vb\nPrivate Function Methods.SingleParameter(b As Integer) As Integer\n```
-'                                                ^ definition scip-dotnet nuget . . VBMain/Methods#SingleParameter().(b)
+'                                                ^ definition local 0
 '                                                  documentation ```vb\nb As Integer\n```
               Return b
-'                    ^ reference scip-dotnet nuget . . VBMain/Methods#SingleParameter().(b)
+'                    ^ reference local 0
           End Function
 
           Private Function TwoParameters(ByVal a As Integer, ByVal b As Integer) As Integer
 '                          ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#TwoParameters().
 '                                        documentation ```vb\nPrivate Function Methods.TwoParameters(a As Integer, b As Integer) As Integer\n```
-'                                              ^ definition scip-dotnet nuget . . VBMain/Methods#TwoParameters().(a)
+'                                              ^ definition local 1
 '                                                documentation ```vb\na As Integer\n```
-'                                                                  ^ definition scip-dotnet nuget . . VBMain/Methods#TwoParameters().(b)
+'                                                                  ^ definition local 2
 '                                                                    documentation ```vb\nb As Integer\n```
               Return a + b
-'                    ^ reference scip-dotnet nuget . . VBMain/Methods#TwoParameters().(a)
-'                        ^ reference scip-dotnet nuget . . VBMain/Methods#TwoParameters().(b)
+'                    ^ reference local 1
+'                        ^ reference local 2
           End Function
 
           Private Function Overload1(ByVal a As Integer) As Integer
 '                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#Overload1().
 '                                    documentation ```vb\nPrivate Function Methods.Overload1(a As Integer) As Integer\n```
-'                                          ^ definition scip-dotnet nuget . . VBMain/Methods#Overload1().(a)
+'                                          ^ definition local 3
 '                                            documentation ```vb\na As Integer\n```
               Return a
-'                    ^ reference scip-dotnet nuget . . VBMain/Methods#Overload1().(a)
+'                    ^ reference local 3
           End Function
 
           Private Function Overload1(ByVal a As Integer, ByVal b As Integer) As Integer
 '                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#Overload1(+1).
 '                                    documentation ```vb\nPrivate Function Methods.Overload1(a As Integer, b As Integer) As Integer\n```
-'                                          ^ definition scip-dotnet nuget . . VBMain/Methods#Overload1(+1).(a)
+'                                          ^ definition local 4
 '                                            documentation ```vb\na As Integer\n```
-'                                                              ^ definition scip-dotnet nuget . . VBMain/Methods#Overload1(+1).(b)
+'                                                              ^ definition local 5
 '                                                                documentation ```vb\nb As Integer\n```
               Return a + b
-'                    ^ reference scip-dotnet nuget . . VBMain/Methods#Overload1(+1).(a)
-'                        ^ reference scip-dotnet nuget . . VBMain/Methods#Overload1(+1).(b)
+'                    ^ reference local 4
+'                        ^ reference local 5
           End Function
 
           Private Function Generic(Of T)(ByVal param As T) As T
 '                          ^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#Generic().
 '                                  documentation ```vb\nPrivate Function Methods.Generic(Of T)(param As T) As T\n```
-'                                     ^ definition scip-dotnet nuget . . VBMain/Methods#Generic().[T]
+'                                     ^ definition local 6
 '                                       documentation ```vb\nT\n```
-'                                              ^^^^^ definition scip-dotnet nuget . . VBMain/Methods#Generic().(param)
+'                                              ^^^^^ definition local 7
 '                                                    documentation ```vb\nparam As T\n```
-'                                                       ^ reference scip-dotnet nuget . . VBMain/Methods#Generic().[T]
-'                                                             ^ reference scip-dotnet nuget . . VBMain/Methods#Generic().[T]
+'                                                       ^ reference local 6
+'                                                             ^ reference local 6
               Return param
-'                    ^^^^^ reference scip-dotnet nuget . . VBMain/Methods#Generic().(param)
+'                    ^^^^^ reference local 7
           End Function
 
           Private Function GenericConstraint(Of T As New)(ByVal param As T) As T
 '                          ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#GenericConstraint().
 '                                            documentation ```vb\nPrivate Function Methods.GenericConstraint(Of T As New)(param As T) As T\n```
-'                                               ^ definition scip-dotnet nuget . . VBMain/Methods#GenericConstraint().[T]
+'                                               ^ definition local 8
 '                                                 documentation ```vb\nT\n```
-'                                                               ^^^^^ definition scip-dotnet nuget . . VBMain/Methods#GenericConstraint().(param)
+'                                                               ^^^^^ definition local 9
 '                                                                     documentation ```vb\nparam As T\n```
-'                                                                        ^ reference scip-dotnet nuget . . VBMain/Methods#GenericConstraint().[T]
-'                                                                              ^ reference scip-dotnet nuget . . VBMain/Methods#GenericConstraint().[T]
+'                                                                        ^ reference local 8
+'                                                                              ^ reference local 8
               Return param
-'                    ^^^^^ reference scip-dotnet nuget . . VBMain/Methods#GenericConstraint().(param)
+'                    ^^^^^ reference local 9
           End Function
 
           Private Sub DefaultParameter(ByVal Optional a As Integer = 5)
 '                     ^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameter().
 '                                      documentation ```vb\nPrivate Sub Methods.DefaultParameter([a As Integer = 5])\n```
-'                                                     ^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameter().(a)
+'                                                     ^ definition local 10
 '                                                       documentation ```vb\n[a As Integer = 5]\n```
           End Sub
 
           Private Function DefaultParameterOverload(ByVal Optional a As Integer = 5) As Integer
 '                          ^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload().
 '                                                   documentation ```vb\nPrivate Function Methods.DefaultParameterOverload([a As Integer = 5]) As Integer\n```
-'                                                                  ^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload().(a)
+'                                                                  ^ definition local 11
 '                                                                    documentation ```vb\n[a As Integer = 5]\n```
               Return DefaultParameterOverload(a, a)
 '                    ^^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload(+1).
-'                                             ^ reference scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload().(a)
-'                                                ^ reference scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload().(a)
+'                                             ^ reference local 11
+'                                                ^ reference local 11
           End Function
 
           Private Function DefaultParameterOverload(ByVal a As Integer, ByVal b As Integer) As Integer
 '                          ^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload(+1).
 '                                                   documentation ```vb\nPrivate Function Methods.DefaultParameterOverload(a As Integer, b As Integer) As Integer\n```
-'                                                         ^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload(+1).(a)
+'                                                         ^ definition local 12
 '                                                           documentation ```vb\na As Integer\n```
-'                                                                             ^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload(+1).(b)
+'                                                                             ^ definition local 13
 '                                                                               documentation ```vb\nb As Integer\n```
               Return DefaultParameterOverload()
 '                    ^^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload().
@@ -153,10 +153,10 @@
               Public Function Method(ByVal parameter As Integer) As Integer
 '                             ^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#Method().
 '                                    documentation ```vb\nPublic Function InheritedOverloads2.Method(parameter As Integer) As Integer\n```
-'                                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#Method().(parameter)
+'                                          ^^^^^^^^^ definition local 14
 '                                                    documentation ```vb\nparameter As Integer\n```
                   Return parameter
-'                        ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#Method().(parameter)
+'                        ^^^^^^^^^ reference local 14
               End Function
           End Class
 
@@ -171,10 +171,10 @@
               Public Function Method(ByVal parameter As String) As String
 '                             ^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#Method().
 '                                    documentation ```vb\nPublic Function InheritedOverloads3.Method(parameter As String) As String\n```
-'                                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#Method().(parameter)
+'                                          ^^^^^^^^^ definition local 15
 '                                                    documentation ```vb\nparameter As String\n```
                   Return parameter
-'                        ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#Method().(parameter)
+'                        ^^^^^^^^^ reference local 15
               End Function
           End Class
 
@@ -182,40 +182,40 @@
 '                           ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads().
 '                                              documentation ```vb\nPublic Shared Sub Methods.InheritedOverloads()\n```
               Dim a As InheritedOverloads1 = New InheritedOverloads1
-'                 ^ definition local 0
+'                 ^ definition local 16
 '                   documentation ```vb\na As Class InheritedOverloads1\n```
 '                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
 '                                                ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
               a.Method()
-'             ^ reference local 0
+'             ^ reference local 16
 '               ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#Method().
               Dim b As InheritedOverloads2 = New InheritedOverloads2
-'                 ^ definition local 1
+'                 ^ definition local 17
 '                   documentation ```vb\nb As Class InheritedOverloads2\n```
 '                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
 '                                                ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
               DirectCast(b, InheritedOverloads1).Method()
-'                        ^ reference local 1
+'                        ^ reference local 17
 '                           ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
 '                                                ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#Method().
               b.Method(42)
-'             ^ reference local 1
+'             ^ reference local 17
 '               ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#Method().
               Dim c As InheritedOverloads3 = New InheritedOverloads3
-'                 ^ definition local 2
+'                 ^ definition local 18
 '                   documentation ```vb\nc As Class InheritedOverloads3\n```
 '                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#
 '                                                ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#
               DirectCast(c, InheritedOverloads1).Method()
-'                        ^ reference local 2
+'                        ^ reference local 18
 '                           ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
 '                                                ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#Method().
               DirectCast(c, InheritedOverloads2).Method(42)
-'                        ^ reference local 2
+'                        ^ reference local 18
 '                           ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
 '                                                ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#Method().
               c.Method("42")
-'             ^ reference local 2
+'             ^ reference local 18
 '               ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#Method().
           End Sub
       End Class

--- a/snapshots/output-net7.0/syntax/VBMain/Modules.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Modules.vb
@@ -13,16 +13,16 @@
           Private Function [Function](ByVal b As Integer) As Integer
 '                          ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Modules#Function().
 '                                     documentation ```vb\nPrivate Function Modules.Function(b As Integer) As Integer\n```
-'                                           ^ definition scip-dotnet nuget . . VBMain/Modules#Function().(b)
+'                                           ^ definition local 0
 '                                             documentation ```vb\nb As Integer\n```
               Return b
-'                    ^ reference scip-dotnet nuget . . VBMain/Modules#Function().(b)
+'                    ^ reference local 0
           End Function
 
           Private Sub [Sub](ByVal Optional a As Integer = 5)
 '                     ^^^^^ definition scip-dotnet nuget . . VBMain/Modules#Sub().
 '                           documentation ```vb\nPrivate Sub Modules.Sub([a As Integer = 5])\n```
-'                                          ^ definition scip-dotnet nuget . . VBMain/Modules#Sub().(a)
+'                                          ^ definition local 1
 '                                            documentation ```vb\n[a As Integer = 5]\n```
           End Sub
 

--- a/snapshots/output-net7.0/syntax/VBMain/Operators.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Operators.vb
@@ -14,24 +14,24 @@
 '                      ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#
 '                                documentation ```vb\nClass PlusMinus\n```
               Public Shared Operator +(A As PlusMinus)
-'                                      ^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#op_UnaryPlus().(A)
+'                                      ^ definition local 0
 '                                        documentation ```vb\nA As PlusMinus\n```
 '                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#PlusMinus#
                   Return 0
               End Operator
 
               Public Shared Operator +(A As PlusMinus, B As PlusMinus)
-'                                      ^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#op_Addition().(A)
+'                                      ^ definition local 1
 '                                        documentation ```vb\nA As PlusMinus\n```
 '                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#PlusMinus#
-'                                                      ^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#op_Addition().(B)
+'                                                      ^ definition local 2
 '                                                        documentation ```vb\nB As PlusMinus\n```
 '                                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#PlusMinus#
                   Return 0
               End Operator
 
               Public Shared Operator -(A As PlusMinus)
-'                                      ^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#op_UnaryNegation().(A)
+'                                      ^ definition local 3
 '                                        documentation ```vb\nA As PlusMinus\n```
 '                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#PlusMinus#
                   Return 0
@@ -42,34 +42,34 @@
 '                      ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#
 '                                documentation ```vb\nClass TrueFalse\n```
               Public Shared Operator IsTrue(A As TrueFalse) As Boolean
-'                                           ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_True().(A)
+'                                           ^ definition local 4
 '                                             documentation ```vb\nA As TrueFalse\n```
 '                                                ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
                   Return True
               End Operator
 
               Public Shared Operator IsFalse(A As TrueFalse) As Boolean
-'                                            ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_False().(A)
+'                                            ^ definition local 5
 '                                              documentation ```vb\nA As TrueFalse\n```
 '                                                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
                   Return False
               End Operator
 
               Public Shared Operator =(A As TrueFalse, B As TrueFalse) As Boolean
-'                                      ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_Equality().(A)
+'                                      ^ definition local 6
 '                                        documentation ```vb\nA As TrueFalse\n```
 '                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
-'                                                      ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_Equality().(B)
+'                                                      ^ definition local 7
 '                                                        documentation ```vb\nB As TrueFalse\n```
 '                                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
                   Return True
               End Operator
 
               Public Shared Operator <>(A As TrueFalse, B As TrueFalse) As Boolean
-'                                       ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_Inequality().(A)
+'                                       ^ definition local 8
 '                                         documentation ```vb\nA As TrueFalse\n```
 '                                            ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
-'                                                       ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_Inequality().(B)
+'                                                       ^ definition local 9
 '                                                         documentation ```vb\nB As TrueFalse\n```
 '                                                            ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
                   Return True
@@ -79,21 +79,21 @@
 '                                       ^^^^^^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().
 '                                              documentation ```vb\nPublic Overrides Function TrueFalse.Equals(obj As Object) As Boolean\n```
 '                                              relationship implementation reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Object#Equals().
-'                                              ^^^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+'                                              ^^^ definition local 10
 '                                                  documentation ```vb\nobj As Object\n```
                   If ReferenceEquals(Nothing, obj) Then Return False
 '                    ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Object#ReferenceEquals().
-'                                             ^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+'                                             ^^^ reference local 10
                   If ReferenceEquals(Me, obj) Then Return True
 '                    ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Object#ReferenceEquals().
-'                                        ^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+'                                        ^^^ reference local 10
                   If obj.GetType() <> Me.GetType() Then Return False
-'                    ^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+'                    ^^^ reference local 10
 '                        ^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Object#GetType().
 '                                        ^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/Object#GetType().
                   Return Equals(CType(obj, TrueFalse))
 '                        ^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().
-'                                     ^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+'                                     ^^^ reference local 10
 '                                          ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
               End Function
 

--- a/snapshots/output-net7.0/syntax/VBMain/Program.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Program.vb
@@ -4,7 +4,7 @@
       Sub Main(args As String())
 '         ^^^^ definition scip-dotnet nuget . . VBMain/Program#Main().
 '              documentation ```vb\nPublic Sub Program.Main(args As String())\n```
-'              ^^^^ definition scip-dotnet nuget . . VBMain/Program#Main().(args)
+'              ^^^^ definition local 0
 '                   documentation ```vb\nargs As String()\n```
 
           Console.WriteLine("Hello, World!")

--- a/snapshots/output-net7.0/syntax/VBMain/Properties.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Properties.vb
@@ -18,7 +18,7 @@
 '                                    ^^^^^ definition scip-dotnet nuget . . VBMain/Properties#Set.
 '                                          documentation ```vb\nPrivate WriteOnly Property Properties.Set As Char\n```
               Set(ByVal value As Char)
-'                       ^^^^^ definition scip-dotnet nuget . . VBMain/Properties#set_Set().(value)
+'                       ^^^^^ definition local 0
 '                             documentation ```vb\nvalue As Char\n```
                   Throw New NotImplementedException()
 '                           ^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 System/NotImplementedException#

--- a/snapshots/output-net7.0/syntax/VBMain/QuerySyntax.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/QuerySyntax.vb
@@ -155,25 +155,25 @@
           Private Sub Into(Students As List(Of Student))
 '                     ^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Into().
 '                          documentation ```vb\nPrivate Sub QuerySyntax.Into(Students As List(Of Student))\n```
-'                          ^^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Into().(Students)
+'                          ^^^^^^^^ definition local 23
 '                                   documentation ```vb\nStudents As List(Of Student)\n```
 '                                              ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Student#
               Dim sortedGroups = From student In Students Order By student.Last, student.First Group student By student.Last Into newGroup = Group Order By newGroup
-'                 ^^^^^^^^^^^^ definition local 23
+'                 ^^^^^^^^^^^^ definition local 24
 '                              documentation ```vb\nsortedGroups As Interface IOrderedEnumerable(Of <anonymous type: Key Last As String, Key newGroup As Interface IEnumerable(Of Student)>)\n```
-'                                     ^^^^^^^ definition local 24
+'                                     ^^^^^^^ definition local 25
 '                                             documentation ```vb\nstudent As Class Student\n```
-'                                                ^^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Into().(Students)
-'                                                                  ^^^^^^^ reference local 24
+'                                                ^^^^^^^^ reference local 23
+'                                                                  ^^^^^^^ reference local 25
 '                                                                          ^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Student#Last.
-'                                                                                ^^^^^^^ reference local 24
+'                                                                                ^^^^^^^ reference local 25
 '                                                                                        ^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Student#First.
-'                                                                                                    ^^^^^^^ reference local 24
-'                                                                                                               ^^^^^^^ reference local 24
+'                                                                                                    ^^^^^^^ reference local 25
+'                                                                                                               ^^^^^^^ reference local 25
 '                                                                                                                       ^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Student#Last.
-'                                                                                                                                 ^^^^^^^^ definition local 25
+'                                                                                                                                 ^^^^^^^^ definition local 26
 '                                                                                                                                          documentation ```vb\nnewGroup As Interface IEnumerable(Of Student)\n```
-'                                                                                                                                                           ^^^^^^^^ reference local 25
+'                                                                                                                                                           ^^^^^^^^ reference local 26
           End Sub
 
           Private Class Student

--- a/snapshots/output-net7.0/syntax/VBMain/Statements.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Statements.vb
@@ -67,30 +67,30 @@
 '                        documentation ```vb\nResult As Interface IEnumerable(Of (F1 As Integer, F2 As Integer))\n```
 '                          ^^^^ reference local 2
 '                               ^^^^^^ reference scip-dotnet nuget System.Linq 7.0.0.0 Linq/Enumerable#Select().
-'                                               ^ definition local 5
+'                                               ^ definition local 4
 '                                                 documentation ```vb\nc As Inferred\n```
-'                                                   ^ reference local 5
+'                                                   ^ reference local 4
 '                                                     ^^ reference scip-dotnet nuget . . VBMain/Statements#Inferred#F1.
-'                                                         ^ reference local 5
+'                                                         ^ reference local 4
 '                                                           ^^ reference scip-dotnet nuget . . VBMain/Statements#Inferred#F2.
 '                                                                ^^^^^ reference scip-dotnet nuget System.Linq 7.0.0.0 Linq/Enumerable#Where().
-'                                                                               ^ definition local 7
+'                                                                               ^ definition local 5
 '                                                                                 documentation ```vb\nt As (F1 As Integer, F2 As Integer)\n```
-'                                                                                  ^ reference local 7
-'                                                                                    ^^ reference local 9
+'                                                                                  ^ reference local 5
+'                                                                                    ^^ reference local 7
           End Sub
 
           Private Function MultipleInitializers() As Integer
 '                          ^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#MultipleInitializers().
 '                                               documentation ```vb\nPrivate Function Statements.MultipleInitializers() As Integer\n```
               Dim a As Integer = 1, b As Integer = 2
-'                 ^ definition local 10
+'                 ^ definition local 8
 '                   documentation ```vb\na As Integer\n```
-'                                   ^ definition local 11
+'                                   ^ definition local 9
 '                                     documentation ```vb\nb As Integer\n```
               Return a + b
-'                    ^ reference local 10
-'                        ^ reference local 11
+'                    ^ reference local 8
+'                        ^ reference local 9
           End Function
 
           Class MyDisposable
@@ -116,16 +116,16 @@
 '                                  documentation ```vb\nPrivate Function Statements.Using() As MyDisposable\n```
 '                                       ^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Statements#MyDisposable#
               Dim b = New MyDisposable()
-'                 ^ definition local 12
+'                 ^ definition local 10
 '                   documentation ```vb\nb As Class MyDisposable\n```
 '                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Statements#MyDisposable#
 
               Using a = b
-'                   ^ definition local 13
+'                   ^ definition local 11
 '                     documentation ```vb\na As Class MyDisposable\n```
-'                       ^ reference local 12
+'                       ^ reference local 10
                   Return a
-'                        ^ reference local 13
+'                        ^ reference local 11
               End Using
           End Function
 
@@ -133,20 +133,20 @@
 '                          ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#MultipleUsing().
 '                                        documentation ```vb\nPrivate Function Statements.MultipleUsing() As Long\n```
               Using a As Stream = File.OpenRead("a"), b As Stream = File.OpenRead("a")
-'                   ^ definition local 14
+'                   ^ definition local 12
 '                     documentation ```vb\na As Class Stream\n```
 '                        ^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 IO/Stream#
 '                                 ^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 IO/File#
 '                                      ^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 IO/File#OpenRead().
-'                                                     ^ definition local 15
+'                                                     ^ definition local 13
 '                                                       documentation ```vb\nb As Class Stream\n```
 '                                                          ^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 IO/Stream#
 '                                                                   ^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 IO/File#
 '                                                                        ^^^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 IO/File#OpenRead().
                   Return a.Length + b.Length
-'                        ^ reference local 14
+'                        ^ reference local 12
 '                          ^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 IO/Stream#Length.
-'                                   ^ reference local 15
+'                                   ^ reference local 13
 '                                     ^^^^^^ reference scip-dotnet nuget System.Runtime 7.0.0.0 IO/Stream#Length.
               End Using
           End Function
@@ -155,23 +155,23 @@
 '                          ^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Foreach().
 '                                  documentation ```vb\nPrivate Function Statements.Foreach() As Integer\n```
               Dim y = New Integer() {1}
-'                 ^ definition local 16
+'                 ^ definition local 14
 '                   documentation ```vb\ny As Integer()\n```
               Dim z = 0
-'                 ^ definition local 17
+'                 ^ definition local 15
 '                   documentation ```vb\nz As Integer\n```
 
               For Each x As Integer In y
-'                      ^ definition local 18
+'                      ^ definition local 16
 '                        documentation ```vb\nx As Integer\n```
-'                                      ^ reference local 16
+'                                      ^ reference local 14
                   z += x
-'                 ^ reference local 17
-'                      ^ reference local 18
+'                 ^ reference local 15
+'                      ^ reference local 16
               Next
 
               Return z
-'                    ^ reference local 17
+'                    ^ reference local 15
           End Function
 
       End Class

--- a/snapshots/output-net7.0/syntax/VBMain/Structs.vb
+++ b/snapshots/output-net7.0/syntax/VBMain/Structs.vb
@@ -20,11 +20,11 @@
               Public Sub New(ByVal field1 As Integer)
 '                        ^^^ definition scip-dotnet nuget . . VBMain/Structs#BasicStruct#`.ctor`(+1).
 '                            documentation ```vb\nPublic Sub BasicStruct.New(field1 As Integer)\n```
-'                                  ^^^^^^ definition scip-dotnet nuget . . VBMain/Structs#BasicStruct#`.ctor`(+1).(field1)
+'                                  ^^^^^^ definition local 0
 '                                         documentation ```vb\nfield1 As Integer\n```
                   Property1 = field1
 '                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Structs#BasicStruct#Property1.
-'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Structs#BasicStruct#`.ctor`(+1).(field1)
+'                             ^^^^^^ reference local 0
               End Sub
           End Structure
       End Class


### PR DESCRIPTION
Hello @olafurpg,

This PR is a follow up to the discussion we had [here](https://github.com/sourcegraph/scip-dotnet/pull/37#discussion_r1255382577).

I also have a bunch of questions that popped up while I was creating this PR. I hope you can help me answering them.

- Should type parameters be local?
  - Type parameters are not local in java, see [test case](https://github.com/sourcegraph/scip-java/blob/5028089e21c0484fa4c26e38179e82e8dd7dcad8/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyTouchCallback.java#L8).
  - They are not local for typescript either. ([test case](https://github.com/sourcegraph/scip-typescript/blob/05e74c4b750990cf7868338500becce33a7997a0/snapshots/output/syntax/src/type-parameter.ts#L1))
  - In clang indexer the type parameters are local ([test case](https://github.com/sourcegraph/scip-clang/blob/a3f9908d6b79fc5e7b1fb5462653ac1e171d512d/test/index/types/bad_tagdecl.snapshot.cc#L13))
  - In go they are local too ([test case](https://github.com/sourcegraph/scip-go/blob/263821315ff57f8fd38c26d946cc302ed5a89ac7/internal/testdata/snapshots/output/inlinestruct/inlinestruct_genericindex.go#L4))
  - For python I cannot see any tests with TypeVar
- Should parameters be local?
  - In java they are ([test case](https://github.com/sourcegraph/scip-java/blob/5028089e21c0484fa4c26e38179e82e8dd7dcad8/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyAdapter.java#L186))
  - For Clang they are not ([test case](https://github.com/sourcegraph/scip-clang/blob/a3f9908d6b79fc5e7b1fb5462653ac1e171d512d/test/index/functions/methods.snapshot.cc#L114))
  - For go they are not ([test case](https://github.com/sourcegraph/scip-go/blob/263821315ff57f8fd38c26d946cc302ed5a89ac7/internal/testdata/snapshots/output/inlinestruct/inlinestruct_genericindex.go#L28))
  - For typescript they are not ([test case](https://github.com/sourcegraph/scip-typescript/blob/05e74c4b750990cf7868338500becce33a7997a0/snapshots/output/syntax/src/type-parameter.ts#L1))
  - For python they are not ([test case](https://github.com/sourcegraph/scip-python/blob/8a21e88ad5da866f6c345af08d95669910968ef6/packages/pyright-scip/snapshots/output/single_function/src/single_function.py#L26))

Also if making a symbol local helps with search because it does not go outside of the document to look for it, would it make sense to make all types/members local that are not visible outside of the document. Examples for C#:

- private nested types
- private members (fields, properties, methods, etc.)
- file scoped types (https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/file)

In general this could be applied to all languages that have the concept of access modifiers (java, c++, etc.).
My only concern here is, if for example methods will be indexed as local, will they still show up correctly in the UI as methods or will they look like local variables?

I have one last question that is not related to global vs local symbols. While I was playing around with the C# implementation I realized that the support for [partial classes and methods](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/partial-classes-and-methods) is not correct. For example both parts of a partial class declaration will create the same symbol definition, if I add a UT test case it will fail, however if users run the indexer it will not fail but generate two symbol definitions. Do you know how this will affect the products consuming the indexes?