### PR TITLE
feat(codeintel):  Add new command line arguments for customizing dotnet restore

### DIFF
--- a/ScipDotnet/IndexCommandHandler.cs
+++ b/ScipDotnet/IndexCommandHandler.cs
@@ -20,8 +20,8 @@ public static class IndexCommandHandler
         List<string> exclude,
         bool allowGlobalSymbolDefinitions,
         int dotnetRestoreTimeout,
-        bool dotnetSkipRestore,
-        FileInfo? dotnetNugetConfigFile
+        bool skipDotnetRestore,
+        FileInfo? nugetConfigPath
         )
     {
         var logger = host.Services.GetRequiredService<ILogger<IndexCommandOptions>>();
@@ -45,8 +45,8 @@ public static class IndexCommandHandler
             matcher,
             allowGlobalSymbolDefinitions,
             dotnetRestoreTimeout,
-            dotnetSkipRestore,
-            dotnetNugetConfigFile
+            skipDotnetRestore,
+            nugetConfigPath
         );
         await ScipIndex(host, options);
         return 0;

--- a/ScipDotnet/IndexCommandHandler.cs
+++ b/ScipDotnet/IndexCommandHandler.cs
@@ -11,8 +11,18 @@ namespace ScipDotnet;
 
 public static class IndexCommandHandler
 {
-    public static async Task<int> Process(IHost host, List<FileInfo> projects, string output, FileInfo workingDirectory,
-        List<string> include, List<string> exclude, bool allowGlobalSymbolDefinitions, int dotnetRestoreTimeout)
+    public static async Task<int> Process(
+        IHost host,
+        List<FileInfo> projects,
+        string output,
+        FileInfo workingDirectory,
+        List<string> include,
+        List<string> exclude,
+        bool allowGlobalSymbolDefinitions,
+        int dotnetRestoreTimeout,
+        bool dotnetSkipRestore,
+        FileInfo? dotnetNugetConfigFile
+        )
     {
         var logger = host.Services.GetRequiredService<ILogger<IndexCommandOptions>>();
         var matcher = new Matcher();
@@ -34,7 +44,9 @@ public static class IndexCommandHandler
             logger,
             matcher,
             allowGlobalSymbolDefinitions,
-            dotnetRestoreTimeout
+            dotnetRestoreTimeout,
+            dotnetSkipRestore,
+            dotnetNugetConfigFile
         );
         await ScipIndex(host, options);
         return 0;

--- a/ScipDotnet/IndexCommandOptions.cs
+++ b/ScipDotnet/IndexCommandOptions.cs
@@ -10,5 +10,7 @@ public record IndexCommandOptions(
     ILogger<IndexCommandOptions> Logger,
     Matcher Matcher,
     bool AllowGlobalSymbolDefinitions,
-    int DotnetRestoreTimeout
+    int DotnetRestoreTimeout,
+    bool DotnetSkipRestore,
+    FileInfo? DotnetNugetConfigFile
 );

--- a/ScipDotnet/IndexCommandOptions.cs
+++ b/ScipDotnet/IndexCommandOptions.cs
@@ -11,6 +11,6 @@ public record IndexCommandOptions(
     Matcher Matcher,
     bool AllowGlobalSymbolDefinitions,
     int DotnetRestoreTimeout,
-    bool DotnetSkipRestore,
-    FileInfo? DotnetNugetConfigFile
+    bool SkipDotnetRestore,
+    FileInfo? NugetConfigPath
 );

--- a/ScipDotnet/Program.cs
+++ b/ScipDotnet/Program.cs
@@ -43,10 +43,12 @@ public static class Program
                 "If disabled, then public symbols will only be visible within the index."),
             new Option<int>("--dotnet-restore-timeout", () => DotnetRestoreTimeout,
                 @"The timeout (in ms) for the ""dotnet restore"" command"),
-            new Option<bool>("--dotnet-skip-restore", () => false,
+            new Option<bool>("--skip-dotnet-restore", () => false,
                 @"Skip executing ""dotnet restore"" and assume it has been run externally."),
-            new Option<FileInfo?>("--dotnet-nuget-config-file", () => null,
-                @"Provide a custom path for ""dotnet restore"" to find the NuGet.config file."),
+            new Option<FileInfo?>("--nuget-config-path", () => null,
+                @"Provide a case sensitive custom path for ""dotnet restore"" to find the NuGet.config file. " +
+                @"If not provided, ""dotnet restore"" will search for the NuGet.config file recursively up the folder hierarchy " +
+                @"and in the default user and system config locations."),
         };
         indexCommand.Handler = CommandHandler.Create(IndexCommandHandler.Process);
         var rootCommand =

--- a/ScipDotnet/Program.cs
+++ b/ScipDotnet/Program.cs
@@ -42,7 +42,11 @@ public static class Program
                 "If enabled, allow public symbol definitions to be accessible from other SCIP indexes. " +
                 "If disabled, then public symbols will only be visible within the index."),
             new Option<int>("--dotnet-restore-timeout", () => DotnetRestoreTimeout,
-                @"The timeout (in ms) for the ""dotnet restore"" command")
+                @"The timeout (in ms) for the ""dotnet restore"" command"),
+            new Option<bool>("--dotnet-skip-restore", () => false,
+                @"Skip executing ""dotnet restore"" and assume it has been run externally."),
+            new Option<FileInfo?>("--dotnet-nuget-config-file", () => null,
+                @"Provide a custom path for ""dotnet restore"" to find the NuGet.config file."),
         };
         indexCommand.Handler = CommandHandler.Create(IndexCommandHandler.Process);
         var rootCommand =

--- a/ScipDotnet/ScipProjectIndexer.cs
+++ b/ScipDotnet/ScipProjectIndexer.cs
@@ -21,9 +21,9 @@ public class ScipProjectIndexer
     private void Restore(IndexCommandOptions options, FileInfo project)
     {
         var arguments = project.Extension.Equals(".sln") ? $"restore {project.FullName} /p:EnableWindowsTargeting=true" : "restore /p:EnableWindowsTargeting=true";
-        if (options.DotnetNugetConfigFile != null)
+        if (options.NugetConfigPath != null)
         {
-            arguments += $" --configfile {options.DotnetNugetConfigFile.FullName}";
+            arguments += $" --configfile \"{options.NugetConfigPath.FullName}\"";
         }
         var process = new Process()
         {
@@ -59,7 +59,7 @@ public class ScipProjectIndexer
                                                                FileInfo rootProject,
                                                                HashSet<ProjectId> indexedProjects)
     {
-        if (!options.DotnetSkipRestore)
+        if (!options.SkipDotnetRestore)
         {
             Restore(options, rootProject);
         }

--- a/ScipDotnet/ScipProjectIndexer.cs
+++ b/ScipDotnet/ScipProjectIndexer.cs
@@ -21,6 +21,10 @@ public class ScipProjectIndexer
     private void Restore(IndexCommandOptions options, FileInfo project)
     {
         var arguments = project.Extension.Equals(".sln") ? $"restore {project.FullName} /p:EnableWindowsTargeting=true" : "restore /p:EnableWindowsTargeting=true";
+        if (options.DotnetNugetConfigFile != null)
+        {
+            arguments += $" --configfile {options.DotnetNugetConfigFile.FullName}";
+        }
         var process = new Process()
         {
             StartInfo = new ProcessStartInfo()
@@ -55,7 +59,11 @@ public class ScipProjectIndexer
                                                                FileInfo rootProject,
                                                                HashSet<ProjectId> indexedProjects)
     {
-        Restore(options, rootProject);
+        if (!options.DotnetSkipRestore)
+        {
+            Restore(options, rootProject);
+        }
+
         var projects = (string.Equals(rootProject.Extension, ".csproj") || string.Equals(rootProject.Extension, ".vbproj")
             ? new[]
             {


### PR DESCRIPTION
Adds the following two new command line options

`--dotnet-skip-restore`: Skips dotnet restore. This is useful if a customer knows in their CI/CD they already restored packages and they don't need it tried again. This can be important if they have private packages and the restore scip-dotnet would perform could fail.

`--dotnet-nuget-config-file`: dotnet restore will try to find a specific file named NuGet.config however, if a customer has a custom file or its in a different location, this setting lets them specify a path directly to it. 


# Testing
- Validated locally that both settings function properly. 