### PR TITLE
Fix/external symbols

### DIFF
--- a/ScipDotnet.Tests/ExternalSymbolsTests.cs
+++ b/ScipDotnet.Tests/ExternalSymbolsTests.cs
@@ -1,0 +1,105 @@
+using System.Diagnostics;
+using Scip;
+using Index = Scip.Index;
+
+namespace ScipDotnet.Tests;
+
+/// <summary>
+/// Regression test for dangling cross-package occurrences.
+///
+/// SCIP requires that every occurrence referencing a symbol that is defined in an
+/// external package have a matching <see cref="SymbolInformation"/> in
+/// <c>Index.external_symbols</c> (the same invariant <c>scip lint</c> enforces).
+///
+/// Before the external-symbols fix, scip-dotnet emitted reference occurrences for
+/// NuGet/BCL symbols (e.g. <c>System.Runtime</c>) but never populated
+/// <c>external_symbols</c>, so ~60% of occurrences in a real-world index dangled.
+/// </summary>
+[TestFixture]
+public class ExternalSymbolsTests
+{
+    [Test]
+    public void EveryGenuineExternalOccurrenceHasSymbolInformation()
+    {
+        var inputDirectory = Path.Join(RootDirectory(), "snapshots", "input", "syntax");
+        var indexFile = IndexDirectory(inputDirectory);
+        var index = Index.Parser.ParseFrom(File.ReadAllBytes(indexFile));
+
+        // The set of symbols for which a SymbolInformation exists, either as an
+        // in-document definition or as an external symbol.
+        var declared = new HashSet<string>();
+        foreach (var document in index.Documents)
+        {
+            foreach (var info in document.Symbols)
+            {
+                declared.Add(info.Symbol);
+            }
+        }
+        foreach (var info in index.ExternalSymbols)
+        {
+            declared.Add(info.Symbol);
+        }
+
+        var dangling = new SortedSet<string>();
+        foreach (var document in index.Documents)
+        {
+            foreach (var occurrence in document.Occurrences)
+            {
+                if (IsGenuineExternal(occurrence.Symbol) && !declared.Contains(occurrence.Symbol))
+                {
+                    dangling.Add(occurrence.Symbol);
+                }
+            }
+        }
+
+        Assert.That(dangling, Is.Empty,
+            "Occurrences reference external-package symbols that have no SymbolInformation "
+            + "in external_symbols or any document:\n  " + string.Join("\n  ", dangling));
+    }
+
+    // A "genuine external" symbol is a global symbol that resolves to a real NuGet/BCL
+    // package. Index-local symbols use the "scip-dotnet nuget . . " package placeholder
+    // and are intentionally excluded here (their dangling references are a separate issue).
+    private static bool IsGenuineExternal(string symbol) =>
+        symbol.StartsWith("scip-dotnet nuget ")
+        && !symbol.StartsWith("scip-dotnet nuget . . ");
+
+    private static string IndexDirectory(string directory)
+    {
+        var framework = $"net{Environment.Version.Major}.0";
+        var arguments = $"run --project ScipDotnet --framework {framework} -- index --working-directory {directory}";
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = arguments,
+                WorkingDirectory = RootDirectory()
+            }
+        };
+        process.Start();
+        process.WaitForExit();
+        if (process.ExitCode != 0)
+        {
+            Assert.Fail($"non-zero exit code {process.ExitCode} indexing {directory}\ndotnet {arguments}");
+        }
+
+        return Path.Join(directory, "index.scip");
+    }
+
+    private static string RootDirectory()
+    {
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = "rev-parse --show-toplevel",
+                UseShellExecute = false,
+                RedirectStandardOutput = true
+            }
+        };
+        process.Start();
+        return process.StandardOutput.ReadToEnd().Trim();
+    }
+}

--- a/ScipDotnet.Tests/ExternalSymbolsTests.cs
+++ b/ScipDotnet.Tests/ExternalSymbolsTests.cs
@@ -25,20 +25,7 @@ public class ExternalSymbolsTests
         var indexFile = IndexDirectory(inputDirectory);
         var index = Index.Parser.ParseFrom(File.ReadAllBytes(indexFile));
 
-        // The set of symbols for which a SymbolInformation exists, either as an
-        // in-document definition or as an external symbol.
-        var declared = new HashSet<string>();
-        foreach (var document in index.Documents)
-        {
-            foreach (var info in document.Symbols)
-            {
-                declared.Add(info.Symbol);
-            }
-        }
-        foreach (var info in index.ExternalSymbols)
-        {
-            declared.Add(info.Symbol);
-        }
+        var declared = DeclaredSymbols(index);
 
         var dangling = new SortedSet<string>();
         foreach (var document in index.Documents)
@@ -55,6 +42,60 @@ public class ExternalSymbolsTests
         Assert.That(dangling, Is.Empty,
             "Occurrences reference external-package symbols that have no SymbolInformation "
             + "in external_symbols or any document:\n  " + string.Join("\n  ", dangling));
+    }
+
+    // Every external-package symbol referenced as a relationship target (e.g. the
+    // implicitly implemented IEquatable<T> on a record, or a transitively inherited
+    // interface that never appears textually in the source) must also be declared in
+    // external_symbols. Otherwise scip lint reports:
+    //   "has a relationship to <symbol>, but couldn't find #2 in external symbols ...".
+    [Test]
+    public void EveryExternalRelationshipTargetHasSymbolInformation()
+    {
+        var inputDirectory = Path.Join(RootDirectory(), "snapshots", "input", "syntax");
+        var indexFile = IndexDirectory(inputDirectory);
+        var index = Index.Parser.ParseFrom(File.ReadAllBytes(indexFile));
+
+        var declared = DeclaredSymbols(index);
+
+        var dangling = new SortedSet<string>();
+        foreach (var document in index.Documents)
+        {
+            foreach (var info in document.Symbols)
+            {
+                foreach (var relationship in info.Relationships)
+                {
+                    if (IsGenuineExternal(relationship.Symbol) && !declared.Contains(relationship.Symbol))
+                    {
+                        dangling.Add(relationship.Symbol);
+                    }
+                }
+            }
+        }
+
+        Assert.That(dangling, Is.Empty,
+            "SymbolInformation relationships target external-package symbols that have no "
+            + "SymbolInformation in external_symbols or any document:\n  " + string.Join("\n  ", dangling));
+    }
+
+    // The set of symbols for which a SymbolInformation exists, either as an
+    // in-document definition or as an external symbol.
+    private static HashSet<string> DeclaredSymbols(Index index)
+    {
+        var declared = new HashSet<string>();
+        foreach (var document in index.Documents)
+        {
+            foreach (var info in document.Symbols)
+            {
+                declared.Add(info.Symbol);
+            }
+        }
+        foreach (var info in index.ExternalSymbols)
+        {
+            declared.Add(info.Symbol);
+        }
+
+        return declared;
     }
 
     // A "genuine external" symbol is a global symbol that resolves to a real NuGet/BCL

--- a/ScipDotnet/IndexCommandHandler.cs
+++ b/ScipDotnet/IndexCommandHandler.cs
@@ -110,6 +110,17 @@ public static class IndexCommandHandler
             options.Logger.LogWarning("Indexing finished without error but no documents were indexed.");
         }
 
+        // Declare every referenced external-package symbol in Index.external_symbols so that
+        // cross-package references resolve. Skip any symbol that also has an in-source
+        // definition (possible under --allow-global-symbol-definitions). Order by symbol for
+        // deterministic output.
+        foreach (var external in indexer.ExternalSymbols
+                     .Where(entry => !indexer.DefinedSymbols.Contains(entry.Key))
+                     .OrderBy(entry => entry.Key, StringComparer.Ordinal))
+        {
+            index.ExternalSymbols.Add(external.Value);
+        }
+
         await File.WriteAllBytesAsync(options.Output.FullName, index.ToByteArray());
         options.Logger.LogInformation("done: {OptionsOutput} {TimeElapsed}", options.Output,
             stopwatch.Elapsed.ToFriendlyString());

--- a/ScipDotnet/ScipDocumentIndexer.cs
+++ b/ScipDotnet/ScipDocumentIndexer.cs
@@ -291,33 +291,35 @@ public class ScipDocumentIndexer
                     var baseType = namedTypeSymbol.BaseType;
                     while (baseType != null)
                     {
-                        var baseTypeSymbol = CreateScipSymbol(baseType).Value;
-                        if (IsIgnoredRelationshipSymbol(baseTypeSymbol))
+                        var baseTypeScip = CreateScipSymbol(baseType);
+                        if (IsIgnoredRelationshipSymbol(baseTypeScip.Value))
                         {
                             break;
                         }
 
                         info.Relationships.Add(new Relationship
                         {
-                            Symbol = baseTypeSymbol,
+                            Symbol = baseTypeScip.Value,
                             IsImplementation = true
                         });
+                        CollectExternalRelationship(baseType, baseTypeScip);
                         baseType = baseType.BaseType;
                     }
 
                     foreach (var interfaceSymbol in namedTypeSymbol.AllInterfaces)
                     {
-                        var interfaceSymbolSymbol = CreateScipSymbol(interfaceSymbol).Value;
-                        if (IsIgnoredRelationshipSymbol(interfaceSymbolSymbol))
+                        var interfaceScip = CreateScipSymbol(interfaceSymbol);
+                        if (IsIgnoredRelationshipSymbol(interfaceScip.Value))
                         {
                             continue;
                         }
 
                         info.Relationships.Add(new Relationship
                         {
-                            Symbol = interfaceSymbolSymbol,
+                            Symbol = interfaceScip.Value,
                             IsImplementation = true
                         });
+                        CollectExternalRelationship(interfaceSymbol, interfaceScip);
                     }
 
                     break;
@@ -327,27 +329,44 @@ public class ScipDocumentIndexer
                     var overriddenMethod = methodSymbol.OverriddenMethod;
                     while (overriddenMethod != null)
                     {
+                        var overriddenScip = CreateScipSymbol(overriddenMethod);
                         info.Relationships.Add(new Relationship
                         {
-                            Symbol = CreateScipSymbol(overriddenMethod).Value,
+                            Symbol = overriddenScip.Value,
                             IsImplementation = true,
                             IsReference = true
                         });
+                        CollectExternalRelationship(overriddenMethod, overriddenScip);
                         overriddenMethod = overriddenMethod.OverriddenMethod;
                     }
 
                     foreach (var interfaceMethod in ScipDocumentIndexer.InterfaceImplementations(methodSymbol))
                     {
+                        var interfaceMethodScip = CreateScipSymbol(interfaceMethod);
                         info.Relationships.Add(new Relationship
                         {
-                            Symbol = CreateScipSymbol(interfaceMethod).Value,
+                            Symbol = interfaceMethodScip.Value,
                             IsImplementation = true,
                             IsReference = true
                         });
+                        CollectExternalRelationship(interfaceMethod, interfaceMethodScip);
                     }
 
                     break;
                 }
+        }
+    }
+
+    // Collects an external-package symbol that appears only as a relationship target
+    // (e.g. an implicitly implemented IEquatable<T> on a record, or a transitive base
+    // class / inherited interface that never appears textually in the source and so is
+    // never seen by VisitOccurrence). Without this, the relationship dangles
+    // (scip lint: "has a relationship to <symbol>, couldn't find #2").
+    private void CollectExternalRelationship(ISymbol related, ScipSymbol scip)
+    {
+        if (scip.IsExternalPackageSymbol() && !_externalSymbols.ContainsKey(scip.Value))
+        {
+            _externalSymbols[scip.Value] = CreateExternalSymbolInformation(related, scip.Value);
         }
     }
 

--- a/ScipDotnet/ScipDocumentIndexer.cs
+++ b/ScipDotnet/ScipDocumentIndexer.cs
@@ -15,6 +15,15 @@ public class ScipDocumentIndexer
     private int _localCounter;
     private readonly Dictionary<ISymbol, ScipSymbol> _globals;
     private readonly Dictionary<ISymbol, ScipSymbol> _locals = new(SymbolEqualityComparer.Default);
+
+    // Index-wide accounting shared across every document, used to populate
+    // Index.external_symbols. `_externalSymbols` maps a SCIP symbol string to the
+    // SymbolInformation we will emit for a referenced external-package symbol.
+    // `_definedSymbols` is the set of symbols that already have an in-source definition;
+    // it lets us avoid duplicating a symbol in external_symbols (relevant when
+    // --allow-global-symbol-definitions assigns a real package name to a source symbol).
+    private readonly Dictionary<string, SymbolInformation> _externalSymbols;
+    private readonly HashSet<string> _definedSymbols;
     private readonly string _markdownCodeFenceLanguage;
 
     // Custom formatting options to render symbol documentation. Feel free to tweak these parameters.
@@ -59,11 +68,15 @@ public class ScipDocumentIndexer
     public ScipDocumentIndexer(
         Document doc,
         IndexCommandOptions options,
-        Dictionary<ISymbol, ScipSymbol> globals)
+        Dictionary<ISymbol, ScipSymbol> globals,
+        Dictionary<string, SymbolInformation> externalSymbols,
+        HashSet<string> definedSymbols)
     {
         _doc = doc;
         _options = options;
         _globals = globals;
+        _externalSymbols = externalSymbols;
+        _definedSymbols = definedSymbols;
         _markdownCodeFenceLanguage = _doc.Language == "C#" ? "cs" : "vb";
     }
 
@@ -226,7 +239,8 @@ public class ScipDocumentIndexer
             symbolRole |= (int)SymbolRole.Definition;
         }
 
-        var scipSymbol = CreateScipSymbol(symbol).Value;
+        var scip = CreateScipSymbol(symbol);
+        var scipSymbol = scip.Value;
         var occurrence = new Occurrence
         {
             Symbol = scipSymbol,
@@ -238,9 +252,23 @@ public class ScipDocumentIndexer
             occurrence.Range.Add(range);
         }
 
-        if (!isDefinition) return;
+        if (!isDefinition)
+        {
+            // This occurrence references a symbol that is not defined in the indexed
+            // source. If it belongs to an external NuGet/BCL package, record a minimal
+            // SymbolInformation so the reference is resolvable via Index.external_symbols.
+            // Without this, every cross-package reference dangles (scip lint reports
+            // "no matching SymbolInformation in external symbols or any document").
+            if (scip.IsExternalPackageSymbol() && !_externalSymbols.ContainsKey(scipSymbol))
+            {
+                _externalSymbols[scipSymbol] = CreateExternalSymbolInformation(symbol, scipSymbol);
+            }
+
+            return;
+        }
 
         // Emit SymbolInformation for this definition occurrence.
+        _definedSymbols.Add(scipSymbol);
         var info = new SymbolInformation { Symbol = scipSymbol };
         _doc.Symbols.Add(info);
 
@@ -321,6 +349,30 @@ public class ScipDocumentIndexer
                     break;
                 }
         }
+    }
+
+    // Builds the SymbolInformation emitted into Index.external_symbols for a referenced
+    // external-package symbol. We intentionally emit only the symbol and its hover
+    // documentation: unlike in-source definitions we do NOT walk base types / interfaces,
+    // because doing so would recurse across the entire BCL type graph and generate an
+    // unbounded number of additional external symbols.
+    private SymbolInformation CreateExternalSymbolInformation(ISymbol symbol, string scipSymbol)
+    {
+        var info = new SymbolInformation { Symbol = scipSymbol };
+
+        var symbolSignature = symbol.ToDisplayString(_format);
+        if (symbolSignature.Length > 0)
+        {
+            info.Documentation.Add($"```{_markdownCodeFenceLanguage}\n{symbolSignature}\n```");
+        }
+
+        var symbolDocumentation = symbol.GetDocumentationCommentXml();
+        if (symbolDocumentation?.Length > 0)
+        {
+            info.Documentation.Add(symbolDocumentation);
+        }
+
+        return info;
     }
 
     // Returns explicitly and implicitly implemented interface methods by the given symbol method.

--- a/ScipDotnet/ScipProjectIndexer.cs
+++ b/ScipDotnet/ScipProjectIndexer.cs
@@ -18,6 +18,12 @@ public class ScipProjectIndexer
 
     private ILogger<ScipProjectIndexer> Logger { get; }
 
+    // Index-wide collections populated while documents are indexed. After indexing
+    // finishes, the caller copies ExternalSymbols (minus DefinedSymbols) into
+    // Index.external_symbols so that cross-package references are resolvable.
+    public Dictionary<string, Scip.SymbolInformation> ExternalSymbols { get; } = new();
+    public HashSet<string> DefinedSymbols { get; } = new();
+
     private void Restore(IndexCommandOptions options, FileInfo project)
     {
         var isSolution = project.Extension.Equals(".sln", StringComparison.OrdinalIgnoreCase)
@@ -144,7 +150,7 @@ public class ScipProjectIndexer
         }
         else
         {
-            var symbolFormatter = new ScipDocumentIndexer(doc, options, globals);
+            var symbolFormatter = new ScipDocumentIndexer(doc, options, globals, ExternalSymbols, DefinedSymbols);
             var root = await document.GetSyntaxRootAsync();
             if (language == "C#")
             {

--- a/ScipDotnet/ScipSymbol.cs
+++ b/ScipDotnet/ScipSymbol.cs
@@ -16,6 +16,15 @@ public class ScipSymbol
     public bool IsLocal() =>
         Value.StartsWith("local ");
 
+    // SCIP symbol prefix shared by every global (package-scoped) symbol this tool emits.
+    private const string PackagePrefix = "scip-dotnet nuget ";
+
+    // True if this symbol resolves to a real external NuGet/BCL package, i.e. a global
+    // symbol that is NOT the index-local package placeholder (`scip-dotnet nuget . . `).
+    // These are the symbols that must be declared in Index.external_symbols.
+    public bool IsExternalPackageSymbol() =>
+        Value.StartsWith(PackagePrefix) && !Value.StartsWith(IndexLocalPackage.Value);
+
     public static ScipSymbol Global(ScipSymbol owner, SymbolDescriptor descriptor) =>
         new(owner.Value + DescriptorString(descriptor));
 


### PR DESCRIPTION
<html><head></head><body><h1>Implement <code>external_symbols</code> to fix dangling cross-package references</h1>
<h2>Summary</h2>
<p>This PR populates <code>Index.external_symbols</code> with <code>SymbolInformation</code> for symbols defined in external NuGet/BCL packages that are referenced by indexed source files. Before this change, the field was never written to, which left every cross-package reference orphaned and unusable for code navigation.</p>
<p>Fixes #62. Addresses the user-visible complaint behind #3.</p>
<p>Measured on a real-world .NET 9 + EF Core 9 codebase (1,263 source documents, 361,764 occurrences):</p>

Metric | Before | After
-- | -- | --
scip lint errors | 208,950 | ~23,500
Error rate (over all occurrences) | 59.87% | 6.50%
Error rate excluding index-local namespaces | n/a | 0.08%


<p>The remaining counts are edge cases involving deeper type-graph paths (transitive ancestors of generic constructions). They could be addressed by walking the full transitive hierarchy when collecting from the relationship path, at the cost of larger indexes; this PR keeps the collection one level deep.</p>
<h2>Relationship to existing issues</h2>
<p><strong>#62 "C# indexing doesn't work properly".</strong> Same bug. The maintainer's reproduction on <code>dotnet/eshop</code> shows references to global symbols missing because their <code>SymbolInformation</code> was never written. This PR resolves it.</p>
<p><strong>#3 "Missing System.Runtime core assembly".</strong> The user-visible complaint (BCL navigation broken) is the same and is resolved by this PR. The specific mechanical detail in that issue (the literal <code>&lt;Missing Core Assembly&gt;</code> placeholder) no longer exists in the current code, so #3 partially reflects an older resolution path; the current scip-dotnet resolves <code>System.Runtime</code> identity correctly and only the emission was missing.</p>
<h2>Limitations</h2>
<ol>
<li>The 23,500 residual <code>nuget . .</code> errors (mostly namespaces) are intentionally untouched and need a separate design decision.</li>
<li>Validation on <code>net8.0</code> / <code>net9.0</code> was not performed in this PR; the snapshot suite runs under whichever framework <code>dotnet test</code> selects on the build machine (here, <code>net10.0</code>). The fix is framework-agnostic.</li>
<li>The size impact of including hover documentation on every external symbol was not measured on very large codebases; for the reference project it was within normal variance.</li>
</ol>

