### PR TITLE
Fix failing build on CI on MacOs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
-            8.0.x
+            6.x
+            7.x
+            8.x
       - run: dotnet format --verify-no-changes
       - run: dotnet format --verify-no-changes
         working-directory: snapshots/input/syntax
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
-            8.0.x
+            6.x
+            7.x
+            8.x
       - run: dotnet test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: |
+            6.0.x
+            7.0.x
+            8.0.x
       - run: dotnet format --verify-no-changes
       - run: dotnet format --verify-no-changes
         working-directory: snapshots/input/syntax
@@ -28,5 +31,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: |
+            6.0.x
+            7.0.x
+            8.0.x
       - run: dotnet test


### PR DESCRIPTION
After the last change it seems the CI is failing on MacOs (not sure why it wasn't caught in PR CI). 