### PR TITLE
Pin digest for base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:9.0
+FROM mcr.microsoft.com/dotnet/sdk:9.0@sha256:ae000be75dac94fc40e00f0eee903289e985995cc06dac3937469254ce5b60b6
 WORKDIR /scip-dotnet
 ADD . /scip-dotnet
 RUN dotnet pack


### PR DESCRIPTION
Update to latest base image

Built locally, unsure what further testing is required:

```
> docker buildx build --platform linux/amd64 -f Dockerfile -t scip-dotnet:latest .

> docker run --rm -it --entrypoint /bin/sh scip-dotnet:latest
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
# scip-dotnet
Required command was not provided.

Description:
  SCIP indexer for the C# and Visual basic programming languages. Built with the Roslyn .NET compiler. Supports MSBuild.

Usage:
  scip-dotnet [command] [options]

Options:
  --version       Show version information
  -?, -h, --help  Show help and usage information

Commands:
  index <projects>  Index a solution file

# scip-dotnet --version
0.2.12+8e17391641b3a1096193d927ca7459e7140fd95f
```

Using index digest:
```
> docker buildx imagetools inspect mcr.microsoft.com/dotnet/sdk:9.0
Name:      mcr.microsoft.com/dotnet/sdk:9.0
MediaType: application/vnd.docker.distribution.manifest.list.v2+json
Digest:    sha256:ae000be75dac94fc40e00f0eee903289e985995cc06dac3937469254ce5b60b6
```