### PR TITLE
Fix NullReferenceException in VisitIdentifierName when calling GetSymbolInfo

### DIFF
--- a/ScipDotnet/ScipCSharpSyntaxWalker.cs
+++ b/ScipDotnet/ScipCSharpSyntaxWalker.cs
@@ -22,7 +22,14 @@ public class ScipCSharpSyntaxWalker : CSharpSyntaxWalker
     {
         if (!node.IsVar)
         {
-            _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetSymbolInfo(node).Symbol, node.GetLocation(), false);
+            try
+            {
+                _scipDocumentIndexer.VisitOccurrence(_semanticModel.GetSymbolInfo(node).Symbol, node.GetLocation(), false);
+            }
+            catch (NullReferenceException)
+            {
+                // Roslyn GetSymbolInfo can throw NullReferenceException on certain code patterns
+            }
         }
 
         base.VisitIdentifierName(node);


### PR DESCRIPTION
## Summary

- Wraps the `GetSymbolInfo` call in `VisitIdentifierName` in a `try/catch (NullReferenceException)` to prevent scip-dotnet crashing when Roslyn's `CSharpSemanticModel.AddReducedAndFilteredMethodGroupSymbol` throws on certain C# code patterns
- The indexer now silently skips problematic nodes rather than crashing

Inspired by the workaround in [justeattakeaway/JustSaying#1946](https://github.com/justeattakeaway/JustSaying/pull/1946), applying the fix directly to the source rather than as a build-time patch.

## Test plan

- [ ] Run scip-dotnet against a codebase that previously triggered the NullReferenceException and confirm it completes successfully