### PR TITLE
Add net8.0 support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,16 +10,18 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
       - run: dotnet pack
-      - run: dotnet nuget push 'ScipDotnet/bin/Debug/*.nupkg' --source 'nuget.org' --api-key '${{ secrets.NUGET_APIKEY }}' --skip-duplicate
+      - run:
+          dotnet nuget push 'ScipDotnet/bin/Debug/*.nupkg' --source 'nuget.org'
+          --api-key '${{ secrets.NUGET_APIKEY }}' --skip-duplicate
   docker-push:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
       - uses: docker/setup-buildx-action@v2
       - run: echo "PATCH=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
       - run: echo "MINOR=${PATCH%.*}" >> $GITHUB_ENV
@@ -39,4 +41,3 @@ jobs:
             sourcegraph/scip-dotnet:${{ env.PATCH }}
             sourcegraph/scip-dotnet:${{ env.MINOR }}
             sourcegraph/scip-dotnet:${{ env.MAJOR }}
-          

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
       - run: dotnet format --verify-no-changes
       - run: dotnet format --verify-no-changes
         working-directory: snapshots/input/syntax
@@ -28,5 +28,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
       - run: dotnet test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 WORKDIR /scip-dotnet
 ADD . /scip-dotnet
 RUN dotnet pack

--- a/ScipDotnet.Tests/ScipDotnet.Tests.csproj
+++ b/ScipDotnet.Tests/ScipDotnet.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/ScipDotnet/ScipDotnet.csproj
+++ b/ScipDotnet/ScipDotnet.csproj
@@ -8,7 +8,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
     <PackageType>DotnetTool</PackageType>
-    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <AssemblyName>scip-dotnet</AssemblyName>
     <RepositoryUrl>https://github.com/sourcegraph/scip-dotnet</RepositoryUrl>

--- a/snapshots/input/syntax/Main/Main.csproj
+++ b/snapshots/input/syntax/Main/Main.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>

--- a/snapshots/input/syntax/VBMain/VBMain.vbproj
+++ b/snapshots/input/syntax/VBMain/VBMain.vbproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>VBMain</RootNamespace>
-    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/snapshots/output-net8.0/WpfApplication/WpfApplication/App.xaml.cs
+++ b/snapshots/output-net8.0/WpfApplication/WpfApplication/App.xaml.cs
@@ -1,0 +1,12 @@
+  using System.Windows;
+
+  namespace WpfApplication
+//          ^^^^^^^^^^^^^^ reference scip-dotnet nuget . . WpfApplication/
+  {
+      public partial class App : Application
+//                         ^^^ definition scip-dotnet nuget . . WpfApplication/App#
+//                             documentation ```cs\nclass App\n```
+//                             relationship implementation scip-dotnet nuget . . ``/Application#
+      {
+      }
+  }

--- a/snapshots/output-net8.0/WpfApplication/WpfApplication/AssemblyInfo.cs
+++ b/snapshots/output-net8.0/WpfApplication/WpfApplication/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+  using System.Windows;
+
+  [assembly: ThemeInfo(
+      ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
+                                       //(used if a resource is not found in the page,
+                                       // or application resource dictionaries)
+      ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
+                                                //(used if a resource is not found in the page,
+                                                // app, or any theme specific resource dictionaries)
+  )]

--- a/snapshots/output-net8.0/WpfApplication/WpfApplication/MainWindow.xaml.cs
+++ b/snapshots/output-net8.0/WpfApplication/WpfApplication/MainWindow.xaml.cs
@@ -1,0 +1,18 @@
+  using System.Windows;
+
+  namespace WpfApplication
+//          ^^^^^^^^^^^^^^ reference scip-dotnet nuget . . WpfApplication/
+  {
+      public partial class MainWindow : Window
+//                         ^^^^^^^^^^ definition scip-dotnet nuget . . WpfApplication/MainWindow#
+//                                    documentation ```cs\nclass MainWindow\n```
+//                                    relationship implementation scip-dotnet nuget . . ``/Window#
+      {
+          public MainWindow()
+//               ^^^^^^^^^^ definition scip-dotnet nuget . . WpfApplication/MainWindow#`.ctor`().
+//                          documentation ```cs\npublic MainWindow.MainWindow()\n```
+          {
+              InitializeComponent();
+          }
+      }
+  }

--- a/snapshots/output-net8.0/syntax/Main/Classes.cs
+++ b/snapshots/output-net8.0/syntax/Main/Classes.cs
@@ -1,0 +1,218 @@
+  using System.Diagnostics.CodeAnalysis;
+//      ^^^^^^ reference scip-dotnet nuget . . System/
+//             ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+//                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  namespace Main;
+//          ^^^^ reference scip-dotnet nuget . . Main/
+
+  [SuppressMessage("ReSharper", "all")]
+// ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+  public class Classes
+//             ^^^^^^^ definition scip-dotnet nuget . . Main/Classes#
+//                     documentation ```cs\nclass Classes\n```
+  {
+      public string Name;
+//                  ^^^^ definition scip-dotnet nuget . . Main/Classes#Name.
+//                       documentation ```cs\npublic string Classes.Name\n```
+      public const int IntConstant = 1;
+//                     ^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#IntConstant.
+//                                 documentation ```cs\npublic const int Classes.IntConstant = 1\n```
+      public const string StringConstant = $"hello";
+//                        ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#StringConstant.
+//                                       documentation ```cs\npublic const string Classes.StringConstant = "hello"\n```
+
+      public Classes(int name)
+//           ^^^^^^^ definition scip-dotnet nuget . . Main/Classes#`.ctor`().
+//                   documentation ```cs\npublic Classes.Classes(int name)\n```
+//                       ^^^^ definition scip-dotnet nuget . . Main/Classes#`.ctor`().(name)
+//                            documentation ```cs\nint name\n```
+      {
+          Name = "name";
+//        ^^^^ reference scip-dotnet nuget . . Main/Classes#Name.
+      }
+
+      public Classes(string name) => Name = name;
+//           ^^^^^^^ definition scip-dotnet nuget . . Main/Classes#`.ctor`(+1).
+//                   documentation ```cs\npublic Classes.Classes(string name)\n```
+//                          ^^^^ definition scip-dotnet nuget . . Main/Classes#`.ctor`(+1).(name)
+//                               documentation ```cs\nstring name\n```
+//                                   ^^^^ reference scip-dotnet nuget . . Main/Classes#Name.
+//                                          ^^^^ reference scip-dotnet nuget . . Main/Classes#`.ctor`(+1).(name)
+
+      ~Classes()
+//     ^^^^^^^ definition scip-dotnet nuget . . Main/Classes#Finalize().
+//             documentation ```cs\nprotected Classes.~Classes()\n```
+      {
+          Console.WriteLine(42);
+//        ^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#
+//                ^^^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#WriteLine(+7).
+      }
+
+      public class ObjectClass : object, SomeInterface
+//                 ^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#ObjectClass#
+//                             documentation ```cs\nclass ObjectClass\n```
+//                             relationship implementation scip-dotnet nuget . . Main/SomeInterface#
+//                                       ^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/SomeInterface#
+      {
+      }
+
+      public partial class PartialClass
+//                         ^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#PartialClass#
+//                                      documentation ```cs\nclass PartialClass\n```
+      {
+      }
+
+      class TypeParameterClass<T>
+//          ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#TypeParameterClass#
+//                             documentation ```cs\nclass TypeParameterClass<T>\n```
+//                             ^ definition local 0
+//                               documentation ```cs\nT\n```
+      {
+      }
+
+      internal class InternalMultipleTypeParametersClass<T1, T2>
+//                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#InternalMultipleTypeParametersClass#
+//                                                       documentation ```cs\nclass InternalMultipleTypeParametersClass<T1, T2>\n```
+//                                                       ^^ definition local 1
+//                                                          documentation ```cs\nT1\n```
+//                                                           ^^ definition local 2
+//                                                              documentation ```cs\nT2\n```
+      {
+      }
+
+      interface ICovariantContravariant<in T1, out T2>
+//              ^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#ICovariantContravariant#
+//                                      documentation ```cs\ninterface ICovariantContravariant<in T1, out T2>\n```
+//                                         ^^ definition local 3
+//                                            documentation ```cs\nin T1\n```
+//                                                 ^^ definition local 4
+//                                                    documentation ```cs\nout T2\n```
+      {
+          public void Method1(T1 t1)
+//                    ^^^^^^^ definition scip-dotnet nuget . . Main/Classes#ICovariantContravariant#Method1().
+//                            documentation ```cs\nvoid ICovariantContravariant<in T1, out T2>.Method1(T1 t1)\n```
+//                            ^^ reference local 3
+//                               ^^ definition scip-dotnet nuget . . Main/Classes#ICovariantContravariant#Method1().(t1)
+//                                  documentation ```cs\nT1 t1\n```
+          {
+              Console.WriteLine(t1);
+//            ^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#
+//                    ^^^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#WriteLine(+9).
+//                              ^^ reference scip-dotnet nuget . . Main/Classes#ICovariantContravariant#Method1().(t1)
+          }
+
+          public T2? Method2()
+//               ^^ reference local 4
+//                   ^^^^^^^ definition scip-dotnet nuget . . Main/Classes#ICovariantContravariant#Method2().
+//                           documentation ```cs\nT2? ICovariantContravariant<in T1, out T2>.Method2()\n```
+          {
+              return default(T2);
+//                           ^^ reference local 4
+          }
+      }
+
+      public class StructConstraintClass<T> where T : struct
+//                 ^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#StructConstraintClass#
+//                                       documentation ```cs\nclass StructConstraintClass<T> where T : struct\n```
+//                                       ^ definition local 5
+//                                         documentation ```cs\nT\n```
+//                                                ^ reference local 5
+      {
+      }
+
+      public class UnmanagedConstraintClass<T> where T : unmanaged
+//                 ^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#UnmanagedConstraintClass#
+//                                          documentation ```cs\nclass UnmanagedConstraintClass<T> where T : unmanaged\n```
+//                                          ^ definition local 6
+//                                            documentation ```cs\nT\n```
+//                                                   ^ reference local 6
+      {
+      }
+
+      public class ClassConstraintClass<T> where T : class
+//                 ^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#ClassConstraintClass#
+//                                      documentation ```cs\nclass ClassConstraintClass<T> where T : class\n```
+//                                      ^ definition local 7
+//                                        documentation ```cs\nT\n```
+//                                               ^ reference local 7
+      {
+      }
+
+      public class NonNullableConstraintClass<T> where T : notnull
+//                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#NonNullableConstraintClass#
+//                                            documentation ```cs\nclass NonNullableConstraintClass<T> where T : notnull\n```
+//                                            ^ definition local 8
+//                                              documentation ```cs\nT\n```
+//                                                     ^ reference local 8
+      {
+      }
+
+      public class NewConstraintClass<T> where T : new()
+//                 ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#NewConstraintClass#
+//                                    documentation ```cs\nclass NewConstraintClass<T> where T : new()\n```
+//                                    ^ definition local 9
+//                                      documentation ```cs\nT\n```
+//                                             ^ reference local 9
+      {
+      }
+
+      public class TypeParameterConstraintClass<T> where T : SomeInterface
+//                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#TypeParameterConstraintClass#
+//                                              documentation ```cs\nclass TypeParameterConstraintClass<T> where T : SomeInterface\n```
+//                                              ^ definition local 10
+//                                                documentation ```cs\nT\n```
+//                                                       ^ reference local 10
+//                                                           ^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/SomeInterface#
+      {
+      }
+
+      private class MultipleTypeParameterConstraintsClass<T1, T2> where T1 : SomeInterface, SomeInterface2, new()
+//                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#MultipleTypeParameterConstraintsClass#
+//                                                        documentation ```cs\nclass MultipleTypeParameterConstraintsClass<T1, T2> where T1 : SomeInterface, SomeInterface2, new() where T2 : SomeInterface2\n```
+//                                                        ^^ definition local 11
+//                                                           documentation ```cs\nT1\n```
+//                                                            ^^ definition local 12
+//                                                               documentation ```cs\nT2\n```
+//                                                                      ^^ reference local 11
+//                                                                           ^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/SomeInterface#
+//                                                                                          ^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/SomeInterface2#
+          where T2 : SomeInterface2
+//              ^^ reference local 12
+//                   ^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/SomeInterface2#
+      {
+      }
+
+      class IndexClass
+//          ^^^^^^^^^^ definition scip-dotnet nuget . . Main/Classes#IndexClass#
+//                     documentation ```cs\nclass IndexClass\n```
+      {
+          private bool a;
+//                     ^ definition scip-dotnet nuget . . Main/Classes#IndexClass#a.
+//                       documentation ```cs\nprivate bool IndexClass.a\n```
+
+          public bool this[int index]
+//                             ^^^^^ definition scip-dotnet nuget . . Main/Classes#IndexClass#`this[]`.(index)
+//                                   documentation ```cs\nint index\n```
+          {
+              get { return a; }
+//                         ^ reference scip-dotnet nuget . . Main/Classes#IndexClass#a.
+              set { a = value; }
+//                  ^ reference scip-dotnet nuget . . Main/Classes#IndexClass#a.
+//                      ^^^^^ reference scip-dotnet nuget . . Main/Classes#IndexClass#set_Item().(value)
+          }
+      }
+
+  }
+
+  public interface SomeInterface
+//                 ^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/SomeInterface#
+//                               documentation ```cs\ninterface SomeInterface\n```
+  {
+  }
+
+  internal interface SomeInterface2
+//                   ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/SomeInterface2#
+//                                  documentation ```cs\ninterface SomeInterface2\n```
+  {
+  }

--- a/snapshots/output-net8.0/syntax/Main/Enums.cs
+++ b/snapshots/output-net8.0/syntax/Main/Enums.cs
@@ -1,0 +1,46 @@
+  using System.Diagnostics.CodeAnalysis;
+//      ^^^^^^ reference scip-dotnet nuget . . System/
+//             ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+//                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  namespace Main;
+//          ^^^^ reference scip-dotnet nuget . . Main/
+
+  [SuppressMessage("ReSharper", "all")]
+// ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+  public class Enums
+//             ^^^^^ definition scip-dotnet nuget . . Main/Enums#
+//                   documentation ```cs\nclass Enums\n```
+  {
+      enum EnumWithIntValues
+//         ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Enums#EnumWithIntValues#
+//                           documentation ```cs\nenum EnumWithIntValues\n```
+//                           relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IComparable#
+//                           relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IConvertible#
+//                           relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/ISpanFormattable#
+//                           relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IFormattable#
+      {
+          Ten = 10,
+//        ^^^ definition scip-dotnet nuget . . Main/Enums#EnumWithIntValues#Ten.
+//            documentation ```cs\nEnumWithIntValues.Ten = 10\n```
+          Twenty = 20
+//        ^^^^^^ definition scip-dotnet nuget . . Main/Enums#EnumWithIntValues#Twenty.
+//               documentation ```cs\nEnumWithIntValues.Twenty = 20\n```
+      }
+
+      enum EnumWithByteValues
+//         ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Enums#EnumWithByteValues#
+//                            documentation ```cs\nenum EnumWithByteValues\n```
+//                            relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IComparable#
+//                            relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IConvertible#
+//                            relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/ISpanFormattable#
+//                            relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IFormattable#
+      {
+          Five = 0x05,
+//        ^^^^ definition scip-dotnet nuget . . Main/Enums#EnumWithByteValues#Five.
+//             documentation ```cs\nEnumWithByteValues.Five = 5\n```
+          Fifteen = 0x0F
+//        ^^^^^^^ definition scip-dotnet nuget . . Main/Enums#EnumWithByteValues#Fifteen.
+//                documentation ```cs\nEnumWithByteValues.Fifteen = 15\n```
+      }
+  }

--- a/snapshots/output-net8.0/syntax/Main/Events.cs
+++ b/snapshots/output-net8.0/syntax/Main/Events.cs
@@ -1,0 +1,49 @@
+  using System.Diagnostics.CodeAnalysis;
+//      ^^^^^^ reference scip-dotnet nuget . . System/
+//             ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+//                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  namespace Main;
+//          ^^^^ reference scip-dotnet nuget . . Main/
+
+  [SuppressMessage("ReSharper", "all")]
+// ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+  public class Events
+//             ^^^^^^ definition scip-dotnet nuget . . Main/Events#
+//                    documentation ```cs\nclass Events\n```
+  {
+      public event EventHandler<int> Event1
+//                                   ^^^^^^ definition scip-dotnet nuget . . Main/Events#Event1#
+//                                          documentation ```cs\npublic event EventHandler<int> Events.Event1\n```
+      {
+          add { }
+          remove { }
+      }
+
+      public event EventHandler Event2
+//                 ^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/EventHandler#
+//                              ^^^^^^ definition scip-dotnet nuget . . Main/Events#Event2#
+//                                     documentation ```cs\npublic event EventHandler Events.Event2\n```
+      {
+          add => addSomething();
+//               ^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Events#addSomething().
+          remove => removeSomething();
+//                  ^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Events#removeSomething().
+      }
+
+      private void removeSomething()
+//                 ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Events#removeSomething().
+//                                 documentation ```cs\nprivate void Events.removeSomething()\n```
+      {
+          throw new NotImplementedException();
+//                  ^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/NotImplementedException#
+      }
+
+      private void addSomething()
+//                 ^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Events#addSomething().
+//                              documentation ```cs\nprivate void Events.addSomething()\n```
+      {
+          throw new NotImplementedException();
+//                  ^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/NotImplementedException#
+      }
+  }

--- a/snapshots/output-net8.0/syntax/Main/Expressions.cs
+++ b/snapshots/output-net8.0/syntax/Main/Expressions.cs
@@ -1,0 +1,843 @@
+  using System.Diagnostics.CodeAnalysis;
+//      ^^^^^^ reference scip-dotnet nuget . . System/
+//             ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+//                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  namespace Main;
+//          ^^^^ reference scip-dotnet nuget . . Main/
+
+  [SuppressMessage("ReSharper", "all")]
+// ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+  public class Expressions
+//             ^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#
+//                         documentation ```cs\nclass Expressions\n```
+  {
+      void AssignmentToPrefixUnaryExpressions()
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#AssignmentToPrefixUnaryExpressions().
+//                                            documentation ```cs\nprivate void Expressions.AssignmentToPrefixUnaryExpressions()\n```
+      {
+          var a = 42;
+//            ^ definition local 0
+//              documentation ```cs\nint a\n```
+          var b = 42;
+//            ^ definition local 1
+//              documentation ```cs\nint b\n```
+          a = +a;
+//        ^ reference local 0
+//             ^ reference local 0
+          a = -a;
+//        ^ reference local 0
+//             ^ reference local 0
+          a = ~a;
+//        ^ reference local 0
+//             ^ reference local 0
+          a = ++a;
+//        ^ reference local 0
+//              ^ reference local 0
+          a = --a;
+//        ^ reference local 0
+//              ^ reference local 0
+          a = a++;
+//        ^ reference local 0
+//            ^ reference local 0
+          a = a--;
+//        ^ reference local 0
+//            ^ reference local 0
+          b = a!;
+//        ^ reference local 1
+//            ^ reference local 0
+
+          var c = true;
+//            ^ definition local 2
+//              documentation ```cs\nbool c\n```
+          c = !c;
+//        ^ reference local 2
+//             ^ reference local 2
+      }
+
+      void AssignmentToPrefixBinaryExpressions()
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#AssignmentToPrefixBinaryExpressions().
+//                                             documentation ```cs\nprivate void Expressions.AssignmentToPrefixBinaryExpressions()\n```
+      {
+          var a = 42;
+//            ^ definition local 3
+//              documentation ```cs\nint a\n```
+          a = a + a;
+//        ^ reference local 3
+//            ^ reference local 3
+//                ^ reference local 3
+          a = a - a;
+//        ^ reference local 3
+//            ^ reference local 3
+//                ^ reference local 3
+          a = a * a;
+//        ^ reference local 3
+//            ^ reference local 3
+//                ^ reference local 3
+          a = a / a;
+//        ^ reference local 3
+//            ^ reference local 3
+//                ^ reference local 3
+          a = a % a;
+//        ^ reference local 3
+//            ^ reference local 3
+//                ^ reference local 3
+          a = a & a;
+//        ^ reference local 3
+//            ^ reference local 3
+//                ^ reference local 3
+          a = a | a;
+//        ^ reference local 3
+//            ^ reference local 3
+//                ^ reference local 3
+          a = a ^ a;
+//        ^ reference local 3
+//            ^ reference local 3
+//                ^ reference local 3
+          a = a >> a;
+//        ^ reference local 3
+//            ^ reference local 3
+//                 ^ reference local 3
+          a = a << a;
+//        ^ reference local 3
+//            ^ reference local 3
+//                 ^ reference local 3
+          a = a >>> a;
+//        ^ reference local 3
+//            ^ reference local 3
+//                  ^ reference local 3
+      }
+
+      void AssignmentToBinaryEqualityExpression()
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#AssignmentToBinaryEqualityExpression().
+//                                              documentation ```cs\nprivate void Expressions.AssignmentToBinaryEqualityExpression()\n```
+      {
+          var a = true;
+//            ^ definition local 4
+//              documentation ```cs\nbool a\n```
+          var b = true;
+//            ^ definition local 5
+//              documentation ```cs\nbool b\n```
+          var c = 42;
+//            ^ definition local 6
+//              documentation ```cs\nint c\n```
+          var d = 42;
+//            ^ definition local 7
+//              documentation ```cs\nint d\n```
+          a = a == b;
+//        ^ reference local 4
+//            ^ reference local 4
+//                 ^ reference local 5
+          a = a != b;
+//        ^ reference local 4
+//            ^ reference local 4
+//                 ^ reference local 5
+          a = c < d;
+//        ^ reference local 4
+//            ^ reference local 6
+//                ^ reference local 7
+          a = c <= d;
+//        ^ reference local 4
+//            ^ reference local 6
+//                 ^ reference local 7
+          a = c > d;
+//        ^ reference local 4
+//            ^ reference local 6
+//                ^ reference local 7
+          a = c >= d;
+//        ^ reference local 4
+//            ^ reference local 6
+//                 ^ reference local 7
+      }
+
+      void AssignmentToBinaryExpression()
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#AssignmentToBinaryExpression().
+//                                      documentation ```cs\nprivate void Expressions.AssignmentToBinaryExpression()\n```
+      {
+          var a = 42;
+//            ^ definition local 8
+//              documentation ```cs\nint a\n```
+          a += a;
+//        ^ reference local 8
+//             ^ reference local 8
+          a -= a;
+//        ^ reference local 8
+//             ^ reference local 8
+          a *= a;
+//        ^ reference local 8
+//             ^ reference local 8
+          a /= a;
+//        ^ reference local 8
+//             ^ reference local 8
+          a %= a;
+//        ^ reference local 8
+//             ^ reference local 8
+          a++;
+//        ^ reference local 8
+          a--;
+//        ^ reference local 8
+          a <<= a;
+//        ^ reference local 8
+//              ^ reference local 8
+          a >>= a;
+//        ^ reference local 8
+//              ^ reference local 8
+          a >>>= a;
+//        ^ reference local 8
+//               ^ reference local 8
+      }
+
+      struct Struct
+//           ^^^^^^ definition scip-dotnet nuget . . Main/Expressions#Struct#
+//                  documentation ```cs\nstruct Struct\n```
+      {
+          public int Property;
+//                   ^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#Struct#Property.
+//                            documentation ```cs\npublic int Struct.Property\n```
+      }
+
+      struct IndexedClass
+//           ^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#IndexedClass#
+//                        documentation ```cs\nstruct IndexedClass\n```
+      {
+          public int Property;
+//                   ^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#IndexedClass#Property.
+//                            documentation ```cs\npublic int IndexedClass.Property\n```
+
+          public int this[int index]
+//                            ^^^^^ definition scip-dotnet nuget . . Main/Expressions#IndexedClass#`this[]`.(index)
+//                                  documentation ```cs\nint index\n```
+          {
+              get { return Property; }
+//                         ^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#IndexedClass#Property.
+              set { Property = value; }
+//                  ^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#IndexedClass#Property.
+//                             ^^^^^ reference scip-dotnet nuget . . Main/Expressions#IndexedClass#set_Item().(value)
+          }
+      }
+
+      void AssignmentToLeftValueTypes()
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#AssignmentToLeftValueTypes().
+//                                    documentation ```cs\nprivate void Expressions.AssignmentToLeftValueTypes()\n```
+      {
+          (var a, var b) = (1, 2);
+//             ^ definition local 9
+//               documentation ```cs\nint a\n```
+//                    ^ definition local 10
+//                      documentation ```cs\nint b\n```
+          a = 1;
+//        ^ reference local 9
+          var c = new Struct { Property = 42 };
+//            ^ definition local 11
+//              documentation ```cs\nStruct c\n```
+//                    ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Struct#
+//                             ^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Struct#Property.
+          c.Property = 1;
+//        ^ reference local 11
+//          ^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Struct#Property.
+          var d = new IndexedClass();
+//            ^ definition local 12
+//              documentation ```cs\nIndexedClass d\n```
+//                    ^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#IndexedClass#
+          d[b] = 1;
+//        ^ reference local 12
+//          ^ reference local 10
+          (a, b) = (1, 2);
+//         ^ reference local 9
+//            ^ reference local 10
+          var x = new IndexedClass
+//            ^ definition local 13
+//              documentation ```cs\nIndexedClass x\n```
+//                    ^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#IndexedClass#
+          {
+              Property = 1,
+//            ^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#IndexedClass#Property.
+              [b] = 1
+//             ^ reference local 10
+          };
+          (a) = 1;
+//         ^ reference local 9
+          unsafe
+          {
+              int myInt = 5;
+//                ^^^^^ definition local 14
+//                      documentation ```cs\nint myInt\n```
+              int* p = &myInt;
+//                 ^ definition local 15
+//                   documentation ```cs\nint* p\n```
+//                      ^^^^^ reference local 14
+              Console.WriteLine("myInt = {0}, *p = {1}", myInt, *p);
+//            ^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#
+//                    ^^^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#WriteLine(+13).
+//                                                       ^^^^^ reference local 14
+//                                                               ^ reference local 15
+          }
+      }
+
+      void TernaryExpression()
+//         ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#TernaryExpression().
+//                           documentation ```cs\nprivate void Expressions.TernaryExpression()\n```
+      {
+          var x = true;
+//            ^ definition local 16
+//              documentation ```cs\nbool x\n```
+          var y = x ? "foo" : "bar";
+//            ^ definition local 17
+//              documentation ```cs\nstring? y\n```
+//                ^ reference local 16
+          object z = true;
+//               ^ definition local 18
+//                 documentation ```cs\nobject z\n```
+          var t = z is bool ? 42 : 41;
+//            ^ definition local 19
+//              documentation ```cs\nint t\n```
+//                ^ reference local 18
+      }
+
+      class Cast
+//          ^^^^ definition scip-dotnet nuget . . Main/Expressions#Cast#
+//               documentation ```cs\nclass Cast\n```
+      {
+          public Cast nested;
+//               ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
+//                    ^^^^^^ definition scip-dotnet nuget . . Main/Expressions#Cast#nested.
+//                           documentation ```cs\npublic Cast Cast.nested\n```
+          public Cast2 nested2;
+//               ^^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#Cast2#
+//                     ^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#Cast#nested2.
+//                             documentation ```cs\npublic Cast2 Cast.nested2\n```
+
+          public Cast plus(Cast other)
+//               ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
+//                    ^^^^ definition scip-dotnet nuget . . Main/Expressions#Cast#plus().
+//                         documentation ```cs\npublic Cast Cast.plus(Cast other)\n```
+//                         ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
+//                              ^^^^^ definition scip-dotnet nuget . . Main/Expressions#Cast#plus().(other)
+//                                    documentation ```cs\nCast other\n```
+          {
+              nested = other;
+//            ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#nested.
+//                     ^^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#plus().(other)
+              return this;
+          }
+
+          public class Cast2
+//                     ^^^^^ definition scip-dotnet nuget . . Main/Expressions#Cast#Cast2#
+//                           documentation ```cs\nclass Cast2\n```
+          {
+          }
+      }
+
+      int CastExpressions()
+//        ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#CastExpressions().
+//                        documentation ```cs\nprivate int Expressions.CastExpressions()\n```
+      {
+          object a = new Cast();
+//               ^ definition local 20
+//                 documentation ```cs\nobject a\n```
+//                       ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
+          object b = new Cast();
+//               ^ definition local 21
+//                 documentation ```cs\nobject b\n```
+//                       ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
+          Cast c = ((Cast)a).plus((Cast)b);
+//        ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
+//             ^ definition local 22
+//               documentation ```cs\nCast c\n```
+//                   ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
+//                        ^ reference local 20
+//                           ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#plus().
+//                                 ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
+//                                      ^ reference local 21
+          Cast d = (Cast)new object[] { a, b }[0];
+//        ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
+//             ^ definition local 23
+//               documentation ```cs\nCast d\n```
+//                  ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
+//                                      ^ reference local 20
+//                                         ^ reference local 21
+          var e = (Cast.Cast2)(c.nested.nested2);
+//            ^ definition local 24
+//              documentation ```cs\nCast2? e\n```
+//                 ^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#
+//                      ^^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#Cast2#
+//                             ^ reference local 22
+//                               ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#nested.
+//                                      ^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Cast#nested2.
+          var f = (Int32)(1);
+//            ^ definition local 25
+//              documentation ```cs\nint f\n```
+//                 ^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Int32#
+          var g = (Int32)(1);
+//            ^ definition local 26
+//              documentation ```cs\nint g\n```
+//                 ^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Int32#
+          var h = (Int32)((1));
+//            ^ definition local 27
+//              documentation ```cs\nint h\n```
+//                 ^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Int32#
+          return f + g + h;
+//               ^ reference local 25
+//                   ^ reference local 26
+//                       ^ reference local 27
+      }
+
+      object AnonymousObject()
+//           ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#AnonymousObject().
+//                           documentation ```cs\nprivate object Expressions.AnonymousObject()\n```
+      {
+          var x = new { Helper = "" };
+//            ^ definition local 28
+//              documentation ```cs\n<anonymous type: string Helper>? x\n```
+//                      ^^^^^^ reference local 30
+          var y = new
+//            ^ definition local 31
+//              documentation ```cs\n<anonymous type: AnonymousType <anonymous type: string Helper> x>? y\n```
+          {
+              x
+//            ^ reference local 28
+          };
+          return y.x.Helper;
+//               ^ reference local 31
+//                 ^ reference local 33
+//                   ^^^^^^ reference local 30
+      }
+
+      class TargetType
+//          ^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#TargetType#
+//                     documentation ```cs\nclass TargetType\n```
+      {
+          public TargetType(string name)
+//               ^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#TargetType#`.ctor`().
+//                          documentation ```cs\npublic TargetType.TargetType(string name)\n```
+//                                 ^^^^ definition scip-dotnet nuget . . Main/Expressions#TargetType#`.ctor`().(name)
+//                                      documentation ```cs\nstring name\n```
+          {
+          }
+      }
+
+      TargetType TargetTypeNew()
+//    ^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#TargetType#
+//               ^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#TargetTypeNew().
+//                             documentation ```cs\nprivate TargetType Expressions.TargetTypeNew()\n```
+      {
+          TargetType x = new("x");
+//        ^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#TargetType#
+//                   ^ definition local 34
+//                     documentation ```cs\nTargetType x\n```
+          return x;
+//               ^ reference local 34
+      }
+
+      int Checked()
+//        ^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#Checked().
+//                documentation ```cs\nprivate int Expressions.Checked()\n```
+      {
+          var three = checked(1 + 2);
+//            ^^^^^ definition local 35
+//                  documentation ```cs\nint three\n```
+          return three;
+//               ^^^^^ reference local 35
+      }
+
+      class ObjectCreationClass
+//          ^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#
+//                              documentation ```cs\nclass ObjectCreationClass\n```
+      {
+          public D field;
+//               ^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#D#
+//                 ^^^^^ definition scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#field.
+//                       documentation ```cs\npublic D ObjectCreationClass.field\n```
+
+          public ObjectCreationClass(D field)
+//               ^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#`.ctor`().
+//                                   documentation ```cs\npublic ObjectCreationClass.ObjectCreationClass(D field)\n```
+//                                   ^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#D#
+//                                     ^^^^^ definition scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#`.ctor`().(field)
+//                                           documentation ```cs\nD field\n```
+          {
+              this.field = field;
+//                 ^^^^^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#field.
+//                         ^^^^^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#`.ctor`().(field)
+          }
+
+          public class D
+//                     ^ definition scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#D#
+//                       documentation ```cs\nclass D\n```
+          {
+              public D(int a, string b)
+//                   ^ definition scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#D#`.ctor`().
+//                     documentation ```cs\npublic D.D(int a, string b)\n```
+//                         ^ definition scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#D#`.ctor`().(a)
+//                           documentation ```cs\nint a\n```
+//                                   ^ definition scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#D#`.ctor`().(b)
+//                                     documentation ```cs\nstring b\n```
+              {
+              }
+          }
+      }
+
+      void ObjectCreation()
+//         ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#ObjectCreation().
+//                        documentation ```cs\nprivate void Expressions.ObjectCreation()\n```
+      {
+          var a = new ObjectCreationClass.D(1, "hi");
+//            ^ definition local 36
+//              documentation ```cs\nD? a\n```
+//                    ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#
+//                                        ^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#D#
+          var b = new ObjectCreationClass(a)
+//            ^ definition local 37
+//              documentation ```cs\nObjectCreationClass? b\n```
+//                    ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#
+//                                        ^ reference local 36
+          {
+              field = a,
+//            ^^^^^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#field.
+//                    ^ reference local 36
+          };
+          b = new ObjectCreationClass(a);
+//        ^ reference local 37
+//                ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#
+//                                    ^ reference local 36
+          b = new ObjectCreationClass(a) { };
+//        ^ reference local 37
+//                ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#ObjectCreationClass#
+//                                    ^ reference local 36
+      }
+
+      class NamedParametersClass
+//          ^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#NamedParametersClass#
+//                               documentation ```cs\nclass NamedParametersClass\n```
+      {
+          public int A;
+//                   ^ definition scip-dotnet nuget . . Main/Expressions#NamedParametersClass#A.
+//                     documentation ```cs\npublic int NamedParametersClass.A\n```
+          public string B;
+//                      ^ definition scip-dotnet nuget . . Main/Expressions#NamedParametersClass#B.
+//                        documentation ```cs\npublic string NamedParametersClass.B\n```
+
+          public NamedParametersClass(int a, string b)
+//               ^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#NamedParametersClass#`.ctor`().
+//                                    documentation ```cs\npublic NamedParametersClass.NamedParametersClass(int a, string b)\n```
+//                                        ^ definition scip-dotnet nuget . . Main/Expressions#NamedParametersClass#`.ctor`().(a)
+//                                          documentation ```cs\nint a\n```
+//                                                  ^ definition scip-dotnet nuget . . Main/Expressions#NamedParametersClass#`.ctor`().(b)
+//                                                    documentation ```cs\nstring b\n```
+          {
+              A = a;
+//            ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#A.
+//                ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#`.ctor`().(a)
+              B = b;
+//            ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#B.
+//                ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#`.ctor`().(b)
+          }
+
+          public void Update(int a, string b)
+//                    ^^^^^^ definition scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().
+//                           documentation ```cs\npublic void NamedParametersClass.Update(int a, string b)\n```
+//                               ^ definition scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().(a)
+//                                 documentation ```cs\nint a\n```
+//                                         ^ definition scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().(b)
+//                                           documentation ```cs\nstring b\n```
+          {
+              A = a;
+//            ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#A.
+//                ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().(a)
+              B = b;
+//            ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#B.
+//                ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().(b)
+          }
+      }
+
+      NamedParametersClass NamedParameters()
+//    ^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#
+//                         ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#NamedParameters().
+//                                         documentation ```cs\nprivate NamedParametersClass Expressions.NamedParameters()\n```
+      {
+          var a = new NamedParametersClass(b: "hi", a: 1);
+//            ^ definition local 38
+//              documentation ```cs\nNamedParametersClass? a\n```
+//                    ^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#
+//                                         ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#`.ctor`().(b)
+//                                                  ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#`.ctor`().(a)
+          a.Update(b: "foo", a: 42);
+//        ^ reference local 38
+//          ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().
+//                 ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().(b)
+//                           ^ reference scip-dotnet nuget . . Main/Expressions#NamedParametersClass#Update().(a)
+          return a;
+//               ^ reference local 38
+      }
+
+      Func<int, int> AnonymousFunction()
+//                   ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#AnonymousFunction().
+//                                     documentation ```cs\nprivate Func<int, int> Expressions.AnonymousFunction()\n```
+      {
+          var d = delegate (int _, int _) { return 42; };
+//            ^ definition local 39
+//              documentation ```cs\nFunc<int, int, int>? d\n```
+//                              ^ definition local 41
+//                                documentation ```cs\nint _\n```
+//                                     ^ definition local 42
+//                                       documentation ```cs\nint _\n```
+          return delegate (int a) { return a + d.Invoke(a, a); };
+//                             ^ definition local 44
+//                               documentation ```cs\nint a\n```
+//                                         ^ reference local 44
+//                                             ^ reference local 39
+//                                               ^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Func#Invoke().
+//                                                      ^ reference local 44
+//                                                         ^ reference local 44
+      }
+
+      class Lambda
+//          ^^^^^^ definition scip-dotnet nuget . . Main/Expressions#Lambda#
+//                 documentation ```cs\nclass Lambda\n```
+      {
+          public string func(Lambda x)
+//                      ^^^^ definition scip-dotnet nuget . . Main/Expressions#Lambda#func().
+//                           documentation ```cs\npublic string Lambda.func(Lambda x)\n```
+//                           ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#
+//                                  ^ definition scip-dotnet nuget . . Main/Expressions#Lambda#func().(x)
+//                                    documentation ```cs\nLambda x\n```
+          {
+              return "";
+          }
+      }
+
+      void LambdaExpressions()
+//         ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#LambdaExpressions().
+//                           documentation ```cs\nprivate void Expressions.LambdaExpressions()\n```
+      {
+          var a = (string x) => x + 1;
+//            ^ definition local 45
+//              documentation ```cs\nFunc<string, string>? a\n```
+//                        ^ definition local 47
+//                          documentation ```cs\nstring x\n```
+//                              ^ reference local 47
+          var b = (Lambda a, Lambda b) => { return a.func(b); };
+//            ^ definition local 48
+//              documentation ```cs\nFunc<Lambda, Lambda, string>? b\n```
+//                 ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#
+//                        ^ definition local 50
+//                          documentation ```cs\nLambda a\n```
+//                           ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#
+//                                  ^ definition local 51
+//                                    documentation ```cs\nLambda b\n```
+//                                                 ^ reference local 50
+//                                                   ^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#func().
+//                                                        ^ reference local 51
+          var c = string (Lambda a, Lambda _) => { return "hi"; };
+//            ^ definition local 52
+//              documentation ```cs\nFunc<Lambda, Lambda, string>? c\n```
+//                        ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#
+//                               ^ definition local 54
+//                                 documentation ```cs\nLambda a\n```
+//                                  ^^^^^^ reference scip-dotnet nuget . . Main/Expressions#Lambda#
+//                                         ^ definition local 55
+//                                           documentation ```cs\nLambda _\n```
+      }
+
+      void TupleExpressions()
+//         ^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#TupleExpressions().
+//                          documentation ```cs\nprivate void Expressions.TupleExpressions()\n```
+      {
+          var a = (1, 2, "");
+//            ^ definition local 56
+//              documentation ```cs\n(int, int, string) a\n```
+      }
+
+      void ArrayCreation()
+//         ^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#ArrayCreation().
+//                       documentation ```cs\nprivate void Expressions.ArrayCreation()\n```
+      {
+          var a = new[,] { { 1, 1 }, { 2, 2 }, { 3, 3 } };
+//            ^ definition local 57
+//              documentation ```cs\nint[*,*]? a\n```
+          Span<int> b = stackalloc[] { 1, 2, 3 };
+//                  ^ definition local 58
+//                    documentation ```cs\nSpan<int> b\n```
+          Span<int> c = stackalloc int[] { 1, 2, 3 };
+//                  ^ definition local 59
+//                    documentation ```cs\nSpan<int> c\n```
+          var d = new int[3] { 1, 2, 3 };
+//            ^ definition local 60
+//              documentation ```cs\nint[]? d\n```
+          var e = new byte[,] { { 1, 2 }, { 2, 3 } };
+//            ^ definition local 61
+//              documentation ```cs\nbyte[*,*]? e\n```
+          var f = new int[3, 2] { { 1, 1 }, { 2, 2 }, { 3, 3 } };
+//            ^ definition local 62
+//              documentation ```cs\nint[*,*]? f\n```
+          var g = new (string b, string c)[3];
+//            ^ definition local 63
+//              documentation ```cs\n(string b, string c)[]? g\n```
+      }
+
+      void MakeRef()
+//         ^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#MakeRef().
+//                 documentation ```cs\nprivate void Expressions.MakeRef()\n```
+      {
+          var g = "";
+//            ^ definition local 64
+//              documentation ```cs\nstring? g\n```
+          var a = __makeref(g);
+//            ^ definition local 65
+//              documentation ```cs\nTypedReference a\n```
+//                          ^ reference local 64
+      }
+
+      void SizeOf()
+//         ^^^^^^ definition scip-dotnet nuget . . Main/Expressions#SizeOf().
+//                documentation ```cs\nprivate void Expressions.SizeOf()\n```
+      {
+          var a = sizeof(int);
+//            ^ definition local 66
+//              documentation ```cs\nint a\n```
+      }
+
+      void TypeOf()
+//         ^^^^^^ definition scip-dotnet nuget . . Main/Expressions#TypeOf().
+//                documentation ```cs\nprivate void Expressions.TypeOf()\n```
+      {
+          var a = typeof(int);
+//            ^ definition local 67
+//              documentation ```cs\nType? a\n```
+          var b = typeof(List<string>.Enumerator);
+//            ^ definition local 68
+//              documentation ```cs\nType? b\n```
+//                                    ^^^^^^^^^^ reference scip-dotnet nuget System.Collections 8.0.0.0 Generic/List#Enumerator#
+          var c = typeof(Dictionary<,>);
+//            ^ definition local 69
+//              documentation ```cs\nType? c\n```
+          var d = typeof(Tuple<,,,>);
+//            ^ definition local 70
+//              documentation ```cs\nType? d\n```
+      }
+
+      interface IAnimal
+//              ^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#IAnimal#
+//                      documentation ```cs\ninterface IAnimal\n```
+      {
+          string Sound();
+//               ^^^^^ definition scip-dotnet nuget . . Main/Expressions#IAnimal#Sound().
+//                     documentation ```cs\nstring IAnimal.Sound()\n```
+      }
+
+      public class Dog : IAnimal
+//                 ^^^ definition scip-dotnet nuget . . Main/Expressions#Dog#
+//                     documentation ```cs\nclass Dog\n```
+//                     relationship implementation scip-dotnet nuget . . Main/Expressions#IAnimal#
+//                       ^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#IAnimal#
+      {
+          public string Sound()
+//                      ^^^^^ definition scip-dotnet nuget . . Main/Expressions#Dog#Sound().
+//                            documentation ```cs\npublic string Dog.Sound()\n```
+//                            relationship implementation reference scip-dotnet nuget . . Main/Expressions#IAnimal#Sound().
+          {
+              return "woof";
+          }
+      }
+
+      public class Cat : IAnimal
+//                 ^^^ definition scip-dotnet nuget . . Main/Expressions#Cat#
+//                     documentation ```cs\nclass Cat\n```
+//                     relationship implementation scip-dotnet nuget . . Main/Expressions#IAnimal#
+//                       ^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#IAnimal#
+      {
+          public string Sound()
+//                      ^^^^^ definition scip-dotnet nuget . . Main/Expressions#Cat#Sound().
+//                            documentation ```cs\npublic string Cat.Sound()\n```
+//                            relationship implementation reference scip-dotnet nuget . . Main/Expressions#IAnimal#Sound().
+          {
+              return "meow";
+          }
+      }
+
+      void Switch()
+//         ^^^^^^ definition scip-dotnet nuget . . Main/Expressions#Switch().
+//                documentation ```cs\nprivate void Expressions.Switch()\n```
+      {
+          int some = 42;
+//            ^^^^ definition local 71
+//                 documentation ```cs\nint some\n```
+          var a = some switch
+//            ^ definition local 72
+//              documentation ```cs\nstring? a\n```
+//                ^^^^ reference local 71
+          {
+              1 => "one",
+              2 => "two",
+              _ => "more"
+          };
+          IAnimal dog = new Dog();
+//        ^^^^^^^ reference scip-dotnet nuget . . Main/Expressions#IAnimal#
+//                ^^^ definition local 73
+//                    documentation ```cs\nIAnimal dog\n```
+//                          ^^^ reference scip-dotnet nuget . . Main/Expressions#Dog#
+          var b = dog switch
+//            ^ definition local 74
+//              documentation ```cs\nstring? b\n```
+//                ^^^ reference local 73
+          {
+              Cat c => c.Sound(),
+//            ^^^ reference scip-dotnet nuget . . Main/Expressions#Cat#
+//                ^ definition local 75
+//                  documentation ```cs\nCat c\n```
+//                     ^ reference local 75
+//                       ^^^^^ reference scip-dotnet nuget . . Main/Expressions#Cat#Sound().
+              Dog c => c.Sound(),
+//            ^^^ reference scip-dotnet nuget . . Main/Expressions#Dog#
+//                ^ definition local 76
+//                  documentation ```cs\nDog c\n```
+//                     ^ reference local 76
+//                       ^^^^^ reference scip-dotnet nuget . . Main/Expressions#Dog#Sound().
+              _ => throw new ArgumentOutOfRangeException()
+//                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/ArgumentOutOfRangeException#
+          };
+      }
+
+      void Dictionary()
+//         ^^^^^^^^^^ definition scip-dotnet nuget . . Main/Expressions#Dictionary().
+//                    documentation ```cs\nprivate void Expressions.Dictionary()\n```
+      {
+          var a = new Dictionary<string, int> { ["a"] = 65 };
+//            ^ definition local 77
+//              documentation ```cs\nDictionary<string, int>? a\n```
+      }
+
+      void Is()
+//         ^^ definition scip-dotnet nuget . . Main/Expressions#Is().
+//            documentation ```cs\nprivate void Expressions.Is()\n```
+      {
+          object s = "s";
+//               ^ definition local 78
+//                 documentation ```cs\nobject s\n```
+          if (s is string s2)
+//            ^ reference local 78
+//                        ^^ definition local 79
+//                           documentation ```cs\nstring s2\n```
+          {
+              Console.WriteLine(s2);
+//            ^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#
+//                    ^^^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#WriteLine(+11).
+//                              ^^ reference local 79
+          }
+
+          var c = s is "test";
+//            ^ definition local 80
+//              documentation ```cs\nbool c\n```
+//                ^ reference local 78
+          var a = s is int.MaxValue;
+//            ^ definition local 81
+//              documentation ```cs\nbool a\n```
+//                ^ reference local 78
+//                         ^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Int32#MaxValue.
+          var d = s is nameof(a);
+//            ^ definition local 82
+//              documentation ```cs\nbool d\n```
+//                ^ reference local 78
+//                            ^ reference local 81
+      }
+  }

--- a/snapshots/output-net8.0/syntax/Main/Fields.cs
+++ b/snapshots/output-net8.0/syntax/Main/Fields.cs
@@ -1,0 +1,76 @@
+  using System.Diagnostics.CodeAnalysis;
+//      ^^^^^^ reference scip-dotnet nuget . . System/
+//             ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+//                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  namespace Main;
+//          ^^^^ reference scip-dotnet nuget . . Main/
+
+  [SuppressMessage("ReSharper", "all")]
+// ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+  public class Fields
+//             ^^^^^^ definition scip-dotnet nuget . . Main/Fields#
+//                    documentation ```cs\nclass Fields\n```
+  {
+      class Fields1
+//          ^^^^^^^ definition scip-dotnet nuget . . Main/Fields#Fields1#
+//                  documentation ```cs\nclass Fields1\n```
+      {
+          private readonly int Property1;
+//                             ^^^^^^^^^ definition scip-dotnet nuget . . Main/Fields#Fields1#Property1.
+//                                       documentation ```cs\nprivate readonly int Fields1.Property1\n```
+          private Int64 Property2, Property3;
+//                ^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Int64#
+//                      ^^^^^^^^^ definition scip-dotnet nuget . . Main/Fields#Fields1#Property2.
+//                                documentation ```cs\nprivate long Fields1.Property2\n```
+//                                 ^^^^^^^^^ definition scip-dotnet nuget . . Main/Fields#Fields1#Property3.
+//                                           documentation ```cs\nprivate long Fields1.Property3\n```
+          private Tuple<char, Nullable<int>> Property4;
+//                                           ^^^^^^^^^ definition scip-dotnet nuget . . Main/Fields#Fields1#Property4.
+//                                                     documentation ```cs\nprivate Tuple<char, int?> Fields1.Property4\n```
+
+          public Fields1(long field2, long field3, Tuple<char, int?> field4, int field1)
+//               ^^^^^^^ definition scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().
+//                       documentation ```cs\npublic Fields1.Fields1(long field2, long field3, Tuple<char, int?> field4, int field1)\n```
+//                            ^^^^^^ definition scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field2)
+//                                   documentation ```cs\nlong field2\n```
+//                                         ^^^^^^ definition scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field3)
+//                                                documentation ```cs\nlong field3\n```
+//                                                                   ^^^^^^ definition scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field4)
+//                                                                          documentation ```cs\nTuple<char, int?> field4\n```
+//                                                                               ^^^^^^ definition scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field1)
+//                                                                                      documentation ```cs\nint field1\n```
+          {
+              Property2 = field2;
+//            ^^^^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#Property2.
+//                        ^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field2)
+              Property3 = field3;
+//            ^^^^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#Property3.
+//                        ^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field3)
+              Property4 = field4;
+//            ^^^^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#Property4.
+//                        ^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field4)
+              Property1 = field1;
+//            ^^^^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#Property1.
+//                        ^^^^^^ reference scip-dotnet nuget . . Main/Fields#Fields1#`.ctor`().(field1)
+          }
+      }
+
+      class Fields2
+//          ^^^^^^^ definition scip-dotnet nuget . . Main/Fields#Fields2#
+//                  documentation ```cs\nclass Fields2\n```
+      {
+          // Function pointer equivalent without calling convention
+          unsafe delegate*<string, int> a;
+//                                      ^ definition scip-dotnet nuget . . Main/Fields#Fields2#a.
+//                                        documentation ```cs\nprivate delegate*<string, int> Fields2.a\n```
+          unsafe delegate*<delegate*<in string, int>, delegate*<ref string, ref readonly int>> b;
+//                                                                                             ^ definition scip-dotnet nuget . . Main/Fields#Fields2#b.
+//                                                                                               documentation ```cs\nprivate delegate*<delegate*<in string, int>, delegate*<ref string, ref readonly int>> Fields2.b\n```
+
+          // Function pointer equivalent with calling convention
+          unsafe delegate* managed<string, int> c;
+//                                              ^ definition scip-dotnet nuget . . Main/Fields#Fields2#c.
+//                                                documentation ```cs\nprivate delegate*<string, int> Fields2.c\n```
+      }
+  }

--- a/snapshots/output-net8.0/syntax/Main/GlobalAttributes.cs
+++ b/snapshots/output-net8.0/syntax/Main/GlobalAttributes.cs
@@ -1,0 +1,99 @@
+  using System.Diagnostics.CodeAnalysis;
+//      ^^^^^^ reference scip-dotnet nuget . . System/
+//             ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+//                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  namespace Main;
+//          ^^^^ reference scip-dotnet nuget . . Main/
+
+  [SuppressMessage("ReSharper", "all")]
+// ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+  [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+// ^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/AttributeUsageAttribute#`.ctor`().
+//                ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/AttributeTargets#
+//                                 ^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/AttributeTargets#Class.
+//                                        ^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/AttributeUsageAttribute#AllowMultiple.
+//                                                              ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/AttributeUsageAttribute#Inherited.
+  public class GlobalAttributes : Attribute
+//             ^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/GlobalAttributes#
+//                              documentation ```cs\nclass GlobalAttributes\n```
+//                              relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/Attribute#
+//                                ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Attribute#
+  {
+      class AuthorAttribute : Attribute
+//          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/GlobalAttributes#AuthorAttribute#
+//                          documentation ```cs\nclass AuthorAttribute\n```
+//                          relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/Attribute#
+//                            ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Attribute#
+      {
+          public AuthorAttribute(string name)
+//               ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/GlobalAttributes#AuthorAttribute#`.ctor`().
+//                               documentation ```cs\npublic AuthorAttribute.AuthorAttribute(string name)\n```
+//                                      ^^^^ definition scip-dotnet nuget . . Main/GlobalAttributes#AuthorAttribute#`.ctor`().(name)
+//                                           documentation ```cs\nstring name\n```
+          {
+          }
+      }
+
+      [Author("PropertyAttribute")] public int Z;
+//     ^^^^^^ reference scip-dotnet nuget . . Main/GlobalAttributes#AuthorAttribute#`.ctor`().
+//                                             ^ definition scip-dotnet nuget . . Main/GlobalAttributes#Z.
+//                                               documentation ```cs\npublic int GlobalAttributes.Z\n```
+
+      [Author("MethodAttribute")]
+//     ^^^^^^ reference scip-dotnet nuget . . Main/GlobalAttributes#AuthorAttribute#`.ctor`().
+      int Method1()
+//        ^^^^^^^ definition scip-dotnet nuget . . Main/GlobalAttributes#Method1().
+//                documentation ```cs\nprivate int GlobalAttributes.Method1()\n```
+      {
+          return 0;
+      }
+
+      [Author("EnumAttribute")]
+//     ^^^^^^ reference scip-dotnet nuget . . Main/GlobalAttributes#AuthorAttribute#`.ctor`().
+      enum A
+//         ^ definition scip-dotnet nuget . . Main/GlobalAttributes#A#
+//           documentation ```cs\nenum A\n```
+//           relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IComparable#
+//           relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IConvertible#
+//           relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/ISpanFormattable#
+//           relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IFormattable#
+      {
+          B,
+//        ^ definition scip-dotnet nuget . . Main/GlobalAttributes#A#B.
+//          documentation ```cs\nA.B = 0\n```
+          C
+//        ^ definition scip-dotnet nuget . . Main/GlobalAttributes#A#C.
+//          documentation ```cs\nA.C = 1\n```
+      }
+
+      [Author("EventAttribute")]
+//     ^^^^^^ reference scip-dotnet nuget . . Main/GlobalAttributes#AuthorAttribute#`.ctor`().
+      public event EventHandler SomeEvent
+//                 ^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/EventHandler#
+//                              ^^^^^^^^^ definition scip-dotnet nuget . . Main/GlobalAttributes#SomeEvent#
+//                                        documentation ```cs\npublic event EventHandler GlobalAttributes.SomeEvent\n```
+      {
+          add { }
+          remove { }
+      }
+
+      [Author("TypeParameterAttribute")]
+//     ^^^^^^ reference scip-dotnet nuget . . Main/GlobalAttributes#AuthorAttribute#`.ctor`().
+      public class InnerClass<[Author("ClassTypeParameter")] T>
+//                 ^^^^^^^^^^ definition scip-dotnet nuget . . Main/GlobalAttributes#InnerClass#
+//                            documentation ```cs\nclass InnerClass<T>\n```
+//                             ^^^^^^ reference scip-dotnet nuget . . Main/GlobalAttributes#AuthorAttribute#`.ctor`().
+//                                                           ^ definition local 0
+//                                                             documentation ```cs\nT\n```
+      {
+          void Method<[Author("MethodTypeParameter")] T2>()
+//             ^^^^^^ definition scip-dotnet nuget . . Main/GlobalAttributes#InnerClass#Method().
+//                    documentation ```cs\nprivate void InnerClass<T>.Method<T2>()\n```
+//                     ^^^^^^ reference scip-dotnet nuget . . Main/GlobalAttributes#AuthorAttribute#`.ctor`().
+//                                                    ^^ definition local 1
+//                                                       documentation ```cs\nT2\n```
+          {
+          }
+      }
+  }

--- a/snapshots/output-net8.0/syntax/Main/Identifiers.cs
+++ b/snapshots/output-net8.0/syntax/Main/Identifiers.cs
@@ -1,0 +1,49 @@
+  using System.Diagnostics.CodeAnalysis;
+//      ^^^^^^ reference scip-dotnet nuget . . System/
+//             ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+//                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  namespace Main;
+//          ^^^^ reference scip-dotnet nuget . . Main/
+  #pragma warning disable CS0219
+  [SuppressMessage("ReSharper", "all")]
+// ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+  public class Identifiers
+//             ^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Identifiers#
+//                         documentation ```cs\nclass Identifiers\n```
+  {
+      void SpecialNames()
+//         ^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Identifiers#SpecialNames().
+//                      documentation ```cs\nprivate void Identifiers.SpecialNames()\n```
+      {
+          var @const = 42;
+//            ^^^^^^ definition local 0
+//                   documentation ```cs\nint @const\n```
+          int @var = @const;
+//            ^^^^ definition local 1
+//                 documentation ```cs\nint var\n```
+//                   ^^^^^^ reference local 0
+          var under_score = 0;
+//            ^^^^^^^^^^^ definition local 2
+//                        documentation ```cs\nint under_score\n```
+          var with1number = 0;
+//            ^^^^^^^^^^^ definition local 3
+//                        documentation ```cs\nint with1number\n```
+          var varæble = 0;
+//            ^^^^^^^ definition local 4
+//                    documentation ```cs\nint varæble\n```
+          var Переменная = 0;
+//            ^^^^^^^^^^ definition local 5
+//                       documentation ```cs\nint Переменная\n```
+          var first‿letter = 0;
+//            ^^^^^^^^^^^^ definition local 6
+//                         documentation ```cs\nint first‿letter\n```
+          var ග්‍රහලෝකය = 0;
+//            ^^^^^^^^^ definition local 7
+//                      documentation ```cs\nint ග්රහලෝකය\n```
+          var _كوكبxxx = 0;
+//            ^^^^^^^^ definition local 8
+//                     documentation ```cs\nint _كوكبxxx\n```
+      }
+  }
+  #pragma warning restore CS0219

--- a/snapshots/output-net8.0/syntax/Main/Interfaces.cs
+++ b/snapshots/output-net8.0/syntax/Main/Interfaces.cs
@@ -1,0 +1,153 @@
+  using System.Diagnostics.CodeAnalysis;
+//      ^^^^^^ reference scip-dotnet nuget . . System/
+//             ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+//                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  namespace Main;
+//          ^^^^ reference scip-dotnet nuget . . Main/
+
+  [SuppressMessage("ReSharper", "all")]
+// ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+  public class Interfaces
+//             ^^^^^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#
+//                        documentation ```cs\nclass Interfaces\n```
+  {
+      public interface IOne
+//                     ^^^^ definition scip-dotnet nuget . . Main/Interfaces#IOne#
+//                          documentation ```cs\ninterface IOne\n```
+      {
+      };
+
+      public interface ITwo
+//                     ^^^^ definition scip-dotnet nuget . . Main/Interfaces#ITwo#
+//                          documentation ```cs\ninterface ITwo\n```
+      {
+      };
+
+      public interface IThree
+//                     ^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IThree#
+//                            documentation ```cs\ninterface IThree\n```
+      {
+      };
+
+      public interface IProperties
+//                     ^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IProperties#
+//                                 documentation ```cs\ninterface IProperties\n```
+      {
+          byte Get { get; }
+//             ^^^ definition scip-dotnet nuget . . Main/Interfaces#IProperties#Get.
+//                 documentation ```cs\nbyte IProperties.Get { get; }\n```
+          char Set { set; }
+//             ^^^ definition scip-dotnet nuget . . Main/Interfaces#IProperties#Set.
+//                 documentation ```cs\nchar IProperties.Set { set; }\n```
+          uint GetSet { get; set; }
+//             ^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IProperties#GetSet.
+//                    documentation ```cs\nuint IProperties.GetSet { get; set; }\n```
+          long SetGet { set; get; }
+//             ^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IProperties#SetGet.
+//                    documentation ```cs\nlong IProperties.SetGet { get; set; }\n```
+      }
+
+      interface IMethods
+//              ^^^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IMethods#
+//                       documentation ```cs\ninterface IMethods\n```
+      {
+          void Nothing();
+//             ^^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IMethods#Nothing().
+//                     documentation ```cs\nvoid IMethods.Nothing()\n```
+          int Output();
+//            ^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IMethods#Output().
+//                   documentation ```cs\nint IMethods.Output()\n```
+          void Input(string a);
+//             ^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IMethods#Input().
+//                   documentation ```cs\nvoid IMethods.Input(string a)\n```
+//                          ^ definition scip-dotnet nuget . . Main/Interfaces#IMethods#Input().(a)
+//                            documentation ```cs\nstring a\n```
+          int InputOutput(string a);
+//            ^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IMethods#InputOutput().
+//                        documentation ```cs\nint IMethods.InputOutput(string a)\n```
+//                               ^ definition scip-dotnet nuget . . Main/Interfaces#IMethods#InputOutput().(a)
+//                                 documentation ```cs\nstring a\n```
+      };
+
+      interface IEvent
+//              ^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IEvent#
+//                     documentation ```cs\ninterface IEvent\n```
+      {
+          event EventHandler<int> SomeEvent;
+//                                ^^^^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IEvent#SomeEvent#
+//                                          documentation ```cs\nevent EventHandler<int> IEvent.SomeEvent\n```
+      }
+
+      interface IIndex
+//              ^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IIndex#
+//                     documentation ```cs\ninterface IIndex\n```
+      {
+          bool this[int index] { get; set; }
+//                      ^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IIndex#`this[]`.(index)
+//                            documentation ```cs\nint index\n```
+      }
+
+      interface IDefault
+//              ^^^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IDefault#
+//                       documentation ```cs\ninterface IDefault\n```
+      {
+          void Log(string message)
+//             ^^^ definition scip-dotnet nuget . . Main/Interfaces#IDefault#Log().
+//                 documentation ```cs\nvoid IDefault.Log(string message)\n```
+//                        ^^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IDefault#Log().(message)
+//                                documentation ```cs\nstring message\n```
+          {
+              Console.WriteLine(message);
+//            ^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#
+//                    ^^^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#WriteLine(+11).
+//                              ^^^^^^^ reference scip-dotnet nuget . . Main/Interfaces#IDefault#Log().(message)
+          }
+      }
+
+
+      private interface IInherit : IOne, ITwo
+//                      ^^^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IInherit#
+//                               documentation ```cs\ninterface IInherit\n```
+//                               relationship implementation scip-dotnet nuget . . Main/Interfaces#IOne#
+//                               relationship implementation scip-dotnet nuget . . Main/Interfaces#ITwo#
+//                                 ^^^^ reference scip-dotnet nuget . . Main/Interfaces#IOne#
+//                                       ^^^^ reference scip-dotnet nuget . . Main/Interfaces#ITwo#
+      {
+      }
+
+      public interface IGetNext<T> where T : IGetNext<T>
+//                     ^^^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IGetNext#
+//                              documentation ```cs\ninterface IGetNext<T> where T : IGetNext<T>\n```
+//                              ^ definition local 0
+//                                documentation ```cs\nT\n```
+//                                       ^ reference local 0
+//                                                    ^ reference local 0
+      {
+          static IGetNext<T> operator ++(IGetNext<T> other)
+//                        ^ reference local 0
+//                                                ^ reference local 0
+//                                                   ^^^^^ definition scip-dotnet nuget . . Main/Interfaces#IGetNext#op_Increment().(other)
+//                                                         documentation ```cs\nIGetNext<T> other\n```
+          {
+              throw new NotImplementedException();
+//                      ^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/NotImplementedException#
+          }
+      }
+
+      private interface ITypeParameter<T1, T2> : ITwo where T1 : IOne where T2 : IThree
+//                      ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Interfaces#ITypeParameter#
+//                                     documentation ```cs\ninterface ITypeParameter<T1, T2> where T1 : IOne where T2 : IThree\n```
+//                                     relationship implementation scip-dotnet nuget . . Main/Interfaces#ITwo#
+//                                     ^^ definition local 1
+//                                        documentation ```cs\nT1\n```
+//                                         ^^ definition local 2
+//                                            documentation ```cs\nT2\n```
+//                                               ^^^^ reference scip-dotnet nuget . . Main/Interfaces#ITwo#
+//                                                          ^^ reference local 1
+//                                                               ^^^^ reference scip-dotnet nuget . . Main/Interfaces#IOne#
+//                                                                          ^^ reference local 2
+//                                                                               ^^^^^^ reference scip-dotnet nuget . . Main/Interfaces#IThree#
+      {
+      }
+  }

--- a/snapshots/output-net8.0/syntax/Main/Literals.cs
+++ b/snapshots/output-net8.0/syntax/Main/Literals.cs
@@ -1,0 +1,37 @@
+  using System.Diagnostics.CodeAnalysis;
+//      ^^^^^^ reference scip-dotnet nuget . . System/
+//             ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+//                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  namespace Main;
+//          ^^^^ reference scip-dotnet nuget . . Main/
+
+  [SuppressMessage("ReSharper", "all")]
+// ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+  public class Literals
+//             ^^^^^^^^ definition scip-dotnet nuget . . Main/Literals#
+//                      documentation ```cs\nclass Literals\n```
+  {
+      string Interpolation()
+//           ^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Literals#Interpolation().
+//                         documentation ```cs\nprivate string Literals.Interpolation()\n```
+      {
+          var a = 1;
+//            ^ definition local 0
+//              documentation ```cs\nint a\n```
+          var b = 2;
+//            ^ definition local 1
+//              documentation ```cs\nint b\n```
+          var c = 3;
+//            ^ definition local 2
+//              documentation ```cs\nint c\n```
+          var d = 3;
+//            ^ definition local 3
+//              documentation ```cs\nint d\n```
+          return $"a={a} b={b:0.00} c={c,24} d={d:g}";
+//                    ^ reference local 0
+//                          ^ reference local 1
+//                                     ^ reference local 2
+//                                              ^ reference local 3
+      }
+  }

--- a/snapshots/output-net8.0/syntax/Main/Methods.cs
+++ b/snapshots/output-net8.0/syntax/Main/Methods.cs
@@ -1,0 +1,250 @@
+  using System.Diagnostics.CodeAnalysis;
+//      ^^^^^^ reference scip-dotnet nuget . . System/
+//             ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+//                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  namespace Main;
+//          ^^^^ reference scip-dotnet nuget . . Main/
+
+  [SuppressMessage("ReSharper", "all")]
+// ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+  public class Methods
+//             ^^^^^^^ definition scip-dotnet nuget . . Main/Methods#
+//                     documentation ```cs\nclass Methods\n```
+  {
+      int SingleParameter(int b)
+//        ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#SingleParameter().
+//                        documentation ```cs\nprivate int Methods.SingleParameter(int b)\n```
+//                            ^ definition scip-dotnet nuget . . Main/Methods#SingleParameter().(b)
+//                              documentation ```cs\nint b\n```
+      {
+          return b;
+//               ^ reference scip-dotnet nuget . . Main/Methods#SingleParameter().(b)
+      }
+
+      int TwoParameters(int a, int b)
+//        ^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#TwoParameters().
+//                      documentation ```cs\nprivate int Methods.TwoParameters(int a, int b)\n```
+//                          ^ definition scip-dotnet nuget . . Main/Methods#TwoParameters().(a)
+//                            documentation ```cs\nint a\n```
+//                                 ^ definition scip-dotnet nuget . . Main/Methods#TwoParameters().(b)
+//                                   documentation ```cs\nint b\n```
+      {
+          return a + b;
+//               ^ reference scip-dotnet nuget . . Main/Methods#TwoParameters().(a)
+//                   ^ reference scip-dotnet nuget . . Main/Methods#TwoParameters().(b)
+      }
+
+      int Overload1(int a)
+//        ^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#Overload1().
+//                  documentation ```cs\nprivate int Methods.Overload1(int a)\n```
+//                      ^ definition scip-dotnet nuget . . Main/Methods#Overload1().(a)
+//                        documentation ```cs\nint a\n```
+      {
+          return a;
+//               ^ reference scip-dotnet nuget . . Main/Methods#Overload1().(a)
+      }
+
+      int Overload1(int a, int b)
+//        ^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#Overload1(+1).
+//                  documentation ```cs\nprivate int Methods.Overload1(int a, int b)\n```
+//                      ^ definition scip-dotnet nuget . . Main/Methods#Overload1(+1).(a)
+//                        documentation ```cs\nint a\n```
+//                             ^ definition scip-dotnet nuget . . Main/Methods#Overload1(+1).(b)
+//                               documentation ```cs\nint b\n```
+      {
+          return a + b;
+//               ^ reference scip-dotnet nuget . . Main/Methods#Overload1(+1).(a)
+//                   ^ reference scip-dotnet nuget . . Main/Methods#Overload1(+1).(b)
+      }
+
+      T Generic<T>(T param)
+//    ^ reference local 0
+//      ^^^^^^^ definition scip-dotnet nuget . . Main/Methods#Generic().
+//              documentation ```cs\nprivate T Methods.Generic<T>(T param)\n```
+//              ^ definition local 0
+//                documentation ```cs\nT\n```
+//                 ^ reference local 0
+//                   ^^^^^ definition scip-dotnet nuget . . Main/Methods#Generic().(param)
+//                         documentation ```cs\nT param\n```
+      {
+          return param;
+//               ^^^^^ reference scip-dotnet nuget . . Main/Methods#Generic().(param)
+      }
+
+      T GenericConstraint<T>(T param) where T : new()
+//    ^ reference local 1
+//      ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#GenericConstraint().
+//                        documentation ```cs\nprivate T Methods.GenericConstraint<T>(T param) where T : new()\n```
+//                        ^ definition local 1
+//                          documentation ```cs\nT\n```
+//                           ^ reference local 1
+//                             ^^^^^ definition scip-dotnet nuget . . Main/Methods#GenericConstraint().(param)
+//                                   documentation ```cs\nT param\n```
+//                                          ^ reference local 1
+      {
+          return param;
+//               ^^^^^ reference scip-dotnet nuget . . Main/Methods#GenericConstraint().(param)
+      }
+
+      void DefaultParameter(int a = 5)
+//         ^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#DefaultParameter().
+//                          documentation ```cs\nprivate void Methods.DefaultParameter([int a = 5])\n```
+//                              ^ definition scip-dotnet nuget . . Main/Methods#DefaultParameter().(a)
+//                                documentation ```cs\n[int a = 5]\n```
+      {
+      }
+
+      int DefaultParameterOverload(int a = 5)
+//        ^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#DefaultParameterOverload().
+//                                 documentation ```cs\nprivate int Methods.DefaultParameterOverload([int a = 5])\n```
+//                                     ^ definition scip-dotnet nuget . . Main/Methods#DefaultParameterOverload().(a)
+//                                       documentation ```cs\n[int a = 5]\n```
+      {
+          return DefaultParameterOverload(a, a);
+//               ^^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Methods#DefaultParameterOverload(+1).
+//                                        ^ reference scip-dotnet nuget . . Main/Methods#DefaultParameterOverload().(a)
+//                                           ^ reference scip-dotnet nuget . . Main/Methods#DefaultParameterOverload().(a)
+      }
+
+      int DefaultParameterOverload(int a, int b)
+//        ^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#DefaultParameterOverload(+1).
+//                                 documentation ```cs\nprivate int Methods.DefaultParameterOverload(int a, int b)\n```
+//                                     ^ definition scip-dotnet nuget . . Main/Methods#DefaultParameterOverload(+1).(a)
+//                                       documentation ```cs\nint a\n```
+//                                            ^ definition scip-dotnet nuget . . Main/Methods#DefaultParameterOverload(+1).(b)
+//                                              documentation ```cs\nint b\n```
+      {
+          return DefaultParameterOverload();
+//               ^^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Methods#DefaultParameterOverload().
+      }
+
+      interface IHello
+//              ^^^^^^ definition scip-dotnet nuget . . Main/Methods#IHello#
+//                     documentation ```cs\ninterface IHello\n```
+      {
+          string Hello();
+//               ^^^^^ definition scip-dotnet nuget . . Main/Methods#IHello#Hello().
+//                     documentation ```cs\nstring IHello.Hello()\n```
+      }
+
+      class ImplementsHello : IHello
+//          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#ImplementsHello#
+//                          documentation ```cs\nclass ImplementsHello\n```
+//                          relationship implementation scip-dotnet nuget . . Main/Methods#IHello#
+//                            ^^^^^^ reference scip-dotnet nuget . . Main/Methods#IHello#
+      {
+          string IHello.Hello()
+//               ^^^^^^ reference scip-dotnet nuget . . Main/Methods#IHello#
+//                      ^^^^^ definition scip-dotnet nuget . . Main/Methods#ImplementsHello#`Main.Methods.IHello.Hello`().
+//                            documentation ```cs\nprivate string ImplementsHello.IHello.Hello()\n```
+//                            relationship implementation reference scip-dotnet nuget . . Main/Methods#IHello#Hello().
+          {
+              return "";
+          }
+      }
+
+      class InheritedOverloads1
+//          ^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#InheritedOverloads1#
+//                              documentation ```cs\nclass InheritedOverloads1\n```
+      {
+          public void Method()
+//                    ^^^^^^ definition scip-dotnet nuget . . Main/Methods#InheritedOverloads1#Method().
+//                           documentation ```cs\npublic void InheritedOverloads1.Method()\n```
+          {
+          }
+      }
+
+      class InheritedOverloads2 : InheritedOverloads1
+//          ^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#InheritedOverloads2#
+//                              documentation ```cs\nclass InheritedOverloads2\n```
+//                              relationship implementation scip-dotnet nuget . . Main/Methods#InheritedOverloads1#
+//                                ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Methods#InheritedOverloads1#
+      {
+          public int Method(int parameter)
+//                   ^^^^^^ definition scip-dotnet nuget . . Main/Methods#InheritedOverloads2#Method().
+//                          documentation ```cs\npublic int InheritedOverloads2.Method(int parameter)\n```
+//                              ^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#InheritedOverloads2#Method().(parameter)
+//                                        documentation ```cs\nint parameter\n```
+          {
+              return parameter;
+//                   ^^^^^^^^^ reference scip-dotnet nuget . . Main/Methods#InheritedOverloads2#Method().(parameter)
+          }
+      }
+
+      class InheritedOverloads3 : InheritedOverloads2
+//          ^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#InheritedOverloads3#
+//                              documentation ```cs\nclass InheritedOverloads3\n```
+//                              relationship implementation scip-dotnet nuget . . Main/Methods#InheritedOverloads2#
+//                              relationship implementation scip-dotnet nuget . . Main/Methods#InheritedOverloads1#
+//                                ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Methods#InheritedOverloads2#
+      {
+          public string Method(string parameter)
+//                      ^^^^^^ definition scip-dotnet nuget . . Main/Methods#InheritedOverloads3#Method().
+//                             documentation ```cs\npublic string InheritedOverloads3.Method(string parameter)\n```
+//                                    ^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#InheritedOverloads3#Method().(parameter)
+//                                              documentation ```cs\nstring parameter\n```
+          {
+              return parameter;
+//                   ^^^^^^^^^ reference scip-dotnet nuget . . Main/Methods#InheritedOverloads3#Method().(parameter)
+          }
+      }
+
+      public static void InheritedOverloads()
+//                       ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#InheritedOverloads().
+//                                          documentation ```cs\npublic static void Methods.InheritedOverloads()\n```
+      {
+          new InheritedOverloads1().Method();
+//            ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Methods#InheritedOverloads1#
+//                                  ^^^^^^ reference scip-dotnet nuget . . Main/Methods#InheritedOverloads1#Method().
+          new InheritedOverloads2().Method();
+//            ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Methods#InheritedOverloads2#
+//                                  ^^^^^^ reference scip-dotnet nuget . . Main/Methods#InheritedOverloads1#Method().
+          new InheritedOverloads2().Method(42);
+//            ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Methods#InheritedOverloads2#
+//                                  ^^^^^^ reference scip-dotnet nuget . . Main/Methods#InheritedOverloads2#Method().
+          new InheritedOverloads3().Method();
+//            ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Methods#InheritedOverloads3#
+//                                  ^^^^^^ reference scip-dotnet nuget . . Main/Methods#InheritedOverloads1#Method().
+          new InheritedOverloads3().Method(42);
+//            ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Methods#InheritedOverloads3#
+//                                  ^^^^^^ reference scip-dotnet nuget . . Main/Methods#InheritedOverloads2#Method().
+          new InheritedOverloads3().Method("42");
+//            ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Methods#InheritedOverloads3#
+//                                  ^^^^^^ reference scip-dotnet nuget . . Main/Methods#InheritedOverloads3#Method().
+      }
+
+      public class LocalFunction
+//                 ^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Methods#LocalFunction#
+//                               documentation ```cs\nclass LocalFunction\n```
+      {
+          public static void Method()
+//                           ^^^^^^ definition scip-dotnet nuget . . Main/Methods#LocalFunction#Method().
+//                                  documentation ```cs\npublic static void LocalFunction.Method()\n```
+          {
+              var myWorld = GetWorld();
+//                ^^^^^^^ definition local 2
+//                        documentation ```cs\nstring? myWorld\n```
+//                          ^^^^^^^^ reference local 3
+              SayHi(myWorld);
+//            ^^^^^ reference local 4
+//                  ^^^^^^^ reference local 2
+
+              string GetWorld() => "world";
+//                   ^^^^^^^^ definition local 3
+//                            documentation ```cs\nstring GetWorld()\n```
+
+              void SayHi(string world)
+//                 ^^^^^ definition local 4
+//                       documentation ```cs\nvoid SayHi(string world)\n```
+//                              ^^^^^ definition local 5
+//                                    documentation ```cs\nstring world\n```
+              {
+                  Console.WriteLine($"Hello {world}!");
+//                ^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#
+//                        ^^^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#WriteLine(+11).
+//                                           ^^^^^ reference local 5
+              }
+          }
+      }
+  }

--- a/snapshots/output-net8.0/syntax/Main/Operators.cs
+++ b/snapshots/output-net8.0/syntax/Main/Operators.cs
@@ -1,0 +1,132 @@
+  using System.Diagnostics.CodeAnalysis;
+//      ^^^^^^ reference scip-dotnet nuget . . System/
+//             ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+//                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  namespace Main;
+//          ^^^^ reference scip-dotnet nuget . . Main/
+
+  [SuppressMessage("ReSharper", "all")]
+// ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+  public class Operators
+//             ^^^^^^^^^ definition scip-dotnet nuget . . Main/Operators#
+//                       documentation ```cs\nclass Operators\n```
+  {
+      class PlusMinus
+//          ^^^^^^^^^ definition scip-dotnet nuget . . Main/Operators#PlusMinus#
+//                    documentation ```cs\nclass PlusMinus\n```
+      {
+          public static int operator +(PlusMinus a)
+//                                     ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#PlusMinus#
+//                                               ^ definition scip-dotnet nuget . . Main/Operators#PlusMinus#op_UnaryPlus().(a)
+//                                                 documentation ```cs\nPlusMinus a\n```
+          {
+              return 0;
+          }
+
+          public static int operator +(PlusMinus a, PlusMinus b)
+//                                     ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#PlusMinus#
+//                                               ^ definition scip-dotnet nuget . . Main/Operators#PlusMinus#op_Addition().(a)
+//                                                 documentation ```cs\nPlusMinus a\n```
+//                                                  ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#PlusMinus#
+//                                                            ^ definition scip-dotnet nuget . . Main/Operators#PlusMinus#op_Addition().(b)
+//                                                              documentation ```cs\nPlusMinus b\n```
+          {
+              return 0;
+          }
+
+          public static int operator -(PlusMinus a)
+//                                     ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#PlusMinus#
+//                                               ^ definition scip-dotnet nuget . . Main/Operators#PlusMinus#op_UnaryNegation().(a)
+//                                                 documentation ```cs\nPlusMinus a\n```
+          {
+              return 0;
+          }
+      }
+
+      class TrueFalse
+//          ^^^^^^^^^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#
+//                    documentation ```cs\nclass TrueFalse\n```
+      {
+          protected bool Equals(TrueFalse other)
+//                       ^^^^^^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#Equals().
+//                              documentation ```cs\nprotected bool TrueFalse.Equals(TrueFalse other)\n```
+//                              ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
+//                                        ^^^^^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#Equals().(other)
+//                                              documentation ```cs\nTrueFalse other\n```
+          {
+              throw new NotImplementedException();
+//                      ^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/NotImplementedException#
+          }
+
+          public override bool Equals(object? obj)
+//                             ^^^^^^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#Equals(+1).
+//                                    documentation ```cs\npublic override bool TrueFalse.Equals(object? obj)\n```
+//                                    relationship implementation reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Object#Equals().
+//                                            ^^^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#Equals(+1).(obj)
+//                                                documentation ```cs\nobject? obj\n```
+          {
+              if (ReferenceEquals(null, obj)) return false;
+//                ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Object#ReferenceEquals().
+//                                      ^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#Equals(+1).(obj)
+              if (ReferenceEquals(this, obj)) return true;
+//                ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Object#ReferenceEquals().
+//                                      ^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#Equals(+1).(obj)
+              if (obj.GetType() != this.GetType()) return false;
+//                ^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#Equals(+1).(obj)
+//                    ^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Object#GetType().
+//                                      ^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Object#GetType().
+              return Equals((TrueFalse)obj);
+//                   ^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#Equals().
+//                           ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
+//                                     ^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#Equals(+1).(obj)
+          }
+
+          public override int GetHashCode()
+//                            ^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#GetHashCode().
+//                                        documentation ```cs\npublic override int TrueFalse.GetHashCode()\n```
+//                                        relationship implementation reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Object#GetHashCode().
+          {
+              throw new NotImplementedException();
+//                      ^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/NotImplementedException#
+          }
+
+          public static bool operator true(TrueFalse a)
+//                                         ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
+//                                                   ^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#op_True().(a)
+//                                                     documentation ```cs\nTrueFalse a\n```
+          {
+              return true;
+          }
+
+          public static bool operator false(TrueFalse a)
+//                                          ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
+//                                                    ^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#op_False().(a)
+//                                                      documentation ```cs\nTrueFalse a\n```
+          {
+              return false;
+          }
+
+          public static bool operator !=(TrueFalse a, TrueFalse b)
+//                                       ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
+//                                                 ^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#op_Inequality().(a)
+//                                                   documentation ```cs\nTrueFalse a\n```
+//                                                    ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
+//                                                              ^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#op_Inequality().(b)
+//                                                                documentation ```cs\nTrueFalse b\n```
+          {
+              return true;
+          }
+
+          public static bool operator ==(TrueFalse a, TrueFalse b)
+//                                       ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
+//                                                 ^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#op_Equality().(a)
+//                                                   documentation ```cs\nTrueFalse a\n```
+//                                                    ^^^^^^^^^ reference scip-dotnet nuget . . Main/Operators#TrueFalse#
+//                                                              ^ definition scip-dotnet nuget . . Main/Operators#TrueFalse#op_Equality().(b)
+//                                                                documentation ```cs\nTrueFalse b\n```
+          {
+              return true;
+          }
+      }
+  }

--- a/snapshots/output-net8.0/syntax/Main/Packages.cs
+++ b/snapshots/output-net8.0/syntax/Main/Packages.cs
@@ -1,0 +1,31 @@
+  using System.Diagnostics.CodeAnalysis;
+//      ^^^^^^ reference scip-dotnet nuget . . System/
+//             ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+//                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+  using DiffPlex.DiffBuilder;
+//      ^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 DiffPlex/
+//               ^^^^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 DiffBuilder/
+  using DiffPlex.DiffBuilder.Model;
+//      ^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 DiffPlex/
+//               ^^^^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 DiffBuilder/
+//                           ^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 Model/
+
+  namespace Main;
+//          ^^^^ reference scip-dotnet nuget . . Main/
+
+  [SuppressMessage("ReSharper", "all")]
+// ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+  public class Packages
+//             ^^^^^^^^ definition scip-dotnet nuget . . Main/Packages#
+//                      documentation ```cs\nclass Packages\n```
+  {
+      DiffPaneModel Diff()
+//    ^^^^^^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 Model/DiffPaneModel#
+//                  ^^^^ definition scip-dotnet nuget . . Main/Packages#Diff().
+//                       documentation ```cs\nprivate DiffPaneModel Packages.Diff()\n```
+      {
+          return InlineDiffBuilder.Diff("a", "b");
+//               ^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 DiffBuilder/InlineDiffBuilder#
+//                                 ^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 DiffBuilder/InlineDiffBuilder#Diff().
+      }
+  }

--- a/snapshots/output-net8.0/syntax/Main/Preprocessors.cs
+++ b/snapshots/output-net8.0/syntax/Main/Preprocessors.cs
@@ -1,0 +1,33 @@
+  using System.Diagnostics.CodeAnalysis;
+//      ^^^^^^ reference scip-dotnet nuget . . System/
+//             ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+//                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  namespace Main;
+//          ^^^^ reference scip-dotnet nuget . . Main/
+
+  [SuppressMessage("ReSharper", "all")]
+// ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+  public class Preprocessors
+//             ^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Preprocessors#
+//                           documentation ```cs\nclass Preprocessors\n```
+  {
+      string OS()
+//           ^^ definition scip-dotnet nuget . . Main/Preprocessors#OS().
+//              documentation ```cs\nprivate string Preprocessors.OS()\n```
+      {
+  #if WIN32
+          string os = "Win32";
+  #warning This class is bad.
+  #error Okay, just stop.
+  #elif MACOS
+          string os = "MacOS";
+  #else
+          string os = "Unknown";
+//               ^^ definition local 0
+//                  documentation ```cs\nstring os\n```
+  #endif
+          return os;
+//               ^^ reference local 0
+      }
+  }

--- a/snapshots/output-net8.0/syntax/Main/Program.cs
+++ b/snapshots/output-net8.0/syntax/Main/Program.cs
@@ -1,0 +1,5 @@
+  // See https://aka.ms/new-console-template for more information
+
+  Console.WriteLine("Hello, World!");
+//^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#
+//        ^^^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#WriteLine(+11).

--- a/snapshots/output-net8.0/syntax/Main/Properties.cs
+++ b/snapshots/output-net8.0/syntax/Main/Properties.cs
@@ -1,0 +1,37 @@
+  using System.Diagnostics.CodeAnalysis;
+//      ^^^^^^ reference scip-dotnet nuget . . System/
+//             ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+//                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  namespace Main;
+//          ^^^^ reference scip-dotnet nuget . . Main/
+
+  [SuppressMessage("ReSharper", "all")]
+// ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+  public class Properties
+//             ^^^^^^^^^^ definition scip-dotnet nuget . . Main/Properties#
+//                        documentation ```cs\nclass Properties\n```
+  {
+      byte Get { get; }
+//         ^^^ definition scip-dotnet nuget . . Main/Properties#Get.
+//             documentation ```cs\nprivate byte Properties.Get { get; }\n```
+
+      char Set
+//         ^^^ definition scip-dotnet nuget . . Main/Properties#Set.
+//             documentation ```cs\nprivate char Properties.Set { set; }\n```
+      {
+          set { throw new NotImplementedException(); }
+//                        ^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/NotImplementedException#
+      }
+
+      uint GetSet { get; set; }
+//         ^^^^^^ definition scip-dotnet nuget . . Main/Properties#GetSet.
+//                documentation ```cs\nprivate uint Properties.GetSet { get; set; }\n```
+      long SetGet { set; get; }
+//         ^^^^^^ definition scip-dotnet nuget . . Main/Properties#SetGet.
+//                documentation ```cs\nprivate long Properties.SetGet { get; set; }\n```
+
+      string? Init { get; init; }
+//            ^^^^ definition scip-dotnet nuget . . Main/Properties#Init.
+//                 documentation ```cs\nprivate string? Properties.Init { get; init; }\n```
+  }

--- a/snapshots/output-net8.0/syntax/Main/QuerySyntax.cs
+++ b/snapshots/output-net8.0/syntax/Main/QuerySyntax.cs
@@ -1,0 +1,247 @@
+  using System.Diagnostics.CodeAnalysis;
+//      ^^^^^^ reference scip-dotnet nuget . . System/
+//             ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+//                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  namespace Main;
+//          ^^^^ reference scip-dotnet nuget . . Main/
+
+  [SuppressMessage("ReSharper", "all")]
+// ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+  public class QuerySyntax
+//             ^^^^^^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#
+//                         documentation ```cs\nclass QuerySyntax\n```
+  {
+      List<IGeneric> sourceA = new List<IGeneric>();
+//         ^^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#IGeneric#
+//                   ^^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#sourceA.
+//                           documentation ```cs\nprivate List<IGeneric> QuerySyntax.sourceA\n```
+//                                      ^^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#IGeneric#
+      List<IGeneric> sourceB = new List<IGeneric>();
+//         ^^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#IGeneric#
+//                   ^^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#sourceB.
+//                           documentation ```cs\nprivate List<IGeneric> QuerySyntax.sourceB\n```
+//                                      ^^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#IGeneric#
+
+      interface IGeneric
+//              ^^^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#IGeneric#
+//                       documentation ```cs\ninterface IGeneric\n```
+      {
+          string Method();
+//               ^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#IGeneric#Method().
+//                      documentation ```cs\nstring IGeneric.Method()\n```
+      }
+
+      void Select()
+//         ^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#Select().
+//                documentation ```cs\nprivate void QuerySyntax.Select()\n```
+      {
+          var x = from a in sourceA select a.Method();
+//            ^ definition local 0
+//              documentation ```cs\nIEnumerable<string>? x\n```
+//                     ^ definition local 1
+//                       documentation ```cs\n? a\n```
+//                          ^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#sourceA.
+//                                         ^ reference local 1
+//                                           ^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#IGeneric#Method().
+      }
+
+      void Projection()
+//         ^^^^^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#Projection().
+//                    documentation ```cs\nprivate void QuerySyntax.Projection()\n```
+      {
+          var x = from a in sourceA select new { Name = a.Method() };
+//            ^ definition local 2
+//              documentation ```cs\nIEnumerable<<anonymous type: string Name>>? x\n```
+//                     ^ definition local 3
+//                       documentation ```cs\n? a\n```
+//                          ^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#sourceA.
+//                                               ^^^^ reference local 5
+//                                                      ^ reference local 3
+//                                                        ^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#IGeneric#Method().
+          var b = from a in x select a.Name;
+//            ^ definition local 6
+//              documentation ```cs\nIEnumerable<string>? b\n```
+//                     ^ definition local 7
+//                       documentation ```cs\n? a\n```
+//                          ^ reference local 2
+//                                   ^ reference local 7
+//                                     ^^^^ reference local 5
+      }
+
+      void Where()
+//         ^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#Where().
+//               documentation ```cs\nprivate void QuerySyntax.Where()\n```
+      {
+          var x = from a in sourceA where a.Method().StartsWith("a") select a;
+//            ^ definition local 8
+//              documentation ```cs\nIEnumerable<IGeneric>? x\n```
+//                     ^ definition local 9
+//                       documentation ```cs\n? a\n```
+//                          ^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#sourceA.
+//                                        ^ reference local 9
+//                                          ^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#IGeneric#Method().
+//                                                   ^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/String#StartsWith(+1).
+//                                                                          ^ reference local 9
+      }
+
+      void Let()
+//         ^^^ definition scip-dotnet nuget . . Main/QuerySyntax#Let().
+//             documentation ```cs\nprivate void QuerySyntax.Let()\n```
+      {
+          var x = from a in sourceA
+//            ^ definition local 10
+//              documentation ```cs\nIEnumerable<<anonymous type: string A, string B>>? x\n```
+//                     ^ definition local 11
+//                       documentation ```cs\n? a\n```
+//                          ^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#sourceA.
+                  let z = new { A = a.Method(), B = a.Method() }
+//                    ^ definition local 12
+//                      documentation ```cs\n? z\n```
+//                              ^ reference local 14
+//                                  ^ reference local 11
+//                                    ^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#IGeneric#Method().
+//                                              ^ reference local 15
+//                                                  ^ reference local 11
+//                                                    ^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#IGeneric#Method().
+                  select z;
+//                       ^ reference local 12
+      }
+
+      void Join()
+//         ^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#Join().
+//              documentation ```cs\nprivate void QuerySyntax.Join()\n```
+      {
+          var x = from a in sourceA
+//            ^ definition local 16
+//              documentation ```cs\nIEnumerable<<anonymous type: string A, string B>>? x\n```
+//                     ^ definition local 17
+//                       documentation ```cs\n? a\n```
+//                          ^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#sourceA.
+                  join b in sourceB on a.Method() equals b.Method()
+//                     ^ definition local 18
+//                       documentation ```cs\n? b\n```
+//                          ^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#sourceB.
+//                                     ^ reference local 17
+//                                       ^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#IGeneric#Method().
+//                                                       ^ reference local 18
+//                                                         ^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#IGeneric#Method().
+                  select new { A = a.Method(), B = b.Method() };
+//                             ^ reference local 14
+//                                 ^ reference local 17
+//                                   ^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#IGeneric#Method().
+//                                             ^ reference local 15
+//                                                 ^ reference local 18
+//                                                   ^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#IGeneric#Method().
+      }
+
+      void MultipleFrom()
+//         ^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#MultipleFrom().
+//                      documentation ```cs\nprivate void QuerySyntax.MultipleFrom()\n```
+      {
+          var x = from a in sourceA
+//            ^ definition local 19
+//              documentation ```cs\nIEnumerable<<anonymous type: string A, string B>>? x\n```
+//                     ^ definition local 20
+//                       documentation ```cs\n? a\n```
+//                          ^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#sourceA.
+                  from b in sourceB
+//                     ^ definition local 21
+//                       documentation ```cs\n? b\n```
+//                          ^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#sourceB.
+                  where a.Method() == b.Method()
+//                      ^ reference local 20
+//                        ^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#IGeneric#Method().
+//                                    ^ reference local 21
+//                                      ^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#IGeneric#Method().
+                  select new { A = a.Method(), B = b.Method() };
+//                             ^ reference local 14
+//                                 ^ reference local 20
+//                                   ^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#IGeneric#Method().
+//                                             ^ reference local 15
+//                                                 ^ reference local 21
+//                                                   ^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#IGeneric#Method().
+      }
+
+      void JoinInto(List<Student> students1, List<Student> students2)
+//         ^^^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#JoinInto().
+//                  documentation ```cs\nprivate void QuerySyntax.JoinInto(List<Student> students1, List<Student> students2)\n```
+//                       ^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#Student#
+//                                ^^^^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#JoinInto().(students1)
+//                                          documentation ```cs\nList<Student> students1\n```
+//                                                ^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#Student#
+//                                                         ^^^^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#JoinInto().(students2)
+//                                                                   documentation ```cs\nList<Student> students2\n```
+      {
+          var innerGroupJoinQuery =
+//            ^^^^^^^^^^^^^^^^^^^ definition local 22
+//                                documentation ```cs\nIEnumerable<<anonymous type: string Student, interface IEnumerable<Student> Students>>? innerGroupJoinQuery\n```
+              from student1 in students1
+//                 ^^^^^^^^ definition local 23
+//                          documentation ```cs\n? student1\n```
+//                             ^^^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#JoinInto().(students1)
+              join student2 in students2 on student1.ID equals student2.ID into studentGroup
+//                 ^^^^^^^^ definition local 24
+//                          documentation ```cs\n? student2\n```
+//                             ^^^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#JoinInto().(students2)
+//                                          ^^^^^^^^ reference local 23
+//                                                   ^^ reference scip-dotnet nuget . . Main/QuerySyntax#Student#ID.
+//                                                             ^^^^^^^^ reference local 24
+//                                                                      ^^ reference scip-dotnet nuget . . Main/QuerySyntax#Student#ID.
+//                                                                              ^^^^^^^^^^^^ definition local 25
+//                                                                                           documentation ```cs\n? studentGroup\n```
+              select new { Student = student1.First, Students = studentGroup };
+//                         ^^^^^^^ reference local 27
+//                                   ^^^^^^^^ reference local 23
+//                                            ^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#Student#First.
+//                                                   ^^^^^^^^ reference local 28
+//                                                              ^^^^^^^^^^^^ reference local 25
+      }
+
+      void Continuation(List<Student> students)
+//         ^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#Continuation().
+//                      documentation ```cs\nprivate void QuerySyntax.Continuation(List<Student> students)\n```
+//                           ^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#Student#
+//                                    ^^^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#Continuation().(students)
+//                                             documentation ```cs\nList<Student> students\n```
+      {
+          var sortedGroups =
+//            ^^^^^^^^^^^^ definition local 29
+//                         documentation ```cs\nIOrderedEnumerable<IGrouping<char, Student>>? sortedGroups\n```
+              from student in students
+//                 ^^^^^^^ definition local 30
+//                         documentation ```cs\n? student\n```
+//                            ^^^^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#Continuation().(students)
+              orderby student.Last, student.First
+//                    ^^^^^^^ reference local 30
+//                            ^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#Student#Last.
+//                                  ^^^^^^^ reference local 30
+//                                          ^^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#Student#First.
+              group student by student.Last[0] into newGroup
+//                  ^^^^^^^ reference local 30
+//                             ^^^^^^^ reference local 30
+//                                     ^^^^ reference scip-dotnet nuget . . Main/QuerySyntax#Student#Last.
+//                                                  ^^^^^^^^ definition local 31
+//                                                           documentation ```cs\n? newGroup\n```
+              orderby newGroup.Key
+//                    ^^^^^^^^ reference local 31
+//                             ^^^ reference scip-dotnet nuget System.Linq 8.0.0.0 Linq/IGrouping#Key.
+              select newGroup;
+//                   ^^^^^^^^ reference local 31
+      }
+
+      private class Student
+//                  ^^^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#Student#
+//                          documentation ```cs\nclass Student\n```
+      {
+          public string First { get; set; }
+//                      ^^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#Student#First.
+//                            documentation ```cs\npublic string Student.First { get; set; }\n```
+          public string Last { get; set; }
+//                      ^^^^ definition scip-dotnet nuget . . Main/QuerySyntax#Student#Last.
+//                           documentation ```cs\npublic string Student.Last { get; set; }\n```
+          public int ID { get; set; }
+//                   ^^ definition scip-dotnet nuget . . Main/QuerySyntax#Student#ID.
+//                      documentation ```cs\npublic int Student.ID { get; set; }\n```
+      }
+  }

--- a/snapshots/output-net8.0/syntax/Main/Records.cs
+++ b/snapshots/output-net8.0/syntax/Main/Records.cs
@@ -1,0 +1,156 @@
+  using System.Diagnostics.CodeAnalysis;
+//      ^^^^^^ reference scip-dotnet nuget . . System/
+//             ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+//                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  namespace Main;
+//          ^^^^ reference scip-dotnet nuget . . Main/
+
+  [SuppressMessage("ReSharper", "all")]
+// ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+  public class Records
+//             ^^^^^^^ definition scip-dotnet nuget . . Main/Records#
+//                     documentation ```cs\nclass Records\n```
+  {
+      record Basic
+//           ^^^^^ definition scip-dotnet nuget . . Main/Records#Basic#
+//                 documentation ```cs\nrecord Basic\n```
+//                 relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IEquatable#
+      {
+          int Age { get; init; }
+//            ^^^ definition scip-dotnet nuget . . Main/Records#Basic#Age.
+//                documentation ```cs\nprivate int Basic.Age { get; init; }\n```
+      }
+
+      record struct Struct
+//                  ^^^^^^ definition scip-dotnet nuget . . Main/Records#Struct#
+//                         documentation ```cs\nrecord struct Struct\n```
+//                         relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IEquatable#
+      {
+          int Age { get; init; }
+//            ^^^ definition scip-dotnet nuget . . Main/Records#Struct#Age.
+//                documentation ```cs\nprivate int Struct.Age { get; init; }\n```
+      }
+
+      record class Class
+//                 ^^^^^ definition scip-dotnet nuget . . Main/Records#Class#
+//                       documentation ```cs\nrecord Class\n```
+//                       relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IEquatable#
+      {
+          int Age { get; init; }
+//            ^^^ definition scip-dotnet nuget . . Main/Records#Class#Age.
+//                documentation ```cs\nprivate int Class.Age { get; init; }\n```
+      }
+
+      public record TypeParameterConstraint<T> where T : struct
+//                  ^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Records#TypeParameterConstraint#
+//                                          documentation ```cs\nrecord TypeParameterConstraint<T> where T : struct\n```
+//                                          relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IEquatable#
+//                                          ^ definition local 0
+//                                            documentation ```cs\nT\n```
+//                                                   ^ reference local 0
+      {
+      }
+
+      interface I1
+//              ^^ definition scip-dotnet nuget . . Main/Records#I1#
+//                 documentation ```cs\ninterface I1\n```
+      {
+      };
+
+      interface I2
+//              ^^ definition scip-dotnet nuget . . Main/Records#I2#
+//                 documentation ```cs\ninterface I2\n```
+      {
+      };
+
+
+      record Person(string FirstName, string LastName) : I1, I2
+//           ^^^^^^ definition scip-dotnet nuget . . Main/Records#Person#
+//                  documentation ```cs\nrecord Person\n```
+//                  relationship implementation scip-dotnet nuget . . Main/Records#I1#
+//                  relationship implementation scip-dotnet nuget . . Main/Records#I2#
+//                  relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IEquatable#
+//                         ^^^^^^^^^ definition scip-dotnet nuget . . Main/Records#Person#`.ctor`().(FirstName)
+//                                   documentation ```cs\nstring FirstName\n```
+//                                           ^^^^^^^^ definition scip-dotnet nuget . . Main/Records#Person#`.ctor`().(LastName)
+//                                                    documentation ```cs\nstring LastName\n```
+//                                                       ^^ reference scip-dotnet nuget . . Main/Records#I1#
+//                                                           ^^ reference scip-dotnet nuget . . Main/Records#I2#
+      {
+          public Person(string FirstName) : this(FirstName, FirstName)
+//               ^^^^^^ definition scip-dotnet nuget . . Main/Records#Person#`.ctor`(+1).
+//                      documentation ```cs\npublic Person.Person(string FirstName)\n```
+//                             ^^^^^^^^^ definition scip-dotnet nuget . . Main/Records#Person#`.ctor`(+1).(FirstName)
+//                                       documentation ```cs\nstring FirstName\n```
+//                                               ^^^^^^^^^ reference scip-dotnet nuget . . Main/Records#Person#`.ctor`(+1).(FirstName)
+//                                                          ^^^^^^^^^ reference scip-dotnet nuget . . Main/Records#Person#`.ctor`(+1).(FirstName)
+          {
+          }
+      };
+
+      record Teacher(string FirstName, string LastName, string Subject) : Person(FirstName, LastName), I1, I2;
+//           ^^^^^^^ definition scip-dotnet nuget . . Main/Records#Teacher#
+//                   documentation ```cs\nrecord Teacher\n```
+//                   relationship implementation scip-dotnet nuget . . Main/Records#Person#
+//                   relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IEquatable#
+//                   relationship implementation scip-dotnet nuget . . Main/Records#I1#
+//                   relationship implementation scip-dotnet nuget . . Main/Records#I2#
+//                   relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IEquatable#
+//                          ^^^^^^^^^ definition scip-dotnet nuget . . Main/Records#Teacher#`.ctor`().(FirstName)
+//                                    documentation ```cs\nstring FirstName\n```
+//                                            ^^^^^^^^ definition scip-dotnet nuget . . Main/Records#Teacher#`.ctor`().(LastName)
+//                                                     documentation ```cs\nstring LastName\n```
+//                                                             ^^^^^^^ definition scip-dotnet nuget . . Main/Records#Teacher#`.ctor`().(Subject)
+//                                                                     documentation ```cs\nstring Subject\n```
+//                                                                        ^^^^^^ reference scip-dotnet nuget . . Main/Records#Person#
+//                                                                               ^^^^^^^^^ reference scip-dotnet nuget . . Main/Records#Teacher#`.ctor`().(FirstName)
+//                                                                                          ^^^^^^^^ reference scip-dotnet nuget . . Main/Records#Teacher#`.ctor`().(LastName)
+//                                                                                                     ^^ reference scip-dotnet nuget . . Main/Records#I1#
+//                                                                                                         ^^ reference scip-dotnet nuget . . Main/Records#I2#
+
+      void UsingRecords()
+//         ^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Records#UsingRecords().
+//                      documentation ```cs\nprivate void Records.UsingRecords()\n```
+      {
+          var person = new Person("a", "b");
+//            ^^^^^^ definition local 1
+//                   documentation ```cs\nPerson? person\n```
+//                         ^^^^^^ reference scip-dotnet nuget . . Main/Records#Person#
+          var teacher = new Teacher("a", "b", "c");
+//            ^^^^^^^ definition local 2
+//                    documentation ```cs\nTeacher? teacher\n```
+//                          ^^^^^^^ reference scip-dotnet nuget . . Main/Records#Teacher#
+      }
+
+      record I3<T>;
+//           ^^ definition scip-dotnet nuget . . Main/Records#I3#
+//              documentation ```cs\nrecord I3<T>\n```
+//              relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IEquatable#
+//              ^ definition local 3
+//                documentation ```cs\nT\n```
+
+      record Teacher2() : I3<Person>(), I1;
+//           ^^^^^^^^ definition scip-dotnet nuget . . Main/Records#Teacher2#
+//                    documentation ```cs\nrecord Teacher2\n```
+//                    relationship implementation scip-dotnet nuget . . Main/Records#I3#
+//                    relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IEquatable#
+//                    relationship implementation scip-dotnet nuget . . Main/Records#I1#
+//                    relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IEquatable#
+//                           ^^^^^^ reference scip-dotnet nuget . . Main/Records#Person#
+//                                      ^^ reference scip-dotnet nuget . . Main/Records#I1#
+
+      record SealedToString
+//           ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Records#SealedToString#
+//                          documentation ```cs\nrecord SealedToString\n```
+//                          relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IEquatable#
+      {
+          public sealed override string ToString()
+//                                      ^^^^^^^^ definition scip-dotnet nuget . . Main/Records#SealedToString#ToString().
+//                                               documentation ```cs\npublic override sealed string SealedToString.ToString()\n```
+//                                               relationship implementation reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Object#ToString().
+          {
+              return "";
+          }
+      }
+  }

--- a/snapshots/output-net8.0/syntax/Main/Statements.cs
+++ b/snapshots/output-net8.0/syntax/Main/Statements.cs
@@ -1,0 +1,224 @@
+  using System.Diagnostics.CodeAnalysis;
+//      ^^^^^^ reference scip-dotnet nuget . . System/
+//             ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+//                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  namespace Main;
+//          ^^^^ reference scip-dotnet nuget . . Main/
+
+  [SuppressMessage("ReSharper", "all")]
+// ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+  public class Statements
+//             ^^^^^^^^^^ definition scip-dotnet nuget . . Main/Statements#
+//                        documentation ```cs\nclass Statements\n```
+  {
+      void Try()
+//         ^^^ definition scip-dotnet nuget . . Main/Statements#Try().
+//             documentation ```cs\nprivate void Statements.Try()\n```
+      {
+          try
+          {
+              File.ReadLines("asd");
+//            ^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 IO/File#
+//                 ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 IO/File#ReadLines().
+          }
+          catch (Exception err)
+//               ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Exception#
+//                         ^^^ definition local 0
+//                             documentation ```cs\nException err\n```
+          {
+              Console.WriteLine(err);
+//            ^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#
+//                    ^^^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#WriteLine(+9).
+//                              ^^^ reference local 0
+          }
+      }
+
+      (string a, bool b) Default()
+//                       ^^^^^^^ definition scip-dotnet nuget . . Main/Statements#Default().
+//                               documentation ```cs\nprivate (string a, bool b) Statements.Default()\n```
+      {
+          (string a, bool b) c = default;
+//                           ^ definition local 1
+//                             documentation ```cs\n(string a, bool b) c\n```
+          return c;
+//               ^ reference local 1
+      }
+
+      void Deconstruction()
+//         ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Statements#Deconstruction().
+//                        documentation ```cs\nprivate void Statements.Deconstruction()\n```
+      {
+          var point = (1, 2);
+//            ^^^^^ definition local 2
+//                  documentation ```cs\n(int, int) point\n```
+          int x = 0;
+//            ^ definition local 3
+//              documentation ```cs\nint x\n```
+          (x, int y) = point;
+//         ^ reference local 3
+//                ^ definition local 4
+//                  documentation ```cs\nint y\n```
+//                     ^^^^^ reference local 2
+      }
+
+      record Inferred(int F1, int F2);
+//           ^^^^^^^^ definition scip-dotnet nuget . . Main/Statements#Inferred#
+//                    documentation ```cs\nrecord Inferred\n```
+//                    relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IEquatable#
+//                        ^^ definition scip-dotnet nuget . . Main/Statements#Inferred#`.ctor`().(F1)
+//                           documentation ```cs\nint F1\n```
+//                                ^^ definition scip-dotnet nuget . . Main/Statements#Inferred#`.ctor`().(F2)
+//                                   documentation ```cs\nint F2\n```
+
+      void InferredTuples()
+//         ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Statements#InferredTuples().
+//                        documentation ```cs\nprivate void Statements.InferredTuples()\n```
+      {
+          var list = new List<Inferred>();
+//            ^^^^ definition local 5
+//                 documentation ```cs\nList<Inferred>? list\n```
+//                            ^^^^^^^^ reference scip-dotnet nuget . . Main/Statements#Inferred#
+          var result = list.Select(c => (c.F1, c.F2)).Where(t => t.F2 == 1);
+//            ^^^^^^ definition local 6
+//                   documentation ```cs\nIEnumerable<(int F1, int F2)>? result\n```
+//                     ^^^^ reference local 5
+//                          ^^^^^^ reference scip-dotnet nuget System.Linq 8.0.0.0 Linq/Enumerable#Select().
+//                                 ^ definition local 8
+//                                   documentation ```cs\nInferred c\n```
+//                                       ^ reference local 8
+//                                         ^^ reference scip-dotnet nuget . . Main/Statements#Inferred#F1.
+//                                             ^ reference local 8
+//                                               ^^ reference scip-dotnet nuget . . Main/Statements#Inferred#F2.
+//                                                    ^^^^^ reference scip-dotnet nuget System.Linq 8.0.0.0 Linq/Enumerable#Where().
+//                                                          ^ definition local 10
+//                                                            documentation ```cs\n(int F1, int F2) t\n```
+//                                                               ^ reference local 10
+//                                                                 ^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/ValueTuple#F2.
+      }
+
+      int MultipleInitializers()
+//        ^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Statements#MultipleInitializers().
+//                             documentation ```cs\nprivate int Statements.MultipleInitializers()\n```
+      {
+          int a = 1, b = 2;
+//            ^ definition local 11
+//              documentation ```cs\nint a\n```
+//                   ^ definition local 12
+//                     documentation ```cs\nint b\n```
+          return a + b;
+//               ^ reference local 11
+//                   ^ reference local 12
+      }
+
+      void RefVariable()
+//         ^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Statements#RefVariable().
+//                     documentation ```cs\nprivate void Statements.RefVariable()\n```
+      {
+          var data = new int[] { 1, 2 };
+//            ^^^^ definition local 13
+//                 documentation ```cs\nint[]? data\n```
+          ref var value = ref data[0];
+//                ^^^^^ definition local 14
+//                      documentation ```cs\nref int value\n```
+//                            ^^^^ reference local 13
+      }
+
+      class MyDisposable : IDisposable
+//          ^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Statements#MyDisposable#
+//                       documentation ```cs\nclass MyDisposable\n```
+//                       relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IDisposable#
+//                         ^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/IDisposable#
+      {
+          public void Dispose()
+//                    ^^^^^^^ definition scip-dotnet nuget . . Main/Statements#MyDisposable#Dispose().
+//                            documentation ```cs\npublic void MyDisposable.Dispose()\n```
+//                            relationship implementation reference scip-dotnet nuget System.Runtime 8.0.0.0 System/IDisposable#Dispose().
+          {
+          }
+      }
+
+      MyDisposable Using()
+//    ^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Statements#MyDisposable#
+//                 ^^^^^ definition scip-dotnet nuget . . Main/Statements#Using().
+//                       documentation ```cs\nprivate MyDisposable Statements.Using()\n```
+      {
+          var b = new MyDisposable();
+//            ^ definition local 15
+//              documentation ```cs\nMyDisposable? b\n```
+//                    ^^^^^^^^^^^^ reference scip-dotnet nuget . . Main/Statements#MyDisposable#
+          using (var a = b)
+//                   ^ definition local 16
+//                     documentation ```cs\nMyDisposable? a\n```
+//                       ^ reference local 15
+          {
+              return a;
+//                   ^ reference local 16
+          }
+      }
+
+      long MultipleUsing()
+//         ^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Statements#MultipleUsing().
+//                       documentation ```cs\nprivate long Statements.MultipleUsing()\n```
+      {
+          using (Stream a = File.OpenRead("a"), b = File.OpenRead("a"))
+//               ^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 IO/Stream#
+//                      ^ definition local 17
+//                        documentation ```cs\nStream a\n```
+//                          ^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 IO/File#
+//                               ^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 IO/File#OpenRead().
+//                                              ^ definition local 18
+//                                                documentation ```cs\nStream b\n```
+//                                                  ^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 IO/File#
+//                                                       ^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 IO/File#OpenRead().
+          {
+              return a.Length + b.Length;
+//                   ^ reference local 17
+//                     ^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 IO/Stream#Length.
+//                              ^ reference local 18
+//                                ^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 IO/Stream#Length.
+          }
+      }
+
+      int Foreach()
+//        ^^^^^^^ definition scip-dotnet nuget . . Main/Statements#Foreach().
+//                documentation ```cs\nprivate int Statements.Foreach()\n```
+      {
+          var y = new int[] { 1 };
+//            ^ definition local 19
+//              documentation ```cs\nint[]? y\n```
+          var z = 0;
+//            ^ definition local 20
+//              documentation ```cs\nint z\n```
+          foreach (int x in y)
+//                     ^ definition local 21
+//                       documentation ```cs\nint x\n```
+//                          ^ reference local 19
+              z += x;
+//            ^ reference local 20
+//                 ^ reference local 21
+          return z;
+//               ^ reference local 20
+      }
+
+      void ForeachVariable(List<(int, int)> names)
+//         ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Statements#ForeachVariable().
+//                         documentation ```cs\nprivate void Statements.ForeachVariable(List<(int, int)> names)\n```
+//                                          ^^^^^ definition scip-dotnet nuget . . Main/Statements#ForeachVariable().(names)
+//                                                documentation ```cs\nList<(int, int)> names\n```
+      {
+          foreach ((int firstName, int lastName) in names)
+//                      ^^^^^^^^^ definition local 22
+//                                documentation ```cs\nint firstName\n```
+//                                     ^^^^^^^^ definition local 23
+//                                              documentation ```cs\nint lastName\n```
+//                                                  ^^^^^ reference scip-dotnet nuget . . Main/Statements#ForeachVariable().(names)
+          {
+              Console.WriteLine($"FirstName:{firstName}, LastName:{lastName}");
+//            ^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#
+//                    ^^^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#WriteLine(+11).
+//                                           ^^^^^^^^^ reference local 22
+//                                                                 ^^^^^^^^ reference local 23
+          }
+      }
+  }

--- a/snapshots/output-net8.0/syntax/Main/Structs.cs
+++ b/snapshots/output-net8.0/syntax/Main/Structs.cs
@@ -1,0 +1,34 @@
+  using System.Diagnostics.CodeAnalysis;
+//      ^^^^^^ reference scip-dotnet nuget . . System/
+//             ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+//                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  namespace Main;
+//          ^^^^ reference scip-dotnet nuget . . Main/
+
+  [SuppressMessage("ReSharper", "all")]
+// ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+  public class Structs
+//             ^^^^^^^ definition scip-dotnet nuget . . Main/Structs#
+//                     documentation ```cs\nclass Structs\n```
+  {
+      struct BasicStruct
+//           ^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Structs#BasicStruct#
+//                       documentation ```cs\nstruct BasicStruct\n```
+      {
+          public int Property1;
+//                   ^^^^^^^^^ definition scip-dotnet nuget . . Main/Structs#BasicStruct#Property1.
+//                             documentation ```cs\npublic int BasicStruct.Property1\n```
+
+          public BasicStruct(int field1)
+//               ^^^^^^^^^^^ definition scip-dotnet nuget . . Main/Structs#BasicStruct#`.ctor`().
+//                           documentation ```cs\npublic BasicStruct.BasicStruct(int field1)\n```
+//                               ^^^^^^ definition scip-dotnet nuget . . Main/Structs#BasicStruct#`.ctor`().(field1)
+//                                      documentation ```cs\nint field1\n```
+          {
+              Property1 = field1;
+//            ^^^^^^^^^ reference scip-dotnet nuget . . Main/Structs#BasicStruct#Property1.
+//                        ^^^^^^ reference scip-dotnet nuget . . Main/Structs#BasicStruct#`.ctor`().(field1)
+          }
+      }
+  }

--- a/snapshots/output-net8.0/syntax/VBMain/CaseInsensitive.vb
+++ b/snapshots/output-net8.0/syntax/VBMain/CaseInsensitive.vb
@@ -1,0 +1,17 @@
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      Public Class CaseInsensitive
+'                  ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/CaseInsensitive#
+'                                  documentation ```vb\nClass CaseInsensitive\n```
+          Public Sub DifferentCase(wEiRdCaSiNg As String)
+'                    ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/CaseInsensitive#DifferentCase().
+'                                  documentation ```vb\nPublic Sub CaseInsensitive.DifferentCase(wEiRdCaSiNg As String)\n```
+'                                  ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/CaseInsensitive#DifferentCase().(wEiRdCaSiNg)
+'                                              documentation ```vb\nwEiRdCaSiNg As String\n```
+              Console.WriteLine(WeIrDcAsInG)
+'             ^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#
+'                     ^^^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#WriteLine(+11).
+'                               ^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/CaseInsensitive#DifferentCase().(wEiRdCaSiNg)
+          End Sub
+      End Class
+  End Namespace

--- a/snapshots/output-net8.0/syntax/VBMain/Classes.vb
+++ b/snapshots/output-net8.0/syntax/VBMain/Classes.vb
@@ -1,0 +1,182 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Classes
+'                  ^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#
+'                          documentation ```vb\nClass Classes\n```
+
+          Public Name As String
+'                ^^^^ definition scip-dotnet nuget . . VBMain/Classes#Name.
+'                     documentation ```vb\nPublic Classes.Name As String\n```
+          Public Const IntConstant As Integer = 1
+'                      ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#IntConstant.
+'                                  documentation ```vb\nPublic Const Classes.IntConstant As Integer = 1\n```
+          Public Const StringConstant As String = "hello"
+'                      ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#StringConstant.
+'                                     documentation ```vb\nPublic Const Classes.StringConstant As String = "hello"\n```
+
+          Public Sub New(ByVal name As Integer)
+'                    ^^^ definition scip-dotnet nuget . . VBMain/Classes#`.ctor`().
+'                        documentation ```vb\nPublic Sub Classes.New(name As Integer)\n```
+'                              ^^^^ definition scip-dotnet nuget . . VBMain/Classes#`.ctor`().(name)
+'                                   documentation ```vb\nname As Integer\n```
+              Me.Name = "name"
+'                ^^^^ reference scip-dotnet nuget . . VBMain/Classes#Name.
+          End Sub
+
+          Public Sub New(ByVal name As String)
+'                    ^^^ definition scip-dotnet nuget . . VBMain/Classes#`.ctor`(+1).
+'                        documentation ```vb\nPublic Sub Classes.New(name As String)\n```
+'                              ^^^^ definition scip-dotnet nuget . . VBMain/Classes#`.ctor`(+1).(name)
+'                                   documentation ```vb\nname As String\n```
+              Me.Name = name
+'                ^^^^ reference scip-dotnet nuget . . VBMain/Classes#Name.
+'                       ^^^^ reference scip-dotnet nuget . . VBMain/Classes#`.ctor`(+1).(name)
+          End Sub
+
+          Protected Overrides Sub Finalize()
+'                                 ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#Finalize().
+'                                          documentation ```vb\nProtected Overrides Sub Classes.Finalize()\n```
+'                                          relationship implementation reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Object#Finalize().
+              Console.WriteLine(42)
+'             ^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#
+'                     ^^^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#WriteLine(+7).
+          End Sub
+
+          Public Class ObjectClass
+'                      ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ObjectClass#
+'                                  documentation ```vb\nClass ObjectClass\n```
+'                                  relationship implementation scip-dotnet nuget . . VBMain/Classes#SomeInterface#
+              Inherits Object
+              Implements SomeInterface
+'                        ^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Classes#SomeInterface#
+          End Class
+
+          Public Partial Class PartialClass
+'                              ^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#PartialClass#
+'                                           documentation ```vb\nClass PartialClass\n```
+          End Class
+
+          Class TypeParameterClass(Of T)
+'               ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#TypeParameterClass#
+'                                  documentation ```vb\nClass TypeParameterClass(Of T)\n```
+'                                     ^ definition local 0
+'                                       documentation ```vb\nT\n```
+          End Class
+
+          Friend Class InternalMultipleTypeParametersClass(Of T1, T2)
+'                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#InternalMultipleTypeParametersClass#
+'                                                          documentation ```vb\nClass InternalMultipleTypeParametersClass(Of T1, T2)\n```
+'                                                             ^^ definition local 1
+'                                                                documentation ```vb\nT1\n```
+'                                                                 ^^ definition local 2
+'                                                                    documentation ```vb\nT2\n```
+          End Class
+
+          Interface ICovariantContravariant(Of In T1, Out T2)
+'                   ^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#
+'                                           documentation ```vb\nInterface ICovariantContravariant(Of In T1, Out T2)\n```
+'                                                 ^^ definition local 3
+'                                                    documentation ```vb\nIn T1\n```
+'                                                         ^^ definition local 4
+'                                                            documentation ```vb\nOut T2\n```
+              Sub Method1(ByVal t1 As T1)
+'                 ^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method1().
+'                         documentation ```vb\nSub ICovariantContravariant(Of In T1, Out T2).Method1(t1 As T1)\n```
+'                               ^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method1().(t1)
+'                                  documentation ```vb\nt1 As T1\n```
+'                                     ^^ reference local 3
+
+              Function Method2() As T2
+'                      ^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ICovariantContravariant#Method2().
+'                              documentation ```vb\nFunction ICovariantContravariant(Of In T1, Out T2).Method2() As T2\n```
+'                                   ^^ reference local 4
+
+          End Interface
+
+          Public Class StructConstraintClass(Of T As Structure)
+'                      ^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#StructConstraintClass#
+'                                            documentation ```vb\nClass StructConstraintClass(Of T As Structure)\n```
+'                                               ^ definition local 5
+'                                                 documentation ```vb\nT\n```
+          End Class
+
+          Public Class ClassConstraintClass(Of T As Class)
+'                      ^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#ClassConstraintClass#
+'                                           documentation ```vb\nClass ClassConstraintClass(Of T As Class)\n```
+'                                              ^ definition local 6
+'                                                documentation ```vb\nT\n```
+          End Class
+
+          Public Class NewConstraintClass(Of T As New)
+'                      ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#NewConstraintClass#
+'                                         documentation ```vb\nClass NewConstraintClass(Of T As New)\n```
+'                                            ^ definition local 7
+'                                              documentation ```vb\nT\n```
+          End Class
+
+          Public Class TypeParameterConstraintClass(Of T As SomeInterface)
+'                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#TypeParameterConstraintClass#
+'                                                   documentation ```vb\nClass TypeParameterConstraintClass(Of T As SomeInterface)\n```
+'                                                      ^ definition local 8
+'                                                        documentation ```vb\nT\n```
+'                                                           ^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Classes#SomeInterface#
+          End Class
+
+          Private Class MultipleTypeParameterConstraintsClass(Of T1 As {SomeInterface, SomeInterface2, New}, T2 As SomeInterface2)
+'                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#MultipleTypeParameterConstraintsClass#
+'                                                             documentation ```vb\nClass MultipleTypeParameterConstraintsClass(Of T1 As {SomeInterface, SomeInterface2, New}, T2 As SomeInterface2)\n```
+'                                                                ^^ definition local 9
+'                                                                   documentation ```vb\nT1\n```
+'                                                                       ^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Classes#SomeInterface#
+'                                                                                      ^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Classes#SomeInterface2#
+'                                                                                                            ^^ definition local 10
+'                                                                                                               documentation ```vb\nT2\n```
+'                                                                                                                  ^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Classes#SomeInterface2#
+          End Class
+
+          Class IndexClass
+'               ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#IndexClass#
+'                          documentation ```vb\nClass IndexClass\n```
+              Private a As Boolean
+'                     ^ definition scip-dotnet nuget . . VBMain/Classes#IndexClass#a.
+'                       documentation ```vb\nPrivate IndexClass.a As Boolean\n```
+
+              Default Public Property Item(ByVal index As Integer) As Boolean
+'                                     ^^^^ definition scip-dotnet nuget . . VBMain/Classes#IndexClass#Item.
+'                                          documentation ```vb\nPublic Default Property IndexClass.Item(index As Integer) As Boolean\n```
+'                                                ^^^^^ definition scip-dotnet nuget . . VBMain/Classes#IndexClass#Item.(index)
+'                                                      documentation ```vb\nindex As Integer\n```
+                  Get
+                      Return a
+'                            ^ reference scip-dotnet nuget . . VBMain/Classes#IndexClass#a.
+                  End Get
+                  Set(ByVal value As Boolean)
+'                           ^^^^^ definition scip-dotnet nuget . . VBMain/Classes#IndexClass#set_Item().(value)
+'                                 documentation ```vb\nvalue As Boolean\n```
+                      a = value
+'                     ^ reference scip-dotnet nuget . . VBMain/Classes#IndexClass#a.
+'                         ^^^^^ reference scip-dotnet nuget . . VBMain/Classes#IndexClass#set_Item().(value)
+                  End Set
+              End Property
+          End Class
+
+          Interface SomeInterface
+'                   ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#SomeInterface#
+'                                 documentation ```vb\nInterface SomeInterface\n```
+          End Interface
+
+          Friend Interface SomeInterface2
+'                          ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Classes#SomeInterface2#
+'                                         documentation ```vb\nInterface SomeInterface2\n```
+          End Interface
+
+      End Class
+
+  End Namespace

--- a/snapshots/output-net8.0/syntax/VBMain/Enums.vb
+++ b/snapshots/output-net8.0/syntax/VBMain/Enums.vb
@@ -1,0 +1,43 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Enums
+'                  ^^^^^ definition scip-dotnet nuget . . VBMain/Enums#
+'                        documentation ```vb\nClass Enums\n```
+          Enum EnumWithIntValues
+'              ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Enums#EnumWithIntValues#
+'                                documentation ```vb\nEnum EnumWithIntValues\n```
+'                                relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IComparable#
+'                                relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IConvertible#
+'                                relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/ISpanFormattable#
+'                                relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IFormattable#
+              Ten = 10
+'             ^^^ definition scip-dotnet nuget . . VBMain/Enums#EnumWithIntValues#Ten.
+'                 documentation ```vb\nEnumWithIntValues.Ten = 10\n```
+              Twenty = 20
+'             ^^^^^^ definition scip-dotnet nuget . . VBMain/Enums#EnumWithIntValues#Twenty.
+'                    documentation ```vb\nEnumWithIntValues.Twenty = 20\n```
+          End Enum
+
+          Enum EnumWithByteValues
+'              ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Enums#EnumWithByteValues#
+'                                 documentation ```vb\nEnum EnumWithByteValues\n```
+'                                 relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IComparable#
+'                                 relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IConvertible#
+'                                 relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/ISpanFormattable#
+'                                 relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IFormattable#
+              Five = &H5
+'             ^^^^ definition scip-dotnet nuget . . VBMain/Enums#EnumWithByteValues#Five.
+'                  documentation ```vb\nEnumWithByteValues.Five = 5\n```
+              Fifteen = &HF
+'             ^^^^^^^ definition scip-dotnet nuget . . VBMain/Enums#EnumWithByteValues#Fifteen.
+'                     documentation ```vb\nEnumWithByteValues.Fifteen = 15\n```
+          End Enum
+      End Class
+  End Namespace

--- a/snapshots/output-net8.0/syntax/VBMain/Events.vb
+++ b/snapshots/output-net8.0/syntax/VBMain/Events.vb
@@ -1,0 +1,78 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Events
+'                  ^^^^^^ definition scip-dotnet nuget . . VBMain/Events#
+'                         documentation ```vb\nClass Events\n```
+          Private EventHandlerList As New ArrayList
+'                 ^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Events#EventHandlerList.
+'                                  documentation ```vb\nPrivate Events.EventHandlerList As ArrayList\n```
+'                                         ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 Collections/ArrayList#
+
+          Public Event Event1 As EventHandler(Of Integer)
+'                      ^^^^^^ definition scip-dotnet nuget . . VBMain/Events#Event1#
+'                             documentation ```vb\nPublic Event Events.Event1 As EventHandler(Of Integer)\n```
+
+          Public Custom Event Event2 As EventHandler
+'                             ^^^^^^ definition scip-dotnet nuget . . VBMain/Events#Event2#
+'                                    documentation ```vb\nPublic Event Events.Event2 As EventHandler\n```
+'                                       ^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/EventHandler#
+
+              AddHandler(ByVal value As EventHandler)
+'                              ^^^^^ definition scip-dotnet nuget . . VBMain/Events#add_Event2().(value)
+'                                    documentation ```vb\nvalue As EventHandler\n```
+'                                       ^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/EventHandler#
+                  EventHandlerList.Add(value)
+'                 ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Events#EventHandlerList.
+'                                  ^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 Collections/ArrayList#Add().
+'                                      ^^^^^ reference scip-dotnet nuget . . VBMain/Events#add_Event2().(value)
+              End AddHandler
+
+              RemoveHandler(ByVal value As EventHandler)
+'                                 ^^^^^ definition scip-dotnet nuget . . VBMain/Events#remove_Event2().(value)
+'                                       documentation ```vb\nvalue As EventHandler\n```
+'                                          ^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/EventHandler#
+                  EventHandlerList.Remove(value)
+'                 ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Events#EventHandlerList.
+'                                  ^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 Collections/ArrayList#Remove().
+'                                         ^^^^^ reference scip-dotnet nuget . . VBMain/Events#remove_Event2().(value)
+              End RemoveHandler
+
+              RaiseEvent(ByVal sender As Object, ByVal e As EventArgs)
+'                              ^^^^^^ definition scip-dotnet nuget . . VBMain/Events#raise_Event2().(sender)
+'                                     documentation ```vb\nsender As Object\n```
+'                                                      ^ definition scip-dotnet nuget . . VBMain/Events#raise_Event2().(e)
+'                                                        documentation ```vb\ne As EventArgs\n```
+'                                                           ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/EventArgs#
+                  For Each handler As EventHandler In EventHandlerList
+'                          ^^^^^^^ definition local 0
+'                                  documentation ```vb\nhandler As Delegate Sub EventHandler(sender As Object, e As EventArgs)\n```
+'                                     ^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/EventHandler#
+'                                                     ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Events#EventHandlerList.
+                      If handler IsNot Nothing Then
+'                        ^^^^^^^ reference local 0
+                          handler.BeginInvoke(sender, e, Nothing, Nothing)
+'                         ^^^^^^^ reference local 0
+'                                 ^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/EventHandler#BeginInvoke().
+'                                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Events#raise_Event2().(sender)
+'                                                     ^ reference scip-dotnet nuget . . VBMain/Events#raise_Event2().(e)
+                      End If
+                  Next
+              End RaiseEvent
+          End Event
+
+          Private Sub Event1Handler() Handles Me.Event1
+'                     ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Events#Event1Handler().
+'                                   documentation ```vb\nPrivate Sub Events.Event1Handler()\n```
+'                                                ^^^^^^ reference scip-dotnet nuget . . VBMain/Events#Event1#
+              Throw New NotImplementedException()
+'                       ^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/NotImplementedException#
+          End Sub
+      End Class
+  End Namespace

--- a/snapshots/output-net8.0/syntax/VBMain/Expressions.vb
+++ b/snapshots/output-net8.0/syntax/VBMain/Expressions.vb
@@ -1,0 +1,656 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Expressions
+'                  ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#
+'                              documentation ```vb\nClass Expressions\n```
+
+          Private Sub AssignmentToPrefixUnaryExpressions()
+'                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AssignmentToPrefixUnaryExpressions().
+'                                                        documentation ```vb\nPrivate Sub Expressions.AssignmentToPrefixUnaryExpressions()\n```
+              Dim A = 42
+'                 ^ definition local 0
+'                   documentation ```vb\nA As Integer\n```
+              Dim B = 42
+'                 ^ definition local 1
+'                   documentation ```vb\nB As Integer\n```
+              A = +A
+'             ^ reference local 0
+'                  ^ reference local 0
+              A = -A
+'             ^ reference local 0
+'                  ^ reference local 0
+              A = Not A
+'             ^ reference local 0
+'                     ^ reference local 0
+              B = A
+'             ^ reference local 1
+'                 ^ reference local 0
+              Dim C = True
+'                 ^ definition local 2
+'                   documentation ```vb\nC As Boolean\n```
+              C = Not C
+'             ^ reference local 2
+'                     ^ reference local 2
+          End Sub
+
+          Private Sub AssignmentToPrefixBinaryExpressions()
+'                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AssignmentToPrefixBinaryExpressions().
+'                                                         documentation ```vb\nPrivate Sub Expressions.AssignmentToPrefixBinaryExpressions()\n```
+              Dim A = 42
+'                 ^ definition local 3
+'                   documentation ```vb\nA As Integer\n```
+              A = A + A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                     ^ reference local 3
+              A = A - A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                     ^ reference local 3
+              A = A * A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                     ^ reference local 3
+              A = A / A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                     ^ reference local 3
+              A = A \ A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                     ^ reference local 3
+              A = A ^ A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                     ^ reference local 3
+              A = A Mod A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                       ^ reference local 3
+              A = A And A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                       ^ reference local 3
+              A = A Or A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                      ^ reference local 3
+              A = A Xor A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                       ^ reference local 3
+              A = A << A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                      ^ reference local 3
+              A = A >> A
+'             ^ reference local 3
+'                 ^ reference local 3
+'                      ^ reference local 3
+          End Sub
+
+          Private Sub AssignmentToBinaryEqualityExpression()
+'                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AssignmentToBinaryEqualityExpression().
+'                                                          documentation ```vb\nPrivate Sub Expressions.AssignmentToBinaryEqualityExpression()\n```
+              Dim A = True
+'                 ^ definition local 4
+'                   documentation ```vb\nA As Boolean\n```
+              Dim B = True
+'                 ^ definition local 5
+'                   documentation ```vb\nB As Boolean\n```
+              Dim C = 42
+'                 ^ definition local 6
+'                   documentation ```vb\nC As Integer\n```
+              Dim D = 42
+'                 ^ definition local 7
+'                   documentation ```vb\nD As Integer\n```
+              A = A = B
+'             ^ reference local 4
+'                 ^ reference local 4
+'                     ^ reference local 5
+              A = A <> B
+'             ^ reference local 4
+'                 ^ reference local 4
+'                      ^ reference local 5
+              A = C < D
+'             ^ reference local 4
+'                 ^ reference local 6
+'                     ^ reference local 7
+              A = C <= D
+'             ^ reference local 4
+'                 ^ reference local 6
+'                      ^ reference local 7
+              A = C > D
+'             ^ reference local 4
+'                 ^ reference local 6
+'                     ^ reference local 7
+              A = C >= D
+'             ^ reference local 4
+'                 ^ reference local 6
+'                      ^ reference local 7
+          End Sub
+
+          Private Sub AssignmentToBinaryExpression()
+'                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AssignmentToBinaryExpression().
+'                                                  documentation ```vb\nPrivate Sub Expressions.AssignmentToBinaryExpression()\n```
+              Dim A = 42
+'                 ^ definition local 8
+'                   documentation ```vb\nA As Integer\n```
+              A += A
+'             ^ reference local 8
+'                  ^ reference local 8
+              A -= A
+'             ^ reference local 8
+'                  ^ reference local 8
+              A *= A
+'             ^ reference local 8
+'                  ^ reference local 8
+              A /= A
+'             ^ reference local 8
+'                  ^ reference local 8
+              A \= A
+'             ^ reference local 8
+'                  ^ reference local 8
+              A &= A
+'             ^ reference local 8
+'                  ^ reference local 8
+              A <<= A
+'             ^ reference local 8
+'                   ^ reference local 8
+              A >>= A
+'             ^ reference local 8
+'                   ^ reference local 8
+              A ^= A
+'             ^ reference local 8
+'                  ^ reference local 8
+          End Sub
+
+          Structure Struct
+'                   ^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Struct#
+'                          documentation ```vb\nStructure Struct\n```
+              Public [Property] As Integer
+'                    ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Struct#Property.
+'                               documentation ```vb\nPublic Struct.Property As Integer\n```
+          End Structure
+
+          Structure IndexedClass
+'                   ^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#IndexedClass#
+'                                documentation ```vb\nStructure IndexedClass\n```
+              Public [Property] As Integer
+'                    ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Property.
+'                               documentation ```vb\nPublic IndexedClass.Property As Integer\n```
+
+              Default Public Property Item(ByVal index As Integer) As Integer
+'                                     ^^^^ definition scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Item.
+'                                          documentation ```vb\nPublic Default Property IndexedClass.Item(index As Integer) As Integer\n```
+'                                                ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Item.(index)
+'                                                      documentation ```vb\nindex As Integer\n```
+                  Get
+                      Return [Property]
+'                            ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Property.
+                  End Get
+                  Set(ByVal value As Integer)
+'                           ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#IndexedClass#set_Item().(value)
+'                                 documentation ```vb\nvalue As Integer\n```
+                      [Property] = value
+'                     ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Property.
+'                                  ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#set_Item().(value)
+                  End Set
+              End Property
+          End Structure
+
+          Private Sub AssignmentToLeftValueTypes()
+'                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AssignmentToLeftValueTypes().
+'                                                documentation ```vb\nPrivate Sub Expressions.AssignmentToLeftValueTypes()\n```
+              Dim E As (A As Integer, B As Integer) = (1, 2)
+'                 ^ definition local 9
+'                   documentation ```vb\nE As (A As Integer, B As Integer)\n```
+              Dim A = 1
+'                 ^ definition local 10
+'                   documentation ```vb\nA As Integer\n```
+              Dim C = New Struct With {
+'                 ^ definition local 11
+'                   documentation ```vb\nC As Structure Struct\n```
+'                         ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Struct#
+                  .[Property] = 42
+'                  ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Struct#Property.
+              }
+              C.[Property] = 1
+'             ^ reference local 11
+'               ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Struct#Property.
+              Dim D = New IndexedClass()
+'                 ^ definition local 12
+'                   documentation ```vb\nD As Structure IndexedClass\n```
+'                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#
+              D(E.B) = 1
+'             ^ reference local 12
+'               ^ reference local 9
+'                 ^ reference local 14
+              Dim X = New IndexedClass With {
+'                 ^ definition local 15
+'                   documentation ```vb\nX As Structure IndexedClass\n```
+'                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#
+                  .[Property] = 1
+'                  ^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#IndexedClass#Property.
+              }
+              E.A = 1
+'             ^ reference local 9
+'               ^ reference local 16
+          End Sub
+
+          Private Sub TernaryExpression()
+'                     ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#TernaryExpression().
+'                                       documentation ```vb\nPrivate Sub Expressions.TernaryExpression()\n```
+              Dim X = True
+'                 ^ definition local 17
+'                   documentation ```vb\nX As Boolean\n```
+              Dim Y = If(X, "foo", "bar")
+'                 ^ definition local 18
+'                   documentation ```vb\nY As String\n```
+'                        ^ reference local 17
+              Dim Z As Object = True
+'                 ^ definition local 19
+'                   documentation ```vb\nZ As Object\n```
+              Dim T = If(TypeOf Z Is Boolean, 42, 41)
+'                 ^ definition local 20
+'                   documentation ```vb\nT As Integer\n```
+'                               ^ reference local 19
+          End Sub
+
+          Class Cast
+'               ^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Cast#
+'                    documentation ```vb\nClass Cast\n```
+              Public Nested As Cast
+'                    ^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Cast#Nested.
+'                           documentation ```vb\nPublic Cast.Nested As Cast\n```
+'                              ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+              Public Nested2 As Cast2
+'                    ^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Cast#Nested2.
+'                            documentation ```vb\nPublic Cast.Nested2 As Cast2\n```
+'                               ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Cast2#
+
+              Public Function Plus(ByVal other As Cast) As Cast
+'                             ^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Cast#Plus().
+'                                  documentation ```vb\nPublic Function Cast.Plus(other As Cast) As Cast\n```
+'                                        ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Cast#Plus().(other)
+'                                              documentation ```vb\nother As Cast\n```
+'                                                 ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+'                                                          ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+                  Nested = other
+'                 ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Nested.
+'                          ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Plus().(other)
+                  Return Me
+              End Function
+
+              Public Class Cast2
+'                          ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Cast#Cast2#
+'                                documentation ```vb\nClass Cast2\n```
+              End Class
+          End Class
+
+          Private Function CastExpressions() As Integer
+'                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#CastExpressions().
+'                                          documentation ```vb\nPrivate Function Expressions.CastExpressions() As Integer\n```
+              Dim A As Object = New Cast()
+'                 ^ definition local 21
+'                   documentation ```vb\nA As Object\n```
+'                                   ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+              Dim B As Object = New Cast()
+'                 ^ definition local 22
+'                   documentation ```vb\nB As Object\n```
+'                                   ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+              Dim C As Cast = (CType(A, Cast)).Plus(CType(B, Cast))
+'                 ^ definition local 23
+'                   documentation ```vb\nC As Class Cast\n```
+'                      ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+'                                    ^ reference local 21
+'                                       ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+'                                              ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Plus().
+'                                                         ^ reference local 22
+'                                                            ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+              Dim D As Cast = CType(New Object() {A, B}(0), Cast)
+'                 ^ definition local 24
+'                   documentation ```vb\nD As Class Cast\n```
+'                      ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+'                                                 ^ reference local 21
+'                                                    ^ reference local 22
+'                                                           ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+              Dim E = CType((C.Nested.Nested2), Cast.Cast2)
+'                 ^ definition local 25
+'                   documentation ```vb\nE As Class Cast2\n```
+'                            ^ reference local 23
+'                              ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Nested.
+'                                     ^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Nested2.
+'                                               ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#
+'                                                    ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Cast#Cast2#
+              Dim F = CType((1), Int32)
+'                 ^ definition local 26
+'                   documentation ```vb\nF As Integer\n```
+'                                ^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Int32#
+              Dim G = CType((1), Int32)
+'                 ^ definition local 27
+'                   documentation ```vb\nG As Integer\n```
+'                                ^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Int32#
+              Dim H = CType(((1)), Int32)
+'                 ^ definition local 28
+'                   documentation ```vb\nH As Integer\n```
+'                                  ^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Int32#
+              Return F + G + H
+'                    ^ reference local 26
+'                        ^ reference local 27
+'                            ^ reference local 28
+          End Function
+
+          Private Function AnonymousObject() As Object
+'                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AnonymousObject().
+'                                          documentation ```vb\nPrivate Function Expressions.AnonymousObject() As Object\n```
+              Dim X = New With {Key .Helper = ""}
+'                 ^ definition local 29
+'                   documentation ```vb\nX As AnonymousType <anonymous type: Key Helper As String>\n```
+'                                    ^^^^^^ reference local 31
+              Dim Y = New With {X}
+'                 ^ definition local 32
+'                   documentation ```vb\nY As AnonymousType <anonymous type: X As AnonymousType <anonymous type: Key Helper As String>>\n```
+'                               ^ reference local 29
+              Return Y.x.Helper
+'                    ^ reference local 32
+'                      ^ reference local 34
+'                        ^^^^^^ reference local 31
+          End Function
+
+          Class ObjectCreationClass
+'               ^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#
+'                                   documentation ```vb\nClass ObjectCreationClass\n```
+              Public Field As D
+'                    ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#Field.
+'                          documentation ```vb\nPublic ObjectCreationClass.Field As D\n```
+'                             ^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#
+
+              Public Sub New(ByVal field As D)
+'                        ^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#`.ctor`().
+'                            documentation ```vb\nPublic Sub ObjectCreationClass.New(field As D)\n```
+'                                  ^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#`.ctor`().(field)
+'                                        documentation ```vb\nfield As D\n```
+'                                           ^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#
+                  Me.Field = field
+'                    ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#Field.
+'                            ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#`.ctor`().(field)
+              End Sub
+
+              Public Class D
+'                          ^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#
+'                            documentation ```vb\nClass D\n```
+                  Public Sub New(ByVal a As Integer, ByVal b As String)
+'                            ^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#`.ctor`().
+'                                documentation ```vb\nPublic Sub D.New(a As Integer, b As String)\n```
+'                                      ^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#`.ctor`().(a)
+'                                        documentation ```vb\na As Integer\n```
+'                                                          ^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#`.ctor`().(b)
+'                                                            documentation ```vb\nb As String\n```
+                  End Sub
+              End Class
+          End Class
+
+          Private Sub ObjectCreation()
+'                     ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#ObjectCreation().
+'                                    documentation ```vb\nPrivate Sub Expressions.ObjectCreation()\n```
+              Dim A = New ObjectCreationClass.D(1, "hi")
+'                 ^ definition local 35
+'                   documentation ```vb\nA As Class D\n```
+'                         ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#
+'                                             ^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#D#
+              Dim B = New ObjectCreationClass(A) With {
+'                 ^ definition local 36
+'                   documentation ```vb\nB As Class ObjectCreationClass\n```
+'                         ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#
+'                                             ^ reference local 35
+                  .Field = A
+'                  ^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#Field.
+'                          ^ reference local 35
+              }
+              B = New ObjectCreationClass(A)
+'             ^ reference local 36
+'                     ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#ObjectCreationClass#
+'                                         ^ reference local 35
+          End Sub
+
+          Class NamedParametersClass
+'               ^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#
+'                                    documentation ```vb\nClass NamedParametersClass\n```
+              Public A As Integer
+'                    ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#A.
+'                      documentation ```vb\nPublic NamedParametersClass.A As Integer\n```
+              Public B As String
+'                    ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#B.
+'                      documentation ```vb\nPublic NamedParametersClass.B As String\n```
+
+              Public Sub New(ByVal a As Integer, ByVal b As String)
+'                        ^^^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().
+'                            documentation ```vb\nPublic Sub NamedParametersClass.New(a As Integer, b As String)\n```
+'                                  ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(a)
+'                                    documentation ```vb\na As Integer\n```
+'                                                      ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(b)
+'                                                        documentation ```vb\nb As String\n```
+                  Me.A = a
+'                    ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#A.
+'                        ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(a)
+                  Me.B = b
+'                    ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#B.
+'                        ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(b)
+              End Sub
+
+              Public Sub Update(ByVal a As Integer, ByVal b As String)
+'                        ^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().
+'                               documentation ```vb\nPublic Sub NamedParametersClass.Update(a As Integer, b As String)\n```
+'                                     ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(a)
+'                                       documentation ```vb\na As Integer\n```
+'                                                         ^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(b)
+'                                                           documentation ```vb\nb As String\n```
+                  Me.A = a
+'                    ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#A.
+'                        ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(a)
+                  Me.B = b
+'                    ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#B.
+'                        ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(b)
+              End Sub
+          End Class
+
+          Private Function NamedParameters() As NamedParametersClass
+'                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#NamedParameters().
+'                                          documentation ```vb\nPrivate Function Expressions.NamedParameters() As NamedParametersClass\n```
+'                                               ^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#
+              Dim A = New NamedParametersClass(b:="hi", a:=1)
+'                 ^ definition local 37
+'                   documentation ```vb\nA As Class NamedParametersClass\n```
+'                         ^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#
+'                                              ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(b)
+'                                                       ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#`.ctor`().(a)
+              A.Update(b:="foo", a:=42)
+'             ^ reference local 37
+'               ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().
+'                      ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(b)
+'                                ^ reference scip-dotnet nuget . . VBMain/Expressions#NamedParametersClass#Update().(a)
+              Return A
+'                    ^ reference local 37
+          End Function
+
+          Private Function AnonymousFunction() As Func(Of Integer, Integer)
+'                          ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#AnonymousFunction().
+'                                            documentation ```vb\nPrivate Function Expressions.AnonymousFunction() As Func(Of Integer, Integer)\n```
+              Dim d = Function(ByVal __ As Integer, ByVal ___ As Integer) 42
+'                 ^ definition local 38
+'                   documentation ```vb\nd As AnonymousType Function <generated method>(__ As Integer, ___ As Integer) As Integer\n```
+'                                    ^^ definition local 40
+'                                       documentation ```vb\n__ As Integer\n```
+'                                                         ^^^ definition local 41
+'                                                             documentation ```vb\n___ As Integer\n```
+              Return Function(ByVal a As Integer) a + d.Invoke(a, a)
+'                                   ^ definition local 43
+'                                     documentation ```vb\na As Integer\n```
+'                                                 ^ reference local 43
+'                                                     ^ reference local 38
+'                                                       ^^^^^^ reference local 45
+'                                                              ^ reference local 43
+'                                                                 ^ reference local 43
+          End Function
+
+          Class Lambda
+'               ^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Lambda#
+'                      documentation ```vb\nClass Lambda\n```
+              Public Function func(ByVal x As Lambda) As String
+'                             ^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Lambda#func().
+'                                  documentation ```vb\nPublic Function Lambda.func(x As Lambda) As String\n```
+'                                        ^ definition scip-dotnet nuget . . VBMain/Expressions#Lambda#func().(x)
+'                                          documentation ```vb\nx As Lambda\n```
+'                                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
+                  Return ""
+              End Function
+          End Class
+
+          Private Sub LambdaExpressions()
+'                     ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#LambdaExpressions().
+'                                       documentation ```vb\nPrivate Sub Expressions.LambdaExpressions()\n```
+              Dim a = Function(ByVal x As String) x & 1
+'                 ^ definition local 46
+'                   documentation ```vb\na As AnonymousType Function <generated method>(x As String) As String\n```
+'                                    ^ definition local 48
+'                                      documentation ```vb\nx As String\n```
+'                                                 ^ reference local 48
+              Dim b = Function(ByVal aa As Lambda, ByVal bb As Lambda) aa.func(bb)
+'                 ^ definition local 49
+'                   documentation ```vb\nb As AnonymousType Function <generated method>(aa As Lambda, bb As Lambda) As String\n```
+'                                    ^^ definition local 51
+'                                       documentation ```vb\naa As Lambda\n```
+'                                          ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
+'                                                        ^^ definition local 52
+'                                                           documentation ```vb\nbb As Lambda\n```
+'                                                              ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
+'                                                                      ^^ reference local 51
+'                                                                         ^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#func().
+'                                                                              ^^ reference local 52
+              Dim c = Function(aaa As Lambda, __ As Lambda)
+'                 ^ definition local 53
+'                   documentation ```vb\nc As AnonymousType Function <generated method>(aaa As Lambda, __ As Lambda) As String\n```
+'                              ^^^ definition local 55
+'                                  documentation ```vb\naaa As Lambda\n```
+'                                     ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
+'                                             ^^ definition local 56
+'                                                documentation ```vb\n__ As Lambda\n```
+'                                                   ^^^^^^ reference scip-dotnet nuget . . VBMain/Expressions#Lambda#
+                          If True Then
+                              Return "hi"
+                          End If
+                      End Function
+          End Sub
+
+          Private Sub TupleExpression()
+'                     ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#TupleExpression().
+'                                     documentation ```vb\nPrivate Sub Expressions.TupleExpression()\n```
+              Dim A = (1, 2, "")
+'                 ^ definition local 57
+'                   documentation ```vb\nA As (Integer, Integer, String)\n```
+          End Sub
+
+          Private Sub ArrayCreation()
+'                     ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#ArrayCreation().
+'                                   documentation ```vb\nPrivate Sub Expressions.ArrayCreation()\n```
+              Dim a = {
+'                 ^ definition local 58
+'                   documentation ```vb\na As Integer(*,*)\n```
+              {1, 1},
+              {2, 2},
+              {3, 3}}
+              Dim d = New Integer(2) {1, 2, 3}
+'                 ^ definition local 59
+'                   documentation ```vb\nd As Integer()\n```
+              Dim e = New Byte(,) {
+'                 ^ definition local 60
+'                   documentation ```vb\ne As Byte(*,*)\n```
+              {1, 2},
+              {2, 3}}
+              Dim f = New Integer(2, 1) {
+'                 ^ definition local 61
+'                   documentation ```vb\nf As Integer(*,*)\n```
+              {1, 1},
+              {2, 2},
+              {3, 3}}
+
+              Dim numbers(4) As Integer
+'                 ^^^^^^^ definition local 62
+'                         documentation ```vb\nnumbers As Integer()\n```
+              Dim numbers2 = New Integer() {1, 2, 4, 8}
+'                 ^^^^^^^^ definition local 63
+'                          documentation ```vb\nnumbers2 As Integer()\n```
+              ReDim Preserve numbers(15)
+'                            ^^^^^^^ reference local 62
+              ReDim numbers(15)
+'                   ^^^^^^^ reference local 62
+              Dim matrix(5, 5) As Double
+'                 ^^^^^^ definition local 64
+'                        documentation ```vb\nmatrix As Double(*,*)\n```
+              Dim matrix2 = New Integer(,) {{1, 2, 3}, {2, 3, 4}, {3, 4, 5}, {4, 5, 6}}
+'                 ^^^^^^^ definition local 65
+'                         documentation ```vb\nmatrix2 As Integer(*,*)\n```
+              Dim sales()() As Double = New Double(11)() {}
+'                 ^^^^^ definition local 66
+'                       documentation ```vb\nsales As Double()()\n```
+          End Sub
+
+          Private Sub [TypeOf]()
+'                     ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#TypeOf().
+'                              documentation ```vb\nPrivate Sub Expressions.TypeOf()\n```
+              Dim a = GetType(Integer)
+'                 ^ definition local 67
+'                   documentation ```vb\na As Class Type\n```
+              Dim b = GetType(List(Of String).Enumerator)
+'                 ^ definition local 68
+'                   documentation ```vb\nb As Class Type\n```
+'                                             ^^^^^^^^^^ reference scip-dotnet nuget System.Collections 8.0.0.0 Generic/List#Enumerator#
+              Dim c = GetType(Dictionary(Of,))
+'                 ^ definition local 69
+'                   documentation ```vb\nc As Class Type\n```
+              Dim d = GetType(Tuple(Of,,,))
+'                 ^ definition local 70
+'                   documentation ```vb\nd As Class Type\n```
+          End Sub
+
+          Private Sub SelectCase()
+'                     ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#SelectCase().
+'                                documentation ```vb\nPrivate Sub Expressions.SelectCase()\n```
+              Dim Some = 42
+'                 ^^^^ definition local 71
+'                      documentation ```vb\nSome As Integer\n```
+              Select Case Some
+'                         ^^^^ reference local 71
+                  Case 1
+                      Debug.WriteLine("One")
+'                     ^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 Diagnostics/Debug#
+'                           ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 Diagnostics/Debug#WriteLine(+2).
+                  Case 2
+                      Debug.WriteLine("One")
+'                     ^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 Diagnostics/Debug#
+'                           ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 Diagnostics/Debug#WriteLine(+2).
+                  Case Else
+                      Debug.WriteLine("More")
+'                     ^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 Diagnostics/Debug#
+'                           ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 Diagnostics/Debug#WriteLine(+2).
+              End Select
+          End Sub
+
+          Private Sub Dictionary()
+'                     ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Expressions#Dictionary().
+'                                documentation ```vb\nPrivate Sub Expressions.Dictionary()\n```
+              Dim A = New Dictionary(Of String, Integer) From {{1, "Test1"}, {2, "Test1"}}
+'                 ^ definition local 72
+'                   documentation ```vb\nA As Class Dictionary(Of String, Integer)\n```
+          End Sub
+
+      End Class
+  End Namespace

--- a/snapshots/output-net8.0/syntax/VBMain/Fields.vb
+++ b/snapshots/output-net8.0/syntax/VBMain/Fields.vb
@@ -1,0 +1,55 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Fields
+'                  ^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#
+'                         documentation ```vb\nClass Fields\n```
+          Class Fields1
+'               ^^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#
+'                       documentation ```vb\nClass Fields1\n```
+              Private ReadOnly Property1 As Integer
+'                              ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#Property1.
+'                                        documentation ```vb\nPrivate ReadOnly Fields1.Property1 As Integer\n```
+              Private Property2, Property3 As Int64
+'                     ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#Property2.
+'                               documentation ```vb\nPrivate Fields1.Property2 As Long\n```
+'                                ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#Property3.
+'                                          documentation ```vb\nPrivate Fields1.Property3 As Long\n```
+'                                             ^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Int64#
+              Private Property4 As Tuple(Of Char, Nullable(Of Integer))
+'                     ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#Property4.
+'                               documentation ```vb\nPrivate Fields1.Property4 As Tuple(Of Char, Integer?)\n```
+
+              Public Sub New(ByVal field2 As Long, ByVal field3 As Long, ByVal field4 As Tuple(Of Char, Integer?), ByVal field1 As Integer)
+'                        ^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().
+'                            documentation ```vb\nPublic Sub Fields1.New(field2 As Long, field3 As Long, field4 As Tuple(Of Char, Integer?), field1 As Integer)\n```
+'                                  ^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field2)
+'                                         documentation ```vb\nfield2 As Long\n```
+'                                                        ^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field3)
+'                                                               documentation ```vb\nfield3 As Long\n```
+'                                                                              ^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field4)
+'                                                                                     documentation ```vb\nfield4 As Tuple(Of Char, Integer?)\n```
+'                                                                                                                        ^^^^^^ definition scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field1)
+'                                                                                                                               documentation ```vb\nfield1 As Integer\n```
+                  Property2 = field2
+'                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#Property2.
+'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field2)
+                  Property3 = field3
+'                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#Property3.
+'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field3)
+                  Property4 = field4
+'                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#Property4.
+'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field4)
+                  Property1 = field1
+'                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#Property1.
+'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Fields#Fields1#`.ctor`().(field1)
+              End Sub
+          End Class
+      End Class
+  End Namespace

--- a/snapshots/output-net8.0/syntax/VBMain/GlobalAttributes.vb
+++ b/snapshots/output-net8.0/syntax/VBMain/GlobalAttributes.vb
@@ -1,0 +1,91 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      <AttributeUsage(AttributeTargets.[Class], AllowMultiple:=True, Inherited:=True)>
+'      ^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/AttributeUsageAttribute#`.ctor`().
+'                     ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/AttributeTargets#
+'                                      ^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/AttributeTargets#Class.
+'                                               ^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/AttributeUsageAttribute#AllowMultiple.
+'                                                                    ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/AttributeUsageAttribute#Inherited.
+      Public Class GlobalAttributes
+'                  ^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#
+'                                   documentation ```vb\nClass GlobalAttributes\n```
+'                                   relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/Attribute#
+          Inherits Attribute
+'                  ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Attribute#
+
+          Class AuthorAttribute
+'               ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#AuthorAttribute#
+'                               documentation ```vb\nClass AuthorAttribute\n```
+'                               relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/Attribute#
+              Inherits Attribute
+'                      ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Attribute#
+
+              Public Sub New(ByVal name As String)
+'                        ^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#AuthorAttribute#`.ctor`().
+'                            documentation ```vb\nPublic Sub AuthorAttribute.New(name As String)\n```
+'                                  ^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#AuthorAttribute#`.ctor`().(name)
+'                                       documentation ```vb\nname As String\n```
+              End Sub
+          End Class
+
+          <Author("PropertyAttribute")>
+'          ^^^^^^ reference scip-dotnet nuget . . VBMain/GlobalAttributes#AuthorAttribute#`.ctor`().
+          Public Z As Integer
+'                ^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#Z.
+'                  documentation ```vb\nPublic GlobalAttributes.Z As Integer\n```
+
+          <Author("MethodAttribute")>
+'          ^^^^^^ reference scip-dotnet nuget . . VBMain/GlobalAttributes#AuthorAttribute#`.ctor`().
+          Private Function Method1() As Integer
+'                          ^^^^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#Method1().
+'                                  documentation ```vb\nPrivate Function GlobalAttributes.Method1() As Integer\n```
+              Return 0
+          End Function
+
+          <Author("EnumAttribute")>
+'          ^^^^^^ reference scip-dotnet nuget . . VBMain/GlobalAttributes#AuthorAttribute#`.ctor`().
+          Enum A
+'              ^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#A#
+'                documentation ```vb\nEnum A\n```
+'                relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IComparable#
+'                relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IConvertible#
+'                relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/ISpanFormattable#
+'                relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IFormattable#
+              B
+'             ^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#A#B.
+'               documentation ```vb\nA.B = 0\n```
+              C
+'             ^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#A#C.
+'               documentation ```vb\nA.C = 1\n```
+          End Enum
+
+          <Author("EventAttribute")>
+'          ^^^^^^ reference scip-dotnet nuget . . VBMain/GlobalAttributes#AuthorAttribute#`.ctor`().
+          Public Event SomeEvent As EventHandler
+'                      ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#SomeEvent#
+'                                documentation ```vb\nPublic Event GlobalAttributes.SomeEvent As EventHandler\n```
+'                                   ^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/EventHandler#
+
+          <Author("TypeParameterAttribute")>
+'          ^^^^^^ reference scip-dotnet nuget . . VBMain/GlobalAttributes#AuthorAttribute#`.ctor`().
+          Public Class InnerClass(Of T)
+'                      ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#InnerClass#
+'                                 documentation ```vb\nClass InnerClass(Of T)\n```
+'                                    ^ definition local 0
+'                                      documentation ```vb\nT\n```
+              Private Sub Method(Of T2)()
+'                         ^^^^^^ definition scip-dotnet nuget . . VBMain/GlobalAttributes#InnerClass#Method().
+'                                documentation ```vb\nPrivate Sub InnerClass(Of T).Method(Of T2)()\n```
+'                                   ^^ definition local 1
+'                                      documentation ```vb\nT2\n```
+              End Sub
+          End Class
+      End Class
+  End Namespace

--- a/snapshots/output-net8.0/syntax/VBMain/Identifiers.vb
+++ b/snapshots/output-net8.0/syntax/VBMain/Identifiers.vb
@@ -1,0 +1,46 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Identifiers
+'                  ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Identifiers#
+'                              documentation ```vb\nClass Identifiers\n```
+          Private Sub SpecialNames()
+'                     ^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Identifiers#SpecialNames().
+'                                  documentation ```vb\nPrivate Sub Identifiers.SpecialNames()\n```
+              Dim [const] = 42
+'                 ^^^^^^^ definition local 0
+'                         documentation ```vb\n[const] As Integer\n```
+              Dim var As Integer = [const]
+'                 ^^^ definition local 1
+'                     documentation ```vb\nvar As Integer\n```
+'                                  ^^^^^^^ reference local 0
+              Dim under_score = 0
+'                 ^^^^^^^^^^^ definition local 2
+'                             documentation ```vb\nunder_score As Integer\n```
+              Dim with1number = 0
+'                 ^^^^^^^^^^^ definition local 3
+'                             documentation ```vb\nwith1number As Integer\n```
+              Dim varæble = 0
+'                 ^^^^^^^ definition local 4
+'                         documentation ```vb\nvaræble As Integer\n```
+              Dim Переменная = 0
+'                 ^^^^^^^^^^ definition local 5
+'                            documentation ```vb\nПеременная As Integer\n```
+              Dim first‿letter = 0
+'                 ^^^^^^^^^^^^ definition local 6
+'                              documentation ```vb\nfirst‿letter As Integer\n```
+              Dim ග්රහලෝකය = 0
+'                 ^^^^^^^^ definition local 7
+'                          documentation ```vb\nග්රහලෝකය As Integer\n```
+              Dim _كوكبxxx = 0
+'                 ^^^^^^^^ definition local 8
+'                          documentation ```vb\n_كوكبxxx As Integer\n```
+          End Sub
+      End Class
+  End Namespace

--- a/snapshots/output-net8.0/syntax/VBMain/Interfaces.vb
+++ b/snapshots/output-net8.0/syntax/VBMain/Interfaces.vb
@@ -1,0 +1,94 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Interfaces
+'                  ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#
+'                             documentation ```vb\nClass Interfaces\n```
+          Interface IOne
+'                   ^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IOne#
+'                        documentation ```vb\nInterface IOne\n```
+          End Interface
+
+          Interface ITwo
+'                   ^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#ITwo#
+'                        documentation ```vb\nInterface ITwo\n```
+          End Interface
+
+          Interface IThree
+'                   ^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IThree#
+'                          documentation ```vb\nInterface IThree\n```
+          End Interface
+
+          Interface IProperties
+'                   ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IProperties#
+'                               documentation ```vb\nInterface IProperties\n```
+              ReadOnly Property [Get] As Byte
+'                               ^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IProperties#Get.
+'                                     documentation ```vb\nReadOnly Property IProperties.Get As Byte\n```
+              WriteOnly Property [Set] As Char
+'                                ^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IProperties#Set.
+'                                      documentation ```vb\nWriteOnly Property IProperties.Set As Char\n```
+              Property GetSet As UInteger
+'                      ^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IProperties#GetSet.
+'                             documentation ```vb\nProperty IProperties.GetSet As UInteger\n```
+              Property SetGet As Long
+'                      ^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IProperties#SetGet.
+'                             documentation ```vb\nProperty IProperties.SetGet As Long\n```
+          End Interface
+
+          Interface IMethods
+'                   ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#
+'                            documentation ```vb\nInterface IMethods\n```
+              Sub [Nothing]()
+'                 ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#Nothing().
+'                           documentation ```vb\nSub IMethods.Nothing()\n```
+              Function Output() As Integer
+'                      ^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#Output().
+'                             documentation ```vb\nFunction IMethods.Output() As Integer\n```
+              Sub Input(ByVal a As String)
+'                 ^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#Input().
+'                       documentation ```vb\nSub IMethods.Input(a As String)\n```
+'                             ^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#Input().(a)
+'                               documentation ```vb\na As String\n```
+              Function InputOutput(ByVal a As String) As Integer
+'                      ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#InputOutput().
+'                                  documentation ```vb\nFunction IMethods.InputOutput(a As String) As Integer\n```
+'                                        ^ definition scip-dotnet nuget . . VBMain/Interfaces#IMethods#InputOutput().(a)
+'                                          documentation ```vb\na As String\n```
+          End Interface
+
+          Interface IEvent
+'                   ^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IEvent#
+'                          documentation ```vb\nInterface IEvent\n```
+              Event SomeEvent As EventHandler(Of Integer)
+'                   ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IEvent#SomeEvent#
+'                             documentation ```vb\nEvent IEvent.SomeEvent As EventHandler(Of Integer)\n```
+          End Interface
+
+          Interface IIndex
+'                   ^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IIndex#
+'                          documentation ```vb\nInterface IIndex\n```
+              Default Property Item(ByVal index As Integer) As Boolean
+'                              ^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IIndex#Item.
+'                                   documentation ```vb\nDefault Property IIndex.Item(index As Integer) As Boolean\n```
+'                                         ^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IIndex#Item.(index)
+'                                               documentation ```vb\nindex As Integer\n```
+          End Interface
+
+          Private Interface IInherit
+'                           ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Interfaces#IInherit#
+'                                    documentation ```vb\nInterface IInherit\n```
+'                                    relationship implementation scip-dotnet nuget . . VBMain/Interfaces#IOne#
+'                                    relationship implementation scip-dotnet nuget . . VBMain/Interfaces#ITwo#
+              Inherits IOne, ITwo
+'                      ^^^^ reference scip-dotnet nuget . . VBMain/Interfaces#IOne#
+'                            ^^^^ reference scip-dotnet nuget . . VBMain/Interfaces#ITwo#
+          End Interface
+      End Class
+  End Namespace

--- a/snapshots/output-net8.0/syntax/VBMain/Literals.vb
+++ b/snapshots/output-net8.0/syntax/VBMain/Literals.vb
@@ -1,0 +1,35 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Literals
+'                  ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Literals#
+'                           documentation ```vb\nClass Literals\n```
+          Private Function Interpolation() As String
+'                          ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Literals#Interpolation().
+'                                        documentation ```vb\nPrivate Function Literals.Interpolation() As String\n```
+              Dim a = 1
+'                 ^ definition local 0
+'                   documentation ```vb\na As Integer\n```
+              Dim b = 2
+'                 ^ definition local 1
+'                   documentation ```vb\nb As Integer\n```
+              Dim c = 3
+'                 ^ definition local 2
+'                   documentation ```vb\nc As Integer\n```
+              Dim d = 3
+'                 ^ definition local 3
+'                   documentation ```vb\nd As Integer\n```
+              Return $"a={a} b={b} c={c} d={d}"
+'                         ^ reference local 0
+'                               ^ reference local 1
+'                                     ^ reference local 2
+'                                           ^ reference local 3
+          End Function
+      End Class
+  End Namespace

--- a/snapshots/output-net8.0/syntax/VBMain/Methods.vb
+++ b/snapshots/output-net8.0/syntax/VBMain/Methods.vb
@@ -1,0 +1,222 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Methods
+'                  ^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#
+'                          documentation ```vb\nClass Methods\n```
+          Private Function SingleParameter(ByVal b As Integer) As Integer
+'                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#SingleParameter().
+'                                          documentation ```vb\nPrivate Function Methods.SingleParameter(b As Integer) As Integer\n```
+'                                                ^ definition scip-dotnet nuget . . VBMain/Methods#SingleParameter().(b)
+'                                                  documentation ```vb\nb As Integer\n```
+              Return b
+'                    ^ reference scip-dotnet nuget . . VBMain/Methods#SingleParameter().(b)
+          End Function
+
+          Private Function TwoParameters(ByVal a As Integer, ByVal b As Integer) As Integer
+'                          ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#TwoParameters().
+'                                        documentation ```vb\nPrivate Function Methods.TwoParameters(a As Integer, b As Integer) As Integer\n```
+'                                              ^ definition scip-dotnet nuget . . VBMain/Methods#TwoParameters().(a)
+'                                                documentation ```vb\na As Integer\n```
+'                                                                  ^ definition scip-dotnet nuget . . VBMain/Methods#TwoParameters().(b)
+'                                                                    documentation ```vb\nb As Integer\n```
+              Return a + b
+'                    ^ reference scip-dotnet nuget . . VBMain/Methods#TwoParameters().(a)
+'                        ^ reference scip-dotnet nuget . . VBMain/Methods#TwoParameters().(b)
+          End Function
+
+          Private Function Overload1(ByVal a As Integer) As Integer
+'                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#Overload1().
+'                                    documentation ```vb\nPrivate Function Methods.Overload1(a As Integer) As Integer\n```
+'                                          ^ definition scip-dotnet nuget . . VBMain/Methods#Overload1().(a)
+'                                            documentation ```vb\na As Integer\n```
+              Return a
+'                    ^ reference scip-dotnet nuget . . VBMain/Methods#Overload1().(a)
+          End Function
+
+          Private Function Overload1(ByVal a As Integer, ByVal b As Integer) As Integer
+'                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#Overload1(+1).
+'                                    documentation ```vb\nPrivate Function Methods.Overload1(a As Integer, b As Integer) As Integer\n```
+'                                          ^ definition scip-dotnet nuget . . VBMain/Methods#Overload1(+1).(a)
+'                                            documentation ```vb\na As Integer\n```
+'                                                              ^ definition scip-dotnet nuget . . VBMain/Methods#Overload1(+1).(b)
+'                                                                documentation ```vb\nb As Integer\n```
+              Return a + b
+'                    ^ reference scip-dotnet nuget . . VBMain/Methods#Overload1(+1).(a)
+'                        ^ reference scip-dotnet nuget . . VBMain/Methods#Overload1(+1).(b)
+          End Function
+
+          Private Function Generic(Of T)(ByVal param As T) As T
+'                          ^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#Generic().
+'                                  documentation ```vb\nPrivate Function Methods.Generic(Of T)(param As T) As T\n```
+'                                     ^ definition local 0
+'                                       documentation ```vb\nT\n```
+'                                              ^^^^^ definition scip-dotnet nuget . . VBMain/Methods#Generic().(param)
+'                                                    documentation ```vb\nparam As T\n```
+'                                                       ^ reference local 0
+'                                                             ^ reference local 0
+              Return param
+'                    ^^^^^ reference scip-dotnet nuget . . VBMain/Methods#Generic().(param)
+          End Function
+
+          Private Function GenericConstraint(Of T As New)(ByVal param As T) As T
+'                          ^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#GenericConstraint().
+'                                            documentation ```vb\nPrivate Function Methods.GenericConstraint(Of T As New)(param As T) As T\n```
+'                                               ^ definition local 1
+'                                                 documentation ```vb\nT\n```
+'                                                               ^^^^^ definition scip-dotnet nuget . . VBMain/Methods#GenericConstraint().(param)
+'                                                                     documentation ```vb\nparam As T\n```
+'                                                                        ^ reference local 1
+'                                                                              ^ reference local 1
+              Return param
+'                    ^^^^^ reference scip-dotnet nuget . . VBMain/Methods#GenericConstraint().(param)
+          End Function
+
+          Private Sub DefaultParameter(ByVal Optional a As Integer = 5)
+'                     ^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameter().
+'                                      documentation ```vb\nPrivate Sub Methods.DefaultParameter([a As Integer = 5])\n```
+'                                                     ^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameter().(a)
+'                                                       documentation ```vb\n[a As Integer = 5]\n```
+          End Sub
+
+          Private Function DefaultParameterOverload(ByVal Optional a As Integer = 5) As Integer
+'                          ^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload().
+'                                                   documentation ```vb\nPrivate Function Methods.DefaultParameterOverload([a As Integer = 5]) As Integer\n```
+'                                                                  ^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload().(a)
+'                                                                    documentation ```vb\n[a As Integer = 5]\n```
+              Return DefaultParameterOverload(a, a)
+'                    ^^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload(+1).
+'                                             ^ reference scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload().(a)
+'                                                ^ reference scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload().(a)
+          End Function
+
+          Private Function DefaultParameterOverload(ByVal a As Integer, ByVal b As Integer) As Integer
+'                          ^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload(+1).
+'                                                   documentation ```vb\nPrivate Function Methods.DefaultParameterOverload(a As Integer, b As Integer) As Integer\n```
+'                                                         ^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload(+1).(a)
+'                                                           documentation ```vb\na As Integer\n```
+'                                                                             ^ definition scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload(+1).(b)
+'                                                                               documentation ```vb\nb As Integer\n```
+              Return DefaultParameterOverload()
+'                    ^^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#DefaultParameterOverload().
+          End Function
+
+          Interface IHello
+'                   ^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#IHello#
+'                          documentation ```vb\nInterface IHello\n```
+              Function Hello() As String
+'                      ^^^^^ definition scip-dotnet nuget . . VBMain/Methods#IHello#Hello().
+'                            documentation ```vb\nFunction IHello.Hello() As String\n```
+          End Interface
+
+          Class ImplementsHello
+'               ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#ImplementsHello#
+'                               documentation ```vb\nClass ImplementsHello\n```
+'                               relationship implementation scip-dotnet nuget . . VBMain/Methods#IHello#
+              Implements IHello
+'                        ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#IHello#
+
+              Private Function Hello() As String Implements IHello.Hello
+'                              ^^^^^ definition scip-dotnet nuget . . VBMain/Methods#ImplementsHello#Hello().
+'                                    documentation ```vb\nPrivate Function ImplementsHello.Hello() As String\n```
+'                                    relationship implementation reference scip-dotnet nuget . . VBMain/Methods#IHello#Hello().
+'                                                           ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#IHello#
+'                                                                  ^^^^^ reference scip-dotnet nuget . . VBMain/Methods#IHello#Hello().
+                  Throw New NotImplementedException()
+'                           ^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/NotImplementedException#
+              End Function
+
+          End Class
+
+          Class InheritedOverloads1
+'               ^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+'                                   documentation ```vb\nClass InheritedOverloads1\n```
+              Public Sub Method()
+'                        ^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#Method().
+'                               documentation ```vb\nPublic Sub InheritedOverloads1.Method()\n```
+              End Sub
+          End Class
+
+          Class InheritedOverloads2
+'               ^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
+'                                   documentation ```vb\nClass InheritedOverloads2\n```
+'                                   relationship implementation scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+              Inherits InheritedOverloads1
+'                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+
+              Public Function Method(ByVal parameter As Integer) As Integer
+'                             ^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#Method().
+'                                    documentation ```vb\nPublic Function InheritedOverloads2.Method(parameter As Integer) As Integer\n```
+'                                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#Method().(parameter)
+'                                                    documentation ```vb\nparameter As Integer\n```
+                  Return parameter
+'                        ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#Method().(parameter)
+              End Function
+          End Class
+
+          Class InheritedOverloads3
+'               ^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#
+'                                   documentation ```vb\nClass InheritedOverloads3\n```
+'                                   relationship implementation scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
+'                                   relationship implementation scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+              Inherits InheritedOverloads2
+'                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
+
+              Public Function Method(ByVal parameter As String) As String
+'                             ^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#Method().
+'                                    documentation ```vb\nPublic Function InheritedOverloads3.Method(parameter As String) As String\n```
+'                                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#Method().(parameter)
+'                                                    documentation ```vb\nparameter As String\n```
+                  Return parameter
+'                        ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#Method().(parameter)
+              End Function
+          End Class
+
+          Public Shared Sub InheritedOverloads()
+'                           ^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Methods#InheritedOverloads().
+'                                              documentation ```vb\nPublic Shared Sub Methods.InheritedOverloads()\n```
+              Dim a As InheritedOverloads1 = New InheritedOverloads1
+'                 ^ definition local 2
+'                   documentation ```vb\na As Class InheritedOverloads1\n```
+'                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+'                                                ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+              a.Method()
+'             ^ reference local 2
+'               ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#Method().
+              Dim b As InheritedOverloads2 = New InheritedOverloads2
+'                 ^ definition local 3
+'                   documentation ```vb\nb As Class InheritedOverloads2\n```
+'                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
+'                                                ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
+              DirectCast(b, InheritedOverloads1).Method()
+'                        ^ reference local 3
+'                           ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+'                                                ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#Method().
+              b.Method(42)
+'             ^ reference local 3
+'               ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#Method().
+              Dim c As InheritedOverloads3 = New InheritedOverloads3
+'                 ^ definition local 4
+'                   documentation ```vb\nc As Class InheritedOverloads3\n```
+'                      ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#
+'                                                ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#
+              DirectCast(c, InheritedOverloads1).Method()
+'                        ^ reference local 4
+'                           ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#
+'                                                ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads1#Method().
+              DirectCast(c, InheritedOverloads2).Method(42)
+'                        ^ reference local 4
+'                           ^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#
+'                                                ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads2#Method().
+              c.Method("42")
+'             ^ reference local 4
+'               ^^^^^^ reference scip-dotnet nuget . . VBMain/Methods#InheritedOverloads3#Method().
+          End Sub
+      End Class
+  End Namespace

--- a/snapshots/output-net8.0/syntax/VBMain/Modules.vb
+++ b/snapshots/output-net8.0/syntax/VBMain/Modules.vb
@@ -1,0 +1,30 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Module Modules
+'                   ^^^^^^^ definition scip-dotnet nuget . . VBMain/Modules#
+'                           documentation ```vb\nModule Modules\n```
+          Private Function [Function](ByVal b As Integer) As Integer
+'                          ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Modules#Function().
+'                                     documentation ```vb\nPrivate Function Modules.Function(b As Integer) As Integer\n```
+'                                           ^ definition scip-dotnet nuget . . VBMain/Modules#Function().(b)
+'                                             documentation ```vb\nb As Integer\n```
+              Return b
+'                    ^ reference scip-dotnet nuget . . VBMain/Modules#Function().(b)
+          End Function
+
+          Private Sub [Sub](ByVal Optional a As Integer = 5)
+'                     ^^^^^ definition scip-dotnet nuget . . VBMain/Modules#Sub().
+'                           documentation ```vb\nPrivate Sub Modules.Sub([a As Integer = 5])\n```
+'                                          ^ definition scip-dotnet nuget . . VBMain/Modules#Sub().(a)
+'                                            documentation ```vb\n[a As Integer = 5]\n```
+          End Sub
+
+      End Module
+  End Namespace

--- a/snapshots/output-net8.0/syntax/VBMain/Operators.vb
+++ b/snapshots/output-net8.0/syntax/VBMain/Operators.vb
@@ -1,0 +1,110 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Operators
+'                  ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Operators#
+'                            documentation ```vb\nClass Operators\n```
+          Public Class PlusMinus
+'                      ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#
+'                                documentation ```vb\nClass PlusMinus\n```
+              Public Shared Operator +(A As PlusMinus)
+'                                      ^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#op_UnaryPlus().(A)
+'                                        documentation ```vb\nA As PlusMinus\n```
+'                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#PlusMinus#
+                  Return 0
+              End Operator
+
+              Public Shared Operator +(A As PlusMinus, B As PlusMinus)
+'                                      ^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#op_Addition().(A)
+'                                        documentation ```vb\nA As PlusMinus\n```
+'                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#PlusMinus#
+'                                                      ^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#op_Addition().(B)
+'                                                        documentation ```vb\nB As PlusMinus\n```
+'                                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#PlusMinus#
+                  Return 0
+              End Operator
+
+              Public Shared Operator -(A As PlusMinus)
+'                                      ^ definition scip-dotnet nuget . . VBMain/Operators#PlusMinus#op_UnaryNegation().(A)
+'                                        documentation ```vb\nA As PlusMinus\n```
+'                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#PlusMinus#
+                  Return 0
+              End Operator
+          End Class
+
+          Public Class TrueFalse
+'                      ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+'                                documentation ```vb\nClass TrueFalse\n```
+              Public Shared Operator IsTrue(A As TrueFalse) As Boolean
+'                                           ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_True().(A)
+'                                             documentation ```vb\nA As TrueFalse\n```
+'                                                ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+                  Return True
+              End Operator
+
+              Public Shared Operator IsFalse(A As TrueFalse) As Boolean
+'                                            ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_False().(A)
+'                                              documentation ```vb\nA As TrueFalse\n```
+'                                                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+                  Return False
+              End Operator
+
+              Public Shared Operator =(A As TrueFalse, B As TrueFalse) As Boolean
+'                                      ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_Equality().(A)
+'                                        documentation ```vb\nA As TrueFalse\n```
+'                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+'                                                      ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_Equality().(B)
+'                                                        documentation ```vb\nB As TrueFalse\n```
+'                                                           ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+                  Return True
+              End Operator
+
+              Public Shared Operator <>(A As TrueFalse, B As TrueFalse) As Boolean
+'                                       ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_Inequality().(A)
+'                                         documentation ```vb\nA As TrueFalse\n```
+'                                            ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+'                                                       ^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#op_Inequality().(B)
+'                                                         documentation ```vb\nB As TrueFalse\n```
+'                                                            ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+                  Return True
+              End Operator
+
+              Public Overrides Function Equals(obj As Object) As Boolean
+'                                       ^^^^^^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().
+'                                              documentation ```vb\nPublic Overrides Function TrueFalse.Equals(obj As Object) As Boolean\n```
+'                                              relationship implementation reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Object#Equals().
+'                                              ^^^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+'                                                  documentation ```vb\nobj As Object\n```
+                  If ReferenceEquals(Nothing, obj) Then Return False
+'                    ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Object#ReferenceEquals().
+'                                             ^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+                  If ReferenceEquals(Me, obj) Then Return True
+'                    ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Object#ReferenceEquals().
+'                                        ^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+                  If obj.GetType() <> Me.GetType() Then Return False
+'                    ^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+'                        ^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Object#GetType().
+'                                        ^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Object#GetType().
+                  Return Equals(CType(obj, TrueFalse))
+'                        ^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().
+'                                     ^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#Equals().(obj)
+'                                          ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Operators#TrueFalse#
+              End Function
+
+              Public Overrides Function GetHashCode() As Integer
+'                                       ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Operators#TrueFalse#GetHashCode().
+'                                                   documentation ```vb\nPublic Overrides Function TrueFalse.GetHashCode() As Integer\n```
+'                                                   relationship implementation reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Object#GetHashCode().
+                  Throw New NotImplementedException()
+'                           ^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/NotImplementedException#
+              End Function
+
+          End Class
+      End Class
+  End Namespace

--- a/snapshots/output-net8.0/syntax/VBMain/Packages.vb
+++ b/snapshots/output-net8.0/syntax/VBMain/Packages.vb
@@ -1,0 +1,29 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+  Imports DiffPlex.DiffBuilder
+'         ^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 DiffPlex/
+'                  ^^^^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 DiffBuilder/
+  Imports DiffPlex.DiffBuilder.Model
+'         ^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 DiffPlex/
+'                  ^^^^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 DiffBuilder/
+'                              ^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 Model/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Packages
+'                  ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Packages#
+'                           documentation ```vb\nClass Packages\n```
+          Private Function Diff() As DiffPaneModel
+'                          ^^^^ definition scip-dotnet nuget . . VBMain/Packages#Diff().
+'                               documentation ```vb\nPrivate Function Packages.Diff() As DiffPaneModel\n```
+'                                    ^^^^^^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 Model/DiffPaneModel#
+              Return InlineDiffBuilder.Diff("a", "b")
+'                    ^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 DiffBuilder/InlineDiffBuilder#
+'                                      ^^^^ reference scip-dotnet nuget DiffPlex 1.7.1.0 DiffBuilder/InlineDiffBuilder#Diff().
+          End Function
+      End Class
+  End Namespace

--- a/snapshots/output-net8.0/syntax/VBMain/Preprocessors.vb
+++ b/snapshots/output-net8.0/syntax/VBMain/Preprocessors.vb
@@ -1,0 +1,31 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Preprocessors
+'                  ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Preprocessors#
+'                                documentation ```vb\nClass Preprocessors\n```
+          Private Function OperatingSystem() As String
+'                          ^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Preprocessors#OperatingSystem().
+'                                          documentation ```vb\nPrivate Function Preprocessors.OperatingSystem() As String\n```
+  #If WIN32 Then
+              Dim Os As String = "Win32"
+  #warning This class is bad.
+  #error Okay, just stop.
+  #elif MACOS
+              Dim Os As String = "MacOS"
+  #Else
+              Dim Os As String = "Unknown"
+'                 ^^ definition local 0
+'                    documentation ```vb\nOs As String\n```
+  #End If
+              Return Os
+'                    ^^ reference local 0
+          End Function
+      End Class
+  End Namespace

--- a/snapshots/output-net8.0/syntax/VBMain/Program.vb
+++ b/snapshots/output-net8.0/syntax/VBMain/Program.vb
@@ -1,0 +1,14 @@
+  Module Program
+'        ^^^^^^^ definition scip-dotnet nuget . . VBMain/Program#
+'                documentation ```vb\nModule Program\n```
+      Sub Main(args As String())
+'         ^^^^ definition scip-dotnet nuget . . VBMain/Program#Main().
+'              documentation ```vb\nPublic Sub Program.Main(args As String())\n```
+'              ^^^^ definition scip-dotnet nuget . . VBMain/Program#Main().(args)
+'                   documentation ```vb\nargs As String()\n```
+
+          Console.WriteLine("Hello, World!")
+'         ^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#
+'                 ^^^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#WriteLine(+11).
+      End Sub
+  End Module

--- a/snapshots/output-net8.0/syntax/VBMain/Properties.vb
+++ b/snapshots/output-net8.0/syntax/VBMain/Properties.vb
@@ -1,0 +1,35 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Properties
+'                  ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Properties#
+'                             documentation ```vb\nClass Properties\n```
+          Private ReadOnly Property [Get] As Byte
+'                                   ^^^^^ definition scip-dotnet nuget . . VBMain/Properties#Get.
+'                                         documentation ```vb\nPrivate ReadOnly Property Properties.Get As Byte\n```
+
+          Private WriteOnly Property [Set] As Char
+'                                    ^^^^^ definition scip-dotnet nuget . . VBMain/Properties#Set.
+'                                          documentation ```vb\nPrivate WriteOnly Property Properties.Set As Char\n```
+              Set(ByVal value As Char)
+'                       ^^^^^ definition scip-dotnet nuget . . VBMain/Properties#set_Set().(value)
+'                             documentation ```vb\nvalue As Char\n```
+                  Throw New NotImplementedException()
+'                           ^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/NotImplementedException#
+              End Set
+          End Property
+
+          Private Property GetSet As UInteger
+'                          ^^^^^^ definition scip-dotnet nuget . . VBMain/Properties#GetSet.
+'                                 documentation ```vb\nPrivate Property Properties.GetSet As UInteger\n```
+          Private Property SetGet As Long
+'                          ^^^^^^ definition scip-dotnet nuget . . VBMain/Properties#SetGet.
+'                                 documentation ```vb\nPrivate Property Properties.SetGet As Long\n```
+      End Class
+  End Namespace

--- a/snapshots/output-net8.0/syntax/VBMain/QuerySyntax.vb
+++ b/snapshots/output-net8.0/syntax/VBMain/QuerySyntax.vb
@@ -1,0 +1,194 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class QuerySyntax
+'                  ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#
+'                              documentation ```vb\nClass QuerySyntax\n```
+          Private sourceA As List(Of IGeneric) = New List(Of IGeneric)()
+'                 ^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
+'                         documentation ```vb\nPrivate QuerySyntax.sourceA As List(Of IGeneric)\n```
+'                                    ^^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#
+'                                                            ^^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#
+          Private sourceB As List(Of IGeneric) = New List(Of IGeneric)()
+'                 ^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#sourceB.
+'                         documentation ```vb\nPrivate QuerySyntax.sourceB As List(Of IGeneric)\n```
+'                                    ^^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#
+'                                                            ^^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#
+
+          Interface IGeneric
+'                   ^^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#
+'                            documentation ```vb\nInterface IGeneric\n```
+              Function Method() As String
+'                      ^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                             documentation ```vb\nFunction IGeneric.Method() As String\n```
+          End Interface
+
+          Private Sub [Select]()
+'                     ^^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Select().
+'                              documentation ```vb\nPrivate Sub QuerySyntax.Select()\n```
+              Dim x = From a In sourceA Select a.Method()
+'                 ^ definition local 0
+'                   documentation ```vb\nx As Interface IEnumerable(Of String)\n```
+'                          ^ definition local 1
+'                            documentation ```vb\na As Interface IGeneric\n```
+'                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
+'                                              ^ reference local 1
+'                                                ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+          End Sub
+
+          Private Sub Projection()
+'                     ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Projection().
+'                                documentation ```vb\nPrivate Sub QuerySyntax.Projection()\n```
+              Dim x = From a In sourceA Select New With {Key .Name = a.Method()}
+'                 ^ definition local 2
+'                   documentation ```vb\nx As Interface IEnumerable(Of <anonymous type: Key Name As String>)\n```
+'                          ^ definition local 3
+'                            documentation ```vb\na As Interface IGeneric\n```
+'                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
+'                                                             ^^^^ reference local 5
+'                                                                    ^ reference local 3
+'                                                                      ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+              Dim b = From a In x Select a.Name
+'                 ^ definition local 6
+'                   documentation ```vb\nb As Interface IEnumerable(Of String)\n```
+'                          ^ definition local 7
+'                            documentation ```vb\na As AnonymousType <anonymous type: Key Name As String>\n```
+'                               ^ reference local 2
+'                                        ^ reference local 7
+'                                          ^^^^ reference local 5
+          End Sub
+
+          Private Sub Where()
+'                     ^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Where().
+'                           documentation ```vb\nPrivate Sub QuerySyntax.Where()\n```
+              Dim x = From a In sourceA Where a.Method().StartsWith("a") Select a
+'                 ^ definition local 8
+'                   documentation ```vb\nx As Interface IEnumerable(Of IGeneric)\n```
+'                          ^ definition local 9
+'                            documentation ```vb\na As Interface IGeneric\n```
+'                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
+'                                             ^ reference local 9
+'                                               ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                                                        ^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/String#StartsWith(+1).
+'                                                                               ^ reference local 9
+          End Sub
+
+          Private Sub [Let]()
+'                     ^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Let().
+'                           documentation ```vb\nPrivate Sub QuerySyntax.Let()\n```
+              Dim x = From a In sourceA Let z = New With {Key .A = a.Method(), Key .B = a.Method()} Select z
+'                 ^ definition local 10
+'                   documentation ```vb\nx As Interface IEnumerable(Of <anonymous type: Key A As String, Key B As String>)\n```
+'                          ^ definition local 11
+'                            documentation ```vb\na As Interface IGeneric\n```
+'                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
+'                                           ^ definition local 12
+'                                             documentation ```vb\nz As AnonymousType <anonymous type: Key A As String, Key B As String>\n```
+'                                                              ^ reference local 14
+'                                                                  ^ reference local 11
+'                                                                    ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                                                                                   ^ reference local 15
+'                                                                                       ^ reference local 11
+'                                                                                         ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                                                                                                          ^ reference local 12
+          End Sub
+
+          Private Sub Join()
+'                     ^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Join().
+'                          documentation ```vb\nPrivate Sub QuerySyntax.Join()\n```
+              Dim x = From a In sourceA Join b In sourceB On a.Method() Equals b.Method() Select New With {Key .A = a.Method(), Key .B = b.Method()}
+'                 ^ definition local 16
+'                   documentation ```vb\nx As Interface IEnumerable(Of <anonymous type: Key A As String, Key B As String>)\n```
+'                          ^ definition local 17
+'                            documentation ```vb\na As Interface IGeneric\n```
+'                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
+'                                            ^ definition local 18
+'                                              documentation ```vb\nb As Interface IGeneric\n```
+'                                                 ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceB.
+'                                                            ^ reference local 17
+'                                                              ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                                                                              ^ reference local 18
+'                                                                                ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                                                                                                               ^ reference local 14
+'                                                                                                                   ^ reference local 17
+'                                                                                                                     ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                                                                                                                                    ^ reference local 15
+'                                                                                                                                        ^ reference local 18
+'                                                                                                                                          ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+          End Sub
+
+          Private Sub MultipleFrom()
+'                     ^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#MultipleFrom().
+'                                  documentation ```vb\nPrivate Sub QuerySyntax.MultipleFrom()\n```
+              Dim x = From a In sourceA From b In sourceB Where a.Method() = b.Method() Select c = New With {Key .A = a.Method(), Key .B = b.Method()} Where c.A = String.Empty
+'                 ^ definition local 19
+'                   documentation ```vb\nx As Interface IEnumerable(Of <anonymous type: Key A As String, Key B As String>)\n```
+'                          ^ definition local 20
+'                            documentation ```vb\na As Interface IGeneric\n```
+'                               ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceA.
+'                                            ^ definition local 21
+'                                              documentation ```vb\nb As Interface IGeneric\n```
+'                                                 ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#sourceB.
+'                                                               ^ reference local 20
+'                                                                 ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                                                                            ^ reference local 21
+'                                                                              ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                                                                                              ^ definition local 22
+'                                                                                                documentation ```vb\nc As AnonymousType <anonymous type: Key A As String, Key B As String>\n```
+'                                                                                                                 ^ reference local 14
+'                                                                                                                     ^ reference local 20
+'                                                                                                                       ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                                                                                                                                      ^ reference local 15
+'                                                                                                                                          ^ reference local 21
+'                                                                                                                                            ^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#IGeneric#Method().
+'                                                                                                                                                            ^ reference local 22
+'                                                                                                                                                              ^ reference local 14
+'                                                                                                                                                                         ^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/String#Empty.
+          End Sub
+
+          Private Sub Into(Students As List(Of Student))
+'                     ^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Into().
+'                          documentation ```vb\nPrivate Sub QuerySyntax.Into(Students As List(Of Student))\n```
+'                          ^^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Into().(Students)
+'                                   documentation ```vb\nStudents As List(Of Student)\n```
+'                                              ^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Student#
+              Dim sortedGroups = From student In Students Order By student.Last, student.First Group student By student.Last Into newGroup = Group Order By newGroup
+'                 ^^^^^^^^^^^^ definition local 23
+'                              documentation ```vb\nsortedGroups As Interface IOrderedEnumerable(Of <anonymous type: Key Last As String, Key newGroup As Interface IEnumerable(Of Student)>)\n```
+'                                     ^^^^^^^ definition local 24
+'                                             documentation ```vb\nstudent As Class Student\n```
+'                                                ^^^^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Into().(Students)
+'                                                                  ^^^^^^^ reference local 24
+'                                                                          ^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Student#Last.
+'                                                                                ^^^^^^^ reference local 24
+'                                                                                        ^^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Student#First.
+'                                                                                                    ^^^^^^^ reference local 24
+'                                                                                                               ^^^^^^^ reference local 24
+'                                                                                                                       ^^^^ reference scip-dotnet nuget . . VBMain/QuerySyntax#Student#Last.
+'                                                                                                                                 ^^^^^^^^ definition local 25
+'                                                                                                                                          documentation ```vb\nnewGroup As Interface IEnumerable(Of Student)\n```
+'                                                                                                                                                           ^^^^^^^^ reference local 25
+          End Sub
+
+          Private Class Student
+'                       ^^^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Student#
+'                               documentation ```vb\nClass Student\n```
+              Public Property First As String
+'                             ^^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Student#First.
+'                                   documentation ```vb\nPublic Property Student.First As String\n```
+              Public Property Last As String
+'                             ^^^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Student#Last.
+'                                  documentation ```vb\nPublic Property Student.Last As String\n```
+              Public Property ID As Integer
+'                             ^^ definition scip-dotnet nuget . . VBMain/QuerySyntax#Student#ID.
+'                                documentation ```vb\nPublic Property Student.ID As Integer\n```
+          End Class
+
+      End Class
+  End Namespace

--- a/snapshots/output-net8.0/syntax/VBMain/Statements.vb
+++ b/snapshots/output-net8.0/syntax/VBMain/Statements.vb
@@ -1,0 +1,178 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+  Imports System.IO
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^ reference scip-dotnet nuget . . IO/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Statements
+'                  ^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#
+'                             documentation ```vb\nClass Statements\n```
+          Private Sub [Try]()
+'                     ^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Try().
+'                           documentation ```vb\nPrivate Sub Statements.Try()\n```
+              Try
+                  File.ReadLines("asd")
+'                 ^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 IO/File#
+'                      ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 IO/File#ReadLines().
+              Catch err As Exception
+'                   ^^^ definition local 0
+'                       documentation ```vb\nerr As Class Exception\n```
+'                   ^^^ reference local 0
+'                          ^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Exception#
+                  Console.WriteLine(err)
+'                 ^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#
+'                         ^^^^^^^^^ reference scip-dotnet nuget System.Console 8.0.0.0 System/Console#WriteLine(+9).
+'                                   ^^^ reference local 0
+              End Try
+          End Sub
+
+          Private Function [Default]() As (A As String, B As Boolean)
+'                          ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Default().
+'                                    documentation ```vb\nPrivate Function Statements.Default() As (A As String, B As Boolean)\n```
+              Dim C As (A As String, B As Boolean) = ("42", 42)
+'                 ^ definition local 1
+'                   documentation ```vb\nC As (A As String, B As Boolean)\n```
+              Return C
+'                    ^ reference local 1
+          End Function
+
+          Public Class Inferred
+'                      ^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Inferred#
+'                               documentation ```vb\nClass Inferred\n```
+              Property F1 As Int32
+'                      ^^ definition scip-dotnet nuget . . VBMain/Statements#Inferred#F1.
+'                         documentation ```vb\nPublic Property Inferred.F1 As Integer\n```
+'                            ^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Int32#
+              Property F2 As Int32
+'                      ^^ definition scip-dotnet nuget . . VBMain/Statements#Inferred#F2.
+'                         documentation ```vb\nPublic Property Inferred.F2 As Integer\n```
+'                            ^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/Int32#
+          End Class
+
+          Private Sub InferredTuples()
+'                     ^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#InferredTuples().
+'                                    documentation ```vb\nPrivate Sub Statements.InferredTuples()\n```
+              Dim List = New List(Of Inferred)()
+'                 ^^^^ definition local 2
+'                      documentation ```vb\nList As Class List(Of Inferred)\n```
+'                                    ^^^^^^^^ reference scip-dotnet nuget . . VBMain/Statements#Inferred#
+              Dim Result = List.Select(Function(c) (c.F1, c.F2)).Where(Function(t) t.F2 = 1)
+'                 ^^^^^^ definition local 3
+'                        documentation ```vb\nResult As Interface IEnumerable(Of (F1 As Integer, F2 As Integer))\n```
+'                          ^^^^ reference local 2
+'                               ^^^^^^ reference scip-dotnet nuget System.Linq 8.0.0.0 Linq/Enumerable#Select().
+'                                               ^ definition local 5
+'                                                 documentation ```vb\nc As Inferred\n```
+'                                                   ^ reference local 5
+'                                                     ^^ reference scip-dotnet nuget . . VBMain/Statements#Inferred#F1.
+'                                                         ^ reference local 5
+'                                                           ^^ reference scip-dotnet nuget . . VBMain/Statements#Inferred#F2.
+'                                                                ^^^^^ reference scip-dotnet nuget System.Linq 8.0.0.0 Linq/Enumerable#Where().
+'                                                                               ^ definition local 7
+'                                                                                 documentation ```vb\nt As (F1 As Integer, F2 As Integer)\n```
+'                                                                                  ^ reference local 7
+'                                                                                    ^^ reference local 9
+          End Sub
+
+          Private Function MultipleInitializers() As Integer
+'                          ^^^^^^^^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#MultipleInitializers().
+'                                               documentation ```vb\nPrivate Function Statements.MultipleInitializers() As Integer\n```
+              Dim a As Integer = 1, b As Integer = 2
+'                 ^ definition local 10
+'                   documentation ```vb\na As Integer\n```
+'                                   ^ definition local 11
+'                                     documentation ```vb\nb As Integer\n```
+              Return a + b
+'                    ^ reference local 10
+'                        ^ reference local 11
+          End Function
+
+          Class MyDisposable
+'               ^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#MyDisposable#
+'                            documentation ```vb\nClass MyDisposable\n```
+'                            relationship implementation scip-dotnet nuget System.Runtime 8.0.0.0 System/IDisposable#
+              Implements IDisposable
+'                        ^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/IDisposable#
+
+              Private Sub Dispose() Implements IDisposable.Dispose
+'                         ^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#MyDisposable#Dispose().
+'                                 documentation ```vb\nPrivate Sub MyDisposable.Dispose()\n```
+'                                 relationship implementation reference scip-dotnet nuget System.Runtime 8.0.0.0 System/IDisposable#Dispose().
+'                                              ^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/IDisposable#
+'                                                          ^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/IDisposable#Dispose().
+                  Throw New NotImplementedException()
+'                           ^^^^^^^^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/NotImplementedException#
+              End Sub
+          End Class
+
+          Private Function [Using]() As MyDisposable
+'                          ^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Using().
+'                                  documentation ```vb\nPrivate Function Statements.Using() As MyDisposable\n```
+'                                       ^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Statements#MyDisposable#
+              Dim b = New MyDisposable()
+'                 ^ definition local 12
+'                   documentation ```vb\nb As Class MyDisposable\n```
+'                         ^^^^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Statements#MyDisposable#
+
+              Using a = b
+'                   ^ definition local 13
+'                     documentation ```vb\na As Class MyDisposable\n```
+'                       ^ reference local 12
+                  Return a
+'                        ^ reference local 13
+              End Using
+          End Function
+
+          Private Function MultipleUsing() As Long
+'                          ^^^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#MultipleUsing().
+'                                        documentation ```vb\nPrivate Function Statements.MultipleUsing() As Long\n```
+              Using a As Stream = File.OpenRead("a"), b As Stream = File.OpenRead("a")
+'                   ^ definition local 14
+'                     documentation ```vb\na As Class Stream\n```
+'                        ^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 IO/Stream#
+'                                 ^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 IO/File#
+'                                      ^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 IO/File#OpenRead().
+'                                                     ^ definition local 15
+'                                                       documentation ```vb\nb As Class Stream\n```
+'                                                          ^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 IO/Stream#
+'                                                                   ^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 IO/File#
+'                                                                        ^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 IO/File#OpenRead().
+                  Return a.Length + b.Length
+'                        ^ reference local 14
+'                          ^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 IO/Stream#Length.
+'                                   ^ reference local 15
+'                                     ^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 IO/Stream#Length.
+              End Using
+          End Function
+
+          Private Function Foreach() As Integer
+'                          ^^^^^^^ definition scip-dotnet nuget . . VBMain/Statements#Foreach().
+'                                  documentation ```vb\nPrivate Function Statements.Foreach() As Integer\n```
+              Dim y = New Integer() {1}
+'                 ^ definition local 16
+'                   documentation ```vb\ny As Integer()\n```
+              Dim z = 0
+'                 ^ definition local 17
+'                   documentation ```vb\nz As Integer\n```
+
+              For Each x As Integer In y
+'                      ^ definition local 18
+'                        documentation ```vb\nx As Integer\n```
+'                                      ^ reference local 16
+                  z += x
+'                 ^ reference local 17
+'                      ^ reference local 18
+              Next
+
+              Return z
+'                    ^ reference local 17
+          End Function
+
+      End Class
+  End Namespace

--- a/snapshots/output-net8.0/syntax/VBMain/Structs.vb
+++ b/snapshots/output-net8.0/syntax/VBMain/Structs.vb
@@ -1,0 +1,31 @@
+  Imports System.Diagnostics.CodeAnalysis
+'         ^^^^^^ reference scip-dotnet nuget . . System/
+'                ^^^^^^^^^^^ reference scip-dotnet nuget . . Diagnostics/
+'                            ^^^^^^^^^^^^ reference scip-dotnet nuget . . CodeAnalysis/
+
+  Namespace VBMain
+'           ^^^^^^ reference scip-dotnet nuget . . VBMain/
+      <SuppressMessage("ReSharper", "all")>
+'      ^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 CodeAnalysis/SuppressMessageAttribute#`.ctor`().
+      Public Class Structs
+'                  ^^^^^^^ definition scip-dotnet nuget . . VBMain/Structs#
+'                          documentation ```vb\nClass Structs\n```
+          Structure BasicStruct
+'                   ^^^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Structs#BasicStruct#
+'                               documentation ```vb\nStructure BasicStruct\n```
+              Public Property1 As Integer
+'                    ^^^^^^^^^ definition scip-dotnet nuget . . VBMain/Structs#BasicStruct#Property1.
+'                              documentation ```vb\nPublic BasicStruct.Property1 As Integer\n```
+
+              Public Sub New(ByVal field1 As Integer)
+'                        ^^^ definition scip-dotnet nuget . . VBMain/Structs#BasicStruct#`.ctor`(+1).
+'                            documentation ```vb\nPublic Sub BasicStruct.New(field1 As Integer)\n```
+'                                  ^^^^^^ definition scip-dotnet nuget . . VBMain/Structs#BasicStruct#`.ctor`(+1).(field1)
+'                                         documentation ```vb\nfield1 As Integer\n```
+                  Property1 = field1
+'                 ^^^^^^^^^ reference scip-dotnet nuget . . VBMain/Structs#BasicStruct#Property1.
+'                             ^^^^^^ reference scip-dotnet nuget . . VBMain/Structs#BasicStruct#`.ctor`(+1).(field1)
+              End Sub
+          End Structure
+      End Class
+  End Namespace


### PR DESCRIPTION
Previously, scip-dotnet was only cross-compiled for net7.0 and net6.0. This PR adds additional support for net8.0, which doesn't have a stable release yet (latest version is a release candidate) but it's good to be prepared for when net8.0 stable goes live.