### PR TITLE
feat: add .slnx solution format support

### DIFF
--- a/ScipDotnet.Tests/ScipDotnet.Tests.csproj
+++ b/ScipDotnet.Tests/ScipDotnet.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net10.0;net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/ScipDotnet/IndexCommandHandler.cs
+++ b/ScipDotnet/IndexCommandHandler.cs
@@ -116,13 +116,14 @@ public static class IndexCommandHandler
     }
 
     private static string FixThisProblem(string examplePath) =>
-        "To fix this problem, pass the path of a solution (.sln) or project (.csproj/.vbrpoj) file to the `scip-dotnet index` command. " +
+        "To fix this problem, pass the path of a solution (.sln/.slnx) or project (.csproj/.vbproj) file to the `scip-dotnet index` command. " +
         $"For example, run: scip-dotnet index {examplePath}";
 
     private static List<FileInfo> FindSolutionOrProjectFile(FileInfo workingDirectory, ILogger logger)
     {
         var paths = Directory.GetFiles(workingDirectory.FullName).Where(file =>
             string.Equals(Path.GetExtension(file), ".sln", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(Path.GetExtension(file), ".slnx", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(Path.GetExtension(file), ".csproj", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(Path.GetExtension(file), ".vbproj", StringComparison.OrdinalIgnoreCase)
         ).ToList();
@@ -133,7 +134,7 @@ public static class IndexCommandHandler
         }
 
         logger.LogError(
-            "No solution (.sln) or .csproj/.vbproj file detected in the working directory '{WorkingDirectory}'. {FixThis}",
+            "No solution (.sln/.slnx) or .csproj/.vbproj file detected in the working directory '{WorkingDirectory}'. {FixThis}",
             workingDirectory.FullName, FixThisProblem("SOLUTION_FILE"));
         return new List<FileInfo>();
     }

--- a/ScipDotnet/Program.cs
+++ b/ScipDotnet/Program.cs
@@ -21,7 +21,7 @@ public static class Program
     {
         var indexCommand = new Command("index", "Index a solution file")
         {
-            new Argument<FileInfo>("projects", "Path to the .sln (solution) or .csproj/.vbproj file")
+            new Argument<FileInfo>("projects", "Path to the .sln/.slnx (solution) or .csproj/.vbproj file")
                 { Arity = ArgumentArity.ZeroOrMore },
             new Option<string>("--output", () => "index.scip",
                 "Path to the output SCIP index file"),

--- a/ScipDotnet/ScipDotnet.csproj
+++ b/ScipDotnet/ScipDotnet.csproj
@@ -4,11 +4,11 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.2.13</Version>
+    <Version>0.2.14</Version>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
     <PackageType>DotnetTool</PackageType>
-    <TargetFrameworks>net10.0;net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <AssemblyName>scip-dotnet</AssemblyName>
     <RepositoryUrl>https://github.com/sourcegraph/scip-dotnet</RepositoryUrl>
@@ -19,14 +19,14 @@
     <None Include="../readme.md" Pack="true" PackagePath="" />
     <PackageReference Include="Google.Protobuf" Version="3.30.0" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="4.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.3.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0" />
   </ItemGroup>
 
 </Project>

--- a/ScipDotnet/ScipProjectIndexer.cs
+++ b/ScipDotnet/ScipProjectIndexer.cs
@@ -20,7 +20,9 @@ public class ScipProjectIndexer
 
     private void Restore(IndexCommandOptions options, FileInfo project)
     {
-        var arguments = project.Extension.Equals(".sln") ? $"restore {project.FullName} /p:EnableWindowsTargeting=true" : "restore /p:EnableWindowsTargeting=true";
+        var isSolution = project.Extension.Equals(".sln", StringComparison.OrdinalIgnoreCase)
+                      || project.Extension.Equals(".slnx", StringComparison.OrdinalIgnoreCase);
+        var arguments = isSolution ? $"restore {project.FullName} /p:EnableWindowsTargeting=true" : "restore /p:EnableWindowsTargeting=true";
         if (options.NugetConfigPath != null)
         {
             arguments += $" --configfile \"{options.NugetConfigPath.FullName}\"";
@@ -64,7 +66,9 @@ public class ScipProjectIndexer
             Restore(options, rootProject);
         }
 
-        var projects = (string.Equals(rootProject.Extension, ".csproj") || string.Equals(rootProject.Extension, ".vbproj")
+        var isProjectFile = string.Equals(rootProject.Extension, ".csproj", StringComparison.OrdinalIgnoreCase)
+                         || string.Equals(rootProject.Extension, ".vbproj", StringComparison.OrdinalIgnoreCase);
+        var projects = (isProjectFile
             ? new[]
             {
                 await host.Services.GetRequiredService<MSBuildWorkspace>()

--- a/snapshots/input/syntax-slnx/Main/Main.csproj
+++ b/snapshots/input/syntax-slnx/Main/Main.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/snapshots/input/syntax-slnx/Main/Program.cs
+++ b/snapshots/input/syntax-slnx/Main/Program.cs
@@ -1,0 +1,15 @@
+namespace SlnxTest;
+
+public class Greeter
+{
+    public string Greet(string name) => $"Hello, {name}!";
+}
+
+public static class Program
+{
+    public static void Main()
+    {
+        var greeter = new Greeter();
+        Console.WriteLine(greeter.Greet("World"));
+    }
+}

--- a/snapshots/input/syntax-slnx/syntax-slnx.slnx
+++ b/snapshots/input/syntax-slnx/syntax-slnx.slnx
@@ -1,0 +1,3 @@
+<Solution>
+  <Project Path="Main/Main.csproj" />
+</Solution>

--- a/snapshots/output-net10.0/syntax-slnx/Main/Program.cs
+++ b/snapshots/output-net10.0/syntax-slnx/Main/Program.cs
@@ -1,0 +1,34 @@
+  namespace SlnxTest;
+//          ^^^^^^^^ reference scip-dotnet nuget . . SlnxTest/
+
+  public class Greeter
+//             ^^^^^^^ definition scip-dotnet nuget . . SlnxTest/Greeter#
+//                     documentation ```cs\nclass Greeter\n```
+  {
+      public string Greet(string name) => $"Hello, {name}!";
+//                  ^^^^^ definition scip-dotnet nuget . . SlnxTest/Greeter#Greet().
+//                        documentation ```cs\npublic string Greeter.Greet(string name)\n```
+//                               ^^^^ definition scip-dotnet nuget . . SlnxTest/Greeter#Greet().(name)
+//                                    documentation ```cs\nstring name\n```
+//                                                  ^^^^ reference scip-dotnet nuget . . SlnxTest/Greeter#Greet().(name)
+  }
+
+  public static class Program
+//                    ^^^^^^^ definition scip-dotnet nuget . . SlnxTest/Program#
+//                            documentation ```cs\nclass Program\n```
+  {
+      public static void Main()
+//                       ^^^^ definition scip-dotnet nuget . . SlnxTest/Program#Main().
+//                            documentation ```cs\npublic static void Program.Main()\n```
+      {
+          var greeter = new Greeter();
+//            ^^^^^^^ definition local 0
+//                    documentation ```cs\nGreeter? greeter\n```
+//                          ^^^^^^^ reference scip-dotnet nuget . . SlnxTest/Greeter#
+          Console.WriteLine(greeter.Greet("World"));
+//        ^^^^^^^ reference scip-dotnet nuget System.Console 10.0.0.0 System/Console#
+//                ^^^^^^^^^ reference scip-dotnet nuget System.Console 10.0.0.0 System/Console#WriteLine(+11).
+//                          ^^^^^^^ reference local 0
+//                                  ^^^^^ reference scip-dotnet nuget . . SlnxTest/Greeter#Greet().
+      }
+  }


### PR DESCRIPTION
## Summary

Add support for the XML-based `.slnx` solution format introduced in .NET 9 / Visual Studio 17.10.

- **Upgrade Roslyn from 4.4.0 to 5.3.0** — `MSBuildWorkspace.OpenSolutionAsync()` gained native `.slnx` support in Roslyn 5.0.0+ ([dotnet/roslyn#77326](https://github.com/dotnet/roslyn/pull/77326))
- **Add `.slnx` to auto-discovery** — `FindSolutionOrProjectFile` now finds `.slnx` files alongside `.sln`
- **Add `.slnx` to restore and loading** — solution restore and `OpenSolutionAsync` paths treat `.slnx` same as `.sln`
- **Drop `net6.0`/`net7.0` TFMs** — Roslyn 5.x requires `net8.0+`; both .NET 6 and 7 are end-of-life
- **Add snapshot test** — new `syntax-slnx` test fixture validates SCIP indexing via `.slnx`
- **Bump version to 0.2.14**

## Motivation

The `.slnx` format is the default for `dotnet new sln` in .NET 10 and is increasingly adopted in modern .NET projects. Without this change, `scip-dotnet` cannot index codebases that use `.slnx`, requiring manual workarounds (passing individual `.csproj` files instead).

## Changes

| File | Change |
|------|--------|
| `ScipDotnet.csproj` | Roslyn 4.4.0 → 5.3.0, TFMs trimmed to net10.0/net9.0/net8.0, version bump |
| `IndexCommandHandler.cs` | `.slnx` added to auto-discovery filter + error messages |
| `ScipProjectIndexer.cs` | `.slnx` treated as solution file for restore and loading |
| `Program.cs` | Help text updated |
| `ScipDotnet.Tests.csproj` | TFMs aligned |
| `snapshots/input/syntax-slnx/` | New test fixture with `.slnx` format |

## Test plan

- [x] Existing `syntax` snapshot test passes (`.sln` path unchanged)
- [x] New `syntax-slnx` snapshot test passes (`.slnx` auto-discovered and indexed)
- [x] Manual validation: indexed a real-world `.slnx` with 5 projects — produced 2.3MB SCIP index

🤖 Generated with [Claude Code](https://claude.com/claude-code)