### PR TITLE
Index Razor views and Blazor components

### DIFF
--- a/ScipDotnet.Tests/SnapshotTests.cs
+++ b/ScipDotnet.Tests/SnapshotTests.cs
@@ -47,7 +47,7 @@ public class SnapshotTests
                 RecursivelyListFiles(outputDirectory, absoluteOutputPaths);
                 foreach (var absolutePath in absoluteOutputPaths)
                 {
-                    if (!absolutePath.EndsWith(".cs"))
+                    if (!IsSnapshotFile(absolutePath))
                     {
                         continue;
                     }
@@ -78,6 +78,13 @@ public class SnapshotTests
             });
         }
     }
+
+    /// <summary>
+    /// Razor views (.cshtml) and Blazor components (.razor) are never compiled from disk, the
+    /// Razor source generator feeds them to the compiler, so they have their own snapshots.
+    /// </summary>
+    private static bool IsSnapshotFile(string path) =>
+        path.EndsWith(".cs") || path.EndsWith(".cshtml") || path.EndsWith(".razor");
 
     private static void RecursivelyListFiles(string path, List<string> result)
     {

--- a/ScipDotnet/ScipDocumentIndexer.cs
+++ b/ScipDotnet/ScipDocumentIndexer.cs
@@ -16,6 +16,7 @@ public class ScipDocumentIndexer
     private readonly Dictionary<ISymbol, ScipSymbol> _globals;
     private readonly Dictionary<ISymbol, ScipSymbol> _locals = new(SymbolEqualityComparer.Default);
     private readonly string _markdownCodeFenceLanguage;
+    private readonly string? _originalFilePath;
 
     // Custom formatting options to render symbol documentation. Feel free to tweak these parameters.
     // The options were derived by multiple rounds of experimentation with the goal of striking a
@@ -56,14 +57,22 @@ public class ScipDocumentIndexer
                               SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers
     );
 
+    /// <param name="originalFilePath">
+    /// When non-null, only record the occurrences that <code>#line</code> directives attribute to
+    /// this file. Source generated documents such as the C# that the Razor generator emits for a
+    /// .cshtml file are a mixture of generated boilerplate and code the developer wrote, and only
+    /// the latter belongs in the index.
+    /// </param>
     public ScipDocumentIndexer(
         Document doc,
         IndexCommandOptions options,
-        Dictionary<ISymbol, ScipSymbol> globals)
+        Dictionary<ISymbol, ScipSymbol> globals,
+        string? originalFilePath = null)
     {
         _doc = doc;
         _options = options;
         _globals = globals;
+        _originalFilePath = originalFilePath;
         _markdownCodeFenceLanguage = _doc.Language == "C#" ? "cs" : "vb";
     }
 
@@ -216,6 +225,12 @@ public class ScipDocumentIndexer
     public void VisitOccurrence(ISymbol? symbol, Location location, bool isDefinition)
     {
         if (symbol == null)
+        {
+            return;
+        }
+
+        if (_originalFilePath != null &&
+            !string.Equals(location.GetMappedLineSpan().Path, _originalFilePath, StringComparison.Ordinal))
         {
             return;
         }

--- a/ScipDotnet/ScipProjectIndexer.cs
+++ b/ScipDotnet/ScipProjectIndexer.cs
@@ -120,8 +120,105 @@ public class ScipProjectIndexer
                         document.FilePath);
                 }
             }
+
+            foreach (var document in await IndexSourceGeneratedDocuments(project, options, globals))
+            {
+                yield return document;
+            }
         }
     }
+
+    /// <summary>
+    /// Indexes the documents that the compiler synthesizes instead of reading from disk.
+    /// Razor views (.cshtml) and Blazor components (.razor) enter the compilation this way,
+    /// through the Razor source generator, so <code>project.Documents</code> never sees them.
+    ///
+    /// The generated C# lives under <code>obj/</code> and usually does not exist on disk at all,
+    /// so reporting its path would produce an index full of files nobody can open. Instead we
+    /// follow the <code>#line</code> directives that the generator emits, group the occurrences
+    /// by the original file each one came from and report that file. Occurrences that map to
+    /// generated code rather than to a file the developer wrote are dropped.
+    /// </summary>
+    private async Task<IEnumerable<Scip.Document>> IndexSourceGeneratedDocuments(
+        Project project,
+        IndexCommandOptions options,
+        Dictionary<ISymbol, ScipSymbol> globals)
+    {
+        var documentsByOriginalPath = new Dictionary<string, Scip.Document>();
+        var generatedDocuments = await project.GetSourceGeneratedDocumentsAsync();
+        options.Logger.LogDebug($"Found {generatedDocuments.Count()} source generated documents in {project.FilePath}");
+        foreach (var document in generatedDocuments)
+        {
+            var tree = await document.GetSyntaxTreeAsync();
+            if (tree == null)
+            {
+                continue;
+            }
+
+            foreach (var originalPath in OriginalFilePaths(tree))
+            {
+                if (!options.Matcher.Match(options.WorkingDirectory.FullName, originalPath).HasMatches)
+                {
+                    options.Logger.LogDebug(
+                        "Excluded file path '{FilePath}' because it did not match the provided --include and --exclude arguments",
+                        originalPath);
+                    continue;
+                }
+
+                if (!documentsByOriginalPath.TryGetValue(originalPath, out var doc))
+                {
+                    doc = new Scip.Document
+                    {
+                        Language = project.Language,
+                        RelativePath = Path.GetRelativePath(options.WorkingDirectory.FullName, originalPath)
+                    };
+                    documentsByOriginalPath.Add(originalPath, doc);
+                }
+
+                await WalkDocument(doc, document, options, globals, project.Language, originalPath);
+            }
+        }
+
+        foreach (var doc in documentsByOriginalPath.Values)
+        {
+            RemoveDuplicates(doc);
+        }
+
+        return documentsByOriginalPath.Values;
+    }
+
+    /// <summary>
+    /// Removes the occurrences and symbols that we recorded more than once because several
+    /// generated files attribute the same region of the same original file to themselves.
+    /// </summary>
+    private static void RemoveDuplicates(Scip.Document doc)
+    {
+        var seenOccurrences = new HashSet<string>();
+        var occurrences = doc.Occurrences.Where(occurrence => seenOccurrences.Add(OccurrenceKey(occurrence))).ToList();
+        doc.Occurrences.Clear();
+        doc.Occurrences.AddRange(occurrences);
+
+        var seenSymbols = new HashSet<string>();
+        var symbols = doc.Symbols.Where(symbol => seenSymbols.Add(symbol.Symbol)).ToList();
+        doc.Symbols.Clear();
+        doc.Symbols.AddRange(symbols);
+    }
+
+    private static string OccurrenceKey(Scip.Occurrence occurrence) =>
+        $"{occurrence.Symbol} {occurrence.SymbolRoles} {string.Join(",", occurrence.Range)}";
+
+    /// <summary>
+    /// Returns the files that a generated syntax tree attributes its contents to via
+    /// <code>#line</code> directives. A single generated Razor file can point at more than one
+    /// original file because directives from <code>_ViewImports.cshtml</code> are copied into
+    /// every view that inherits them.
+    /// </summary>
+    private static IEnumerable<string> OriginalFilePaths(SyntaxTree tree) =>
+        tree.GetLineMappings()
+            .Where(mapping => !mapping.IsHidden && mapping.MappedSpan.HasMappedPath)
+            .Select(mapping => mapping.MappedSpan.Path)
+            .Where(path => !string.IsNullOrEmpty(path) && File.Exists(path))
+            .Distinct();
 
     private async Task<Scip.Document> IndexDocument(Document document,
                                                     IndexCommandOptions options,
@@ -135,29 +232,42 @@ public class ScipProjectIndexer
                 ? null
                 : Path.GetRelativePath(options.WorkingDirectory.FullName, document.FilePath)
         };
+        await WalkDocument(doc, document, options, globals, language, originalFilePath: null);
+        return doc;
+    }
+
+    /// <summary>
+    /// Walks <paramref name="document"/> and adds what it finds to <paramref name="doc"/>. When
+    /// <paramref name="originalFilePath"/> is non-null only the occurrences that <code>#line</code>
+    /// directives attribute to that file are recorded.
+    /// </summary>
+    private async Task WalkDocument(Scip.Document doc,
+                                    Document document,
+                                    IndexCommandOptions options,
+                                    Dictionary<ISymbol, ScipSymbol> globals,
+                                    string language,
+                                    string? originalFilePath)
+    {
         var semanticModel = await document.GetSemanticModelAsync();
         if (semanticModel == null)
         {
             Logger.LogWarning(
                 "Skipping document {DocumentFilePath} because document.GetSemanticModelAsync() returned null",
                 document.FilePath);
-        }
-        else
-        {
-            var symbolFormatter = new ScipDocumentIndexer(doc, options, globals);
-            var root = await document.GetSyntaxRootAsync();
-            if (language == "C#")
-            {
-                var walker = new ScipCSharpSyntaxWalker(symbolFormatter, semanticModel);
-                walker.Visit(root);
-            }
-            else if (language == "Visual Basic")
-            {
-                var walker = new ScipVisualBasicSyntaxWalker(symbolFormatter, semanticModel);
-                walker.Visit(root);
-            }
+            return;
         }
 
-        return doc;
+        var symbolFormatter = new ScipDocumentIndexer(doc, options, globals, originalFilePath);
+        var root = await document.GetSyntaxRootAsync();
+        if (language == "C#")
+        {
+            var walker = new ScipCSharpSyntaxWalker(symbolFormatter, semanticModel);
+            walker.Visit(root);
+        }
+        else if (language == "Visual Basic")
+        {
+            var walker = new ScipVisualBasicSyntaxWalker(symbolFormatter, semanticModel);
+            walker.Visit(root);
+        }
     }
 }

--- a/snapshots/input/razor/RazorApp/Components/Counter.razor
+++ b/snapshots/input/razor/RazorApp/Components/Counter.razor
@@ -1,0 +1,12 @@
+<p>Current count: @CurrentCount</p>
+
+<button @onclick="Increment">Click me</button>
+
+@code {
+    private int CurrentCount { get; set; }
+
+    private void Increment()
+    {
+        CurrentCount++;
+    }
+}

--- a/snapshots/input/razor/RazorApp/Components/_Imports.razor
+++ b/snapshots/input/razor/RazorApp/Components/_Imports.razor
@@ -1,0 +1,1 @@
+@using Microsoft.AspNetCore.Components.Web

--- a/snapshots/input/razor/RazorApp/Pages/Index.cshtml
+++ b/snapshots/input/razor/RazorApp/Pages/Index.cshtml
@@ -1,0 +1,14 @@
+@page
+@model IndexModel
+@{
+    ViewData["Title"] = Model.Greeting;
+}
+
+<h1>@Model.Greeting</h1>
+<p>@Model.Shout("world")</p>
+
+@functions {
+    private static string Loud(string text) => text.ToUpperInvariant();
+}
+
+<p>@Loud(Model.Greeting)</p>

--- a/snapshots/input/razor/RazorApp/Pages/Index.cshtml.cs
+++ b/snapshots/input/razor/RazorApp/Pages/Index.cshtml.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace RazorApp.Pages;
+
+public class IndexModel : PageModel
+{
+    public string Greeting { get; set; } = "Hello";
+
+    public string Shout(string name) => $"{Greeting}, {name}!";
+
+    public void OnGet()
+    {
+        Greeting = "Welcome";
+    }
+}

--- a/snapshots/input/razor/RazorApp/Pages/_ViewImports.cshtml
+++ b/snapshots/input/razor/RazorApp/Pages/_ViewImports.cshtml
@@ -1,0 +1,2 @@
+@using RazorApp.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/snapshots/input/razor/RazorApp/Program.cs
+++ b/snapshots/input/razor/RazorApp/Program.cs
@@ -1,0 +1,5 @@
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddRazorPages();
+var app = builder.Build();
+app.MapRazorPages();
+app.Run();

--- a/snapshots/input/razor/RazorApp/RazorApp.csproj
+++ b/snapshots/input/razor/RazorApp/RazorApp.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/snapshots/input/razor/razor.sln
+++ b/snapshots/input/razor/razor.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RazorApp", "RazorApp\RazorApp.csproj", "{2E0B95A8-D543-4F39-8618-4E1BE8AE024B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2E0B95A8-D543-4F39-8618-4E1BE8AE024B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E0B95A8-D543-4F39-8618-4E1BE8AE024B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E0B95A8-D543-4F39-8618-4E1BE8AE024B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2E0B95A8-D543-4F39-8618-4E1BE8AE024B}.Debug|x64.Build.0 = Debug|Any CPU
+		{2E0B95A8-D543-4F39-8618-4E1BE8AE024B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2E0B95A8-D543-4F39-8618-4E1BE8AE024B}.Debug|x86.Build.0 = Debug|Any CPU
+		{2E0B95A8-D543-4F39-8618-4E1BE8AE024B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E0B95A8-D543-4F39-8618-4E1BE8AE024B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E0B95A8-D543-4F39-8618-4E1BE8AE024B}.Release|x64.ActiveCfg = Release|Any CPU
+		{2E0B95A8-D543-4F39-8618-4E1BE8AE024B}.Release|x64.Build.0 = Release|Any CPU
+		{2E0B95A8-D543-4F39-8618-4E1BE8AE024B}.Release|x86.ActiveCfg = Release|Any CPU
+		{2E0B95A8-D543-4F39-8618-4E1BE8AE024B}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/snapshots/output-net10.0/razor/RazorApp/Components/Counter.razor
+++ b/snapshots/output-net10.0/razor/RazorApp/Components/Counter.razor
@@ -1,0 +1,21 @@
+  <p>Current count: @CurrentCount</p>
+//                   ^^^^^^^^^^^^ reference scip-dotnet nuget . . Components/Counter#CurrentCount.
+//                   ^^^^^^^^^^^^^ reference scip-dotnet nuget . . Components/Counter#BuildRenderTree().(__builder)
+//                   ^^^^^^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore.Components 10.0.0.0 Rendering/RenderTreeBuilder#AddContent(+5).
+
+  <button @onclick="Increment">Click me</button>
+//                  ^^^^^^^^^ reference scip-dotnet nuget . . Components/Counter#Increment().
+
+  @code {
+      private int CurrentCount { get; set; }
+//                ^^^^^^^^^^^^ definition scip-dotnet nuget . . Components/Counter#CurrentCount.
+//                             documentation ```cs\nprivate int Counter.CurrentCount { get; set; }\n```
+
+      private void Increment()
+//                 ^^^^^^^^^ definition scip-dotnet nuget . . Components/Counter#Increment().
+//                           documentation ```cs\nprivate void Counter.Increment()\n```
+      {
+          CurrentCount++;
+//        ^^^^^^^^^^^^ reference scip-dotnet nuget . . Components/Counter#CurrentCount.
+      }
+  }

--- a/snapshots/output-net10.0/razor/RazorApp/Components/_Imports.razor
+++ b/snapshots/output-net10.0/razor/RazorApp/Components/_Imports.razor
@@ -1,0 +1,5 @@
+  @using Microsoft.AspNetCore.Components.Web
+//       ^^^^^^^^^ reference scip-dotnet nuget . . Microsoft/
+//                 ^^^^^^^^^^ reference scip-dotnet nuget . . AspNetCore/
+//                            ^^^^^^^^^^ reference scip-dotnet nuget . . Components/
+//                                       ^^^ reference scip-dotnet nuget . . Web/

--- a/snapshots/output-net10.0/razor/RazorApp/Pages/Index.cshtml
+++ b/snapshots/output-net10.0/razor/RazorApp/Pages/Index.cshtml
@@ -1,0 +1,31 @@
+  @page
+  @model IndexModel
+//       ^^^^^^^^^^ reference scip-dotnet nuget . . Pages/IndexModel#
+  @{
+      ViewData["Title"] = Model.Greeting;
+//    ^^^^^^^^ reference scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#ViewData.
+//                        ^^^^^ reference scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Model.
+//                              ^^^^^^^^ reference scip-dotnet nuget . . Pages/IndexModel#Greeting.
+  }
+
+  <h1>@Model.Greeting</h1>
+//     ^^^^^ reference scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Model.
+//           ^^^^^^^^ reference scip-dotnet nuget . . Pages/IndexModel#Greeting.
+  <p>@Model.Shout("world")</p>
+//    ^^^^^ reference scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Model.
+//          ^^^^^ reference scip-dotnet nuget . . Pages/IndexModel#Shout().
+
+  @functions {
+      private static string Loud(string text) => text.ToUpperInvariant();
+//                          ^^^^ definition scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Loud().
+//                               documentation ```cs\nprivate static string Pages_Index.Loud(string text)\n```
+//                                      ^^^^ definition scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Loud().(text)
+//                                           documentation ```cs\nstring text\n```
+//                                               ^^^^ reference scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Loud().(text)
+//                                                    ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 10.0.0.0 System/String#ToUpperInvariant().
+  }
+
+  <p>@Loud(Model.Greeting)</p>
+//    ^^^^ reference scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Loud().
+//         ^^^^^ reference scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Model.
+//               ^^^^^^^^ reference scip-dotnet nuget . . Pages/IndexModel#Greeting.

--- a/snapshots/output-net10.0/razor/RazorApp/Pages/Index.cshtml.cs
+++ b/snapshots/output-net10.0/razor/RazorApp/Pages/Index.cshtml.cs
@@ -1,0 +1,39 @@
+  using Microsoft.AspNetCore.Mvc.RazorPages;
+//      ^^^^^^^^^ reference scip-dotnet nuget . . Microsoft/
+//                ^^^^^^^^^^ reference scip-dotnet nuget . . AspNetCore/
+//                           ^^^ reference scip-dotnet nuget . . Mvc/
+//                               ^^^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore.Mvc.RazorPages 10.0.0.0 RazorPages/
+
+  namespace RazorApp.Pages;
+//          ^^^^^^^^ reference scip-dotnet nuget . . RazorApp/
+//                   ^^^^^ reference scip-dotnet nuget . . Pages/
+
+  public class IndexModel : PageModel
+//             ^^^^^^^^^^ definition scip-dotnet nuget . . Pages/IndexModel#
+//                        documentation ```cs\nclass IndexModel\n```
+//                        relationship implementation scip-dotnet nuget Microsoft.AspNetCore.Mvc.RazorPages 10.0.0.0 RazorPages/PageModel#
+//                        relationship implementation scip-dotnet nuget Microsoft.AspNetCore.Mvc.RazorPages 10.0.0.0 Filters/IAsyncPageFilter#
+//                        relationship implementation scip-dotnet nuget Microsoft.AspNetCore.Mvc.RazorPages 10.0.0.0 Filters/IPageFilter#
+//                        relationship implementation scip-dotnet nuget Microsoft.AspNetCore.Mvc.Abstractions 10.0.0.0 Filters/IFilterMetadata#
+//                          ^^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore.Mvc.RazorPages 10.0.0.0 RazorPages/PageModel#
+  {
+      public string Greeting { get; set; } = "Hello";
+//                  ^^^^^^^^ definition scip-dotnet nuget . . Pages/IndexModel#Greeting.
+//                           documentation ```cs\npublic string IndexModel.Greeting { get; set; }\n```
+
+      public string Shout(string name) => $"{Greeting}, {name}!";
+//                  ^^^^^ definition scip-dotnet nuget . . Pages/IndexModel#Shout().
+//                        documentation ```cs\npublic string IndexModel.Shout(string name)\n```
+//                               ^^^^ definition scip-dotnet nuget . . Pages/IndexModel#Shout().(name)
+//                                    documentation ```cs\nstring name\n```
+//                                           ^^^^^^^^ reference scip-dotnet nuget . . Pages/IndexModel#Greeting.
+//                                                       ^^^^ reference scip-dotnet nuget . . Pages/IndexModel#Shout().(name)
+
+      public void OnGet()
+//                ^^^^^ definition scip-dotnet nuget . . Pages/IndexModel#OnGet().
+//                      documentation ```cs\npublic void IndexModel.OnGet()\n```
+      {
+          Greeting = "Welcome";
+//        ^^^^^^^^ reference scip-dotnet nuget . . Pages/IndexModel#Greeting.
+      }
+  }

--- a/snapshots/output-net10.0/razor/RazorApp/Pages/_ViewImports.cshtml
+++ b/snapshots/output-net10.0/razor/RazorApp/Pages/_ViewImports.cshtml
@@ -1,0 +1,4 @@
+  @using RazorApp.Pages
+//       ^^^^^^^^ reference scip-dotnet nuget . . RazorApp/
+//                ^^^^^ reference scip-dotnet nuget . . Pages/
+  @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/snapshots/output-net10.0/razor/RazorApp/Program.cs
+++ b/snapshots/output-net10.0/razor/RazorApp/Program.cs
@@ -1,0 +1,21 @@
+  var builder = WebApplication.CreateBuilder(args);
+//    ^^^^^^^ definition local 0
+//            documentation ```cs\nWebApplicationBuilder? builder\n```
+//              ^^^^^^^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore 10.0.0.0 Builder/WebApplication#
+//                             ^^^^^^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore 10.0.0.0 Builder/WebApplication#CreateBuilder(+1).
+//                                           ^^^^ reference scip-dotnet nuget . . ``/Program#`<Main>$`().(args)
+  builder.Services.AddRazorPages();
+//^^^^^^^ reference local 0
+//        ^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore 10.0.0.0 Builder/WebApplicationBuilder#Services.
+//                 ^^^^^^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore.Mvc 10.0.0.0 DependencyInjection/MvcServiceCollectionExtensions#AddRazorPages().
+  var app = builder.Build();
+//    ^^^ definition local 1
+//        documentation ```cs\nWebApplication? app\n```
+//          ^^^^^^^ reference local 0
+//                  ^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore 10.0.0.0 Builder/WebApplicationBuilder#Build().
+  app.MapRazorPages();
+//^^^ reference local 1
+//    ^^^^^^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore.Mvc.RazorPages 10.0.0.0 Builder/RazorPagesEndpointRouteBuilderExtensions#MapRazorPages().
+  app.Run();
+//^^^ reference local 1
+//    ^^^ reference scip-dotnet nuget Microsoft.AspNetCore 10.0.0.0 Builder/WebApplication#Run().

--- a/snapshots/output-net8.0/razor/RazorApp/Components/Counter.razor
+++ b/snapshots/output-net8.0/razor/RazorApp/Components/Counter.razor
@@ -1,0 +1,21 @@
+  <p>Current count: @CurrentCount</p>
+//                   ^^^^^^^^^^^^ reference scip-dotnet nuget . . Components/Counter#CurrentCount.
+//                   ^^^^^^^^^^^^^ reference scip-dotnet nuget . . Components/Counter#BuildRenderTree().(__builder)
+//                   ^^^^^^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore.Components 8.0.0.0 Rendering/RenderTreeBuilder#AddContent(+5).
+
+  <button @onclick="Increment">Click me</button>
+//                  ^^^^^^^^^ reference scip-dotnet nuget . . Components/Counter#Increment().
+
+  @code {
+      private int CurrentCount { get; set; }
+//                ^^^^^^^^^^^^ definition scip-dotnet nuget . . Components/Counter#CurrentCount.
+//                             documentation ```cs\nprivate int Counter.CurrentCount { get; set; }\n```
+
+      private void Increment()
+//                 ^^^^^^^^^ definition scip-dotnet nuget . . Components/Counter#Increment().
+//                           documentation ```cs\nprivate void Counter.Increment()\n```
+      {
+          CurrentCount++;
+//        ^^^^^^^^^^^^ reference scip-dotnet nuget . . Components/Counter#CurrentCount.
+      }
+  }

--- a/snapshots/output-net8.0/razor/RazorApp/Components/_Imports.razor
+++ b/snapshots/output-net8.0/razor/RazorApp/Components/_Imports.razor
@@ -1,0 +1,5 @@
+  @using Microsoft.AspNetCore.Components.Web
+//       ^^^^^^^^^ reference scip-dotnet nuget . . Microsoft/
+//                 ^^^^^^^^^^ reference scip-dotnet nuget . . AspNetCore/
+//                            ^^^^^^^^^^ reference scip-dotnet nuget . . Components/
+//                                       ^^^ reference scip-dotnet nuget . . Web/

--- a/snapshots/output-net8.0/razor/RazorApp/Pages/Index.cshtml
+++ b/snapshots/output-net8.0/razor/RazorApp/Pages/Index.cshtml
@@ -1,0 +1,30 @@
+  @page
+  @model IndexModel
+  @{
+      ViewData["Title"] = Model.Greeting;
+//    ^^^^^^^^ reference scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#ViewData.
+//                        ^^^^^ reference scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Model.
+//                              ^^^^^^^^ reference scip-dotnet nuget . . Pages/IndexModel#Greeting.
+  }
+
+  <h1>@Model.Greeting</h1>
+//     ^^^^^ reference scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Model.
+//           ^^^^^^^^ reference scip-dotnet nuget . . Pages/IndexModel#Greeting.
+  <p>@Model.Shout("world")</p>
+//    ^^^^^ reference scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Model.
+//          ^^^^^ reference scip-dotnet nuget . . Pages/IndexModel#Shout().
+
+  @functions {
+      private static string Loud(string text) => text.ToUpperInvariant();
+//                          ^^^^ definition scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Loud().
+//                               documentation ```cs\nprivate static string Pages_Index.Loud(string text)\n```
+//                                      ^^^^ definition scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Loud().(text)
+//                                           documentation ```cs\nstring text\n```
+//                                               ^^^^ reference scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Loud().(text)
+//                                                    ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 8.0.0.0 System/String#ToUpperInvariant().
+  }
+
+  <p>@Loud(Model.Greeting)</p>
+//    ^^^^ reference scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Loud().
+//         ^^^^^ reference scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Model.
+//               ^^^^^^^^ reference scip-dotnet nuget . . Pages/IndexModel#Greeting.

--- a/snapshots/output-net8.0/razor/RazorApp/Pages/Index.cshtml.cs
+++ b/snapshots/output-net8.0/razor/RazorApp/Pages/Index.cshtml.cs
@@ -1,0 +1,39 @@
+  using Microsoft.AspNetCore.Mvc.RazorPages;
+//      ^^^^^^^^^ reference scip-dotnet nuget . . Microsoft/
+//                ^^^^^^^^^^ reference scip-dotnet nuget . . AspNetCore/
+//                           ^^^ reference scip-dotnet nuget . . Mvc/
+//                               ^^^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore.Mvc.RazorPages 8.0.0.0 RazorPages/
+
+  namespace RazorApp.Pages;
+//          ^^^^^^^^ reference scip-dotnet nuget . . RazorApp/
+//                   ^^^^^ reference scip-dotnet nuget . . Pages/
+
+  public class IndexModel : PageModel
+//             ^^^^^^^^^^ definition scip-dotnet nuget . . Pages/IndexModel#
+//                        documentation ```cs\nclass IndexModel\n```
+//                        relationship implementation scip-dotnet nuget Microsoft.AspNetCore.Mvc.RazorPages 8.0.0.0 RazorPages/PageModel#
+//                        relationship implementation scip-dotnet nuget Microsoft.AspNetCore.Mvc.RazorPages 8.0.0.0 Filters/IAsyncPageFilter#
+//                        relationship implementation scip-dotnet nuget Microsoft.AspNetCore.Mvc.RazorPages 8.0.0.0 Filters/IPageFilter#
+//                        relationship implementation scip-dotnet nuget Microsoft.AspNetCore.Mvc.Abstractions 8.0.0.0 Filters/IFilterMetadata#
+//                          ^^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore.Mvc.RazorPages 8.0.0.0 RazorPages/PageModel#
+  {
+      public string Greeting { get; set; } = "Hello";
+//                  ^^^^^^^^ definition scip-dotnet nuget . . Pages/IndexModel#Greeting.
+//                           documentation ```cs\npublic string IndexModel.Greeting { get; set; }\n```
+
+      public string Shout(string name) => $"{Greeting}, {name}!";
+//                  ^^^^^ definition scip-dotnet nuget . . Pages/IndexModel#Shout().
+//                        documentation ```cs\npublic string IndexModel.Shout(string name)\n```
+//                               ^^^^ definition scip-dotnet nuget . . Pages/IndexModel#Shout().(name)
+//                                    documentation ```cs\nstring name\n```
+//                                           ^^^^^^^^ reference scip-dotnet nuget . . Pages/IndexModel#Greeting.
+//                                                       ^^^^ reference scip-dotnet nuget . . Pages/IndexModel#Shout().(name)
+
+      public void OnGet()
+//                ^^^^^ definition scip-dotnet nuget . . Pages/IndexModel#OnGet().
+//                      documentation ```cs\npublic void IndexModel.OnGet()\n```
+      {
+          Greeting = "Welcome";
+//        ^^^^^^^^ reference scip-dotnet nuget . . Pages/IndexModel#Greeting.
+      }
+  }

--- a/snapshots/output-net8.0/razor/RazorApp/Pages/_ViewImports.cshtml
+++ b/snapshots/output-net8.0/razor/RazorApp/Pages/_ViewImports.cshtml
@@ -1,0 +1,4 @@
+  @using RazorApp.Pages
+//       ^^^^^^^^ reference scip-dotnet nuget . . RazorApp/
+//                ^^^^^ reference scip-dotnet nuget . . Pages/
+  @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/snapshots/output-net8.0/razor/RazorApp/Program.cs
+++ b/snapshots/output-net8.0/razor/RazorApp/Program.cs
@@ -1,0 +1,21 @@
+  var builder = WebApplication.CreateBuilder(args);
+//    ^^^^^^^ definition local 0
+//            documentation ```cs\nWebApplicationBuilder? builder\n```
+//              ^^^^^^^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore 8.0.0.0 Builder/WebApplication#
+//                             ^^^^^^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore 8.0.0.0 Builder/WebApplication#CreateBuilder(+1).
+//                                           ^^^^ reference scip-dotnet nuget . . ``/Program#`<Main>$`().(args)
+  builder.Services.AddRazorPages();
+//^^^^^^^ reference local 0
+//        ^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore 8.0.0.0 Builder/WebApplicationBuilder#Services.
+//                 ^^^^^^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore.Mvc 8.0.0.0 DependencyInjection/MvcServiceCollectionExtensions#AddRazorPages().
+  var app = builder.Build();
+//    ^^^ definition local 1
+//        documentation ```cs\nWebApplication? app\n```
+//          ^^^^^^^ reference local 0
+//                  ^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore 8.0.0.0 Builder/WebApplicationBuilder#Build().
+  app.MapRazorPages();
+//^^^ reference local 1
+//    ^^^^^^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore.Mvc.RazorPages 8.0.0.0 Builder/RazorPagesEndpointRouteBuilderExtensions#MapRazorPages().
+  app.Run();
+//^^^ reference local 1
+//    ^^^ reference scip-dotnet nuget Microsoft.AspNetCore 8.0.0.0 Builder/WebApplication#Run().

--- a/snapshots/output-net9.0/razor/RazorApp/Components/Counter.razor
+++ b/snapshots/output-net9.0/razor/RazorApp/Components/Counter.razor
@@ -1,0 +1,21 @@
+  <p>Current count: @CurrentCount</p>
+//                   ^^^^^^^^^^^^ reference scip-dotnet nuget . . Components/Counter#CurrentCount.
+//                   ^^^^^^^^^^^^^ reference scip-dotnet nuget . . Components/Counter#BuildRenderTree().(__builder)
+//                   ^^^^^^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore.Components 9.0.0.0 Rendering/RenderTreeBuilder#AddContent(+5).
+
+  <button @onclick="Increment">Click me</button>
+//                  ^^^^^^^^^ reference scip-dotnet nuget . . Components/Counter#Increment().
+
+  @code {
+      private int CurrentCount { get; set; }
+//                ^^^^^^^^^^^^ definition scip-dotnet nuget . . Components/Counter#CurrentCount.
+//                             documentation ```cs\nprivate int Counter.CurrentCount { get; set; }\n```
+
+      private void Increment()
+//                 ^^^^^^^^^ definition scip-dotnet nuget . . Components/Counter#Increment().
+//                           documentation ```cs\nprivate void Counter.Increment()\n```
+      {
+          CurrentCount++;
+//        ^^^^^^^^^^^^ reference scip-dotnet nuget . . Components/Counter#CurrentCount.
+      }
+  }

--- a/snapshots/output-net9.0/razor/RazorApp/Components/_Imports.razor
+++ b/snapshots/output-net9.0/razor/RazorApp/Components/_Imports.razor
@@ -1,0 +1,5 @@
+  @using Microsoft.AspNetCore.Components.Web
+//       ^^^^^^^^^ reference scip-dotnet nuget . . Microsoft/
+//                 ^^^^^^^^^^ reference scip-dotnet nuget . . AspNetCore/
+//                            ^^^^^^^^^^ reference scip-dotnet nuget . . Components/
+//                                       ^^^ reference scip-dotnet nuget . . Web/

--- a/snapshots/output-net9.0/razor/RazorApp/Pages/Index.cshtml
+++ b/snapshots/output-net9.0/razor/RazorApp/Pages/Index.cshtml
@@ -1,0 +1,31 @@
+  @page
+  @model IndexModel
+//       ^^^^^^^^^^ reference scip-dotnet nuget . . Pages/IndexModel#
+  @{
+      ViewData["Title"] = Model.Greeting;
+//    ^^^^^^^^ reference scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#ViewData.
+//                        ^^^^^ reference scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Model.
+//                              ^^^^^^^^ reference scip-dotnet nuget . . Pages/IndexModel#Greeting.
+  }
+
+  <h1>@Model.Greeting</h1>
+//     ^^^^^ reference scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Model.
+//           ^^^^^^^^ reference scip-dotnet nuget . . Pages/IndexModel#Greeting.
+  <p>@Model.Shout("world")</p>
+//    ^^^^^ reference scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Model.
+//          ^^^^^ reference scip-dotnet nuget . . Pages/IndexModel#Shout().
+
+  @functions {
+      private static string Loud(string text) => text.ToUpperInvariant();
+//                          ^^^^ definition scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Loud().
+//                               documentation ```cs\nprivate static string Pages_Index.Loud(string text)\n```
+//                                      ^^^^ definition scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Loud().(text)
+//                                           documentation ```cs\nstring text\n```
+//                                               ^^^^ reference scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Loud().(text)
+//                                                    ^^^^^^^^^^^^^^^^ reference scip-dotnet nuget System.Runtime 9.0.0.0 System/String#ToUpperInvariant().
+  }
+
+  <p>@Loud(Model.Greeting)</p>
+//    ^^^^ reference scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Loud().
+//         ^^^^^ reference scip-dotnet nuget . . AspNetCoreGeneratedDocument/Pages_Index#Model.
+//               ^^^^^^^^ reference scip-dotnet nuget . . Pages/IndexModel#Greeting.

--- a/snapshots/output-net9.0/razor/RazorApp/Pages/Index.cshtml.cs
+++ b/snapshots/output-net9.0/razor/RazorApp/Pages/Index.cshtml.cs
@@ -1,0 +1,39 @@
+  using Microsoft.AspNetCore.Mvc.RazorPages;
+//      ^^^^^^^^^ reference scip-dotnet nuget . . Microsoft/
+//                ^^^^^^^^^^ reference scip-dotnet nuget . . AspNetCore/
+//                           ^^^ reference scip-dotnet nuget . . Mvc/
+//                               ^^^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore.Mvc.RazorPages 9.0.0.0 RazorPages/
+
+  namespace RazorApp.Pages;
+//          ^^^^^^^^ reference scip-dotnet nuget . . RazorApp/
+//                   ^^^^^ reference scip-dotnet nuget . . Pages/
+
+  public class IndexModel : PageModel
+//             ^^^^^^^^^^ definition scip-dotnet nuget . . Pages/IndexModel#
+//                        documentation ```cs\nclass IndexModel\n```
+//                        relationship implementation scip-dotnet nuget Microsoft.AspNetCore.Mvc.RazorPages 9.0.0.0 RazorPages/PageModel#
+//                        relationship implementation scip-dotnet nuget Microsoft.AspNetCore.Mvc.RazorPages 9.0.0.0 Filters/IAsyncPageFilter#
+//                        relationship implementation scip-dotnet nuget Microsoft.AspNetCore.Mvc.RazorPages 9.0.0.0 Filters/IPageFilter#
+//                        relationship implementation scip-dotnet nuget Microsoft.AspNetCore.Mvc.Abstractions 9.0.0.0 Filters/IFilterMetadata#
+//                          ^^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore.Mvc.RazorPages 9.0.0.0 RazorPages/PageModel#
+  {
+      public string Greeting { get; set; } = "Hello";
+//                  ^^^^^^^^ definition scip-dotnet nuget . . Pages/IndexModel#Greeting.
+//                           documentation ```cs\npublic string IndexModel.Greeting { get; set; }\n```
+
+      public string Shout(string name) => $"{Greeting}, {name}!";
+//                  ^^^^^ definition scip-dotnet nuget . . Pages/IndexModel#Shout().
+//                        documentation ```cs\npublic string IndexModel.Shout(string name)\n```
+//                               ^^^^ definition scip-dotnet nuget . . Pages/IndexModel#Shout().(name)
+//                                    documentation ```cs\nstring name\n```
+//                                           ^^^^^^^^ reference scip-dotnet nuget . . Pages/IndexModel#Greeting.
+//                                                       ^^^^ reference scip-dotnet nuget . . Pages/IndexModel#Shout().(name)
+
+      public void OnGet()
+//                ^^^^^ definition scip-dotnet nuget . . Pages/IndexModel#OnGet().
+//                      documentation ```cs\npublic void IndexModel.OnGet()\n```
+      {
+          Greeting = "Welcome";
+//        ^^^^^^^^ reference scip-dotnet nuget . . Pages/IndexModel#Greeting.
+      }
+  }

--- a/snapshots/output-net9.0/razor/RazorApp/Pages/_ViewImports.cshtml
+++ b/snapshots/output-net9.0/razor/RazorApp/Pages/_ViewImports.cshtml
@@ -1,0 +1,4 @@
+  @using RazorApp.Pages
+//       ^^^^^^^^ reference scip-dotnet nuget . . RazorApp/
+//                ^^^^^ reference scip-dotnet nuget . . Pages/
+  @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/snapshots/output-net9.0/razor/RazorApp/Program.cs
+++ b/snapshots/output-net9.0/razor/RazorApp/Program.cs
@@ -1,0 +1,21 @@
+  var builder = WebApplication.CreateBuilder(args);
+//    ^^^^^^^ definition local 0
+//            documentation ```cs\nWebApplicationBuilder? builder\n```
+//              ^^^^^^^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore 9.0.0.0 Builder/WebApplication#
+//                             ^^^^^^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore 9.0.0.0 Builder/WebApplication#CreateBuilder(+1).
+//                                           ^^^^ reference scip-dotnet nuget . . ``/Program#`<Main>$`().(args)
+  builder.Services.AddRazorPages();
+//^^^^^^^ reference local 0
+//        ^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore 9.0.0.0 Builder/WebApplicationBuilder#Services.
+//                 ^^^^^^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore.Mvc 9.0.0.0 DependencyInjection/MvcServiceCollectionExtensions#AddRazorPages().
+  var app = builder.Build();
+//    ^^^ definition local 1
+//        documentation ```cs\nWebApplication? app\n```
+//          ^^^^^^^ reference local 0
+//                  ^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore 9.0.0.0 Builder/WebApplicationBuilder#Build().
+  app.MapRazorPages();
+//^^^ reference local 1
+//    ^^^^^^^^^^^^^ reference scip-dotnet nuget Microsoft.AspNetCore.Mvc.RazorPages 9.0.0.0 Builder/RazorPagesEndpointRouteBuilderExtensions#MapRazorPages().
+  app.Run();
+//^^^ reference local 1
+//    ^^^ reference scip-dotnet nuget Microsoft.AspNetCore 9.0.0.0 Builder/WebApplication#Run().


### PR DESCRIPTION
Addresses #61.

### The problem

`ScipProjectIndexer` iterates `project.Documents`, which is the set of files the compiler reads from disk. Razor views (`.cshtml`) and Blazor components (`.razor`) never reach the compiler that way. The Razor source generator turns them into C# and hands them straight to the compilation, so they live behind `Project.GetSourceGeneratedDocumentsAsync` and the indexer has never seen them.

Measured on freshly scaffolded apps against `main` at 4788446:

| | `dotnet new webapp` | `dotnet new blazor` |
|---|---|---|
| Razor files on disk | 7 `.cshtml` | 11 `.razor` |
| Documents in `index.scip` | 0 | 0 |

On #61 the reply was "Razor templates don't seem to be supported, Blazor should be supported. If you have an example of it not working, please provide a reproducer." The second column is that reproducer: a stock `dotnet new blazor` yields zero `.razor` documents today. Steps to reproduce are in the linked write-up.

That thread also said "We'll be happy to review a PR adding this feature", which is what this is.

### Why the obvious fix is not enough

Adding the source-generated documents to the existing loop produces an index full of paths like

```
obj/Debug/net10.0/Microsoft.CodeAnalysis.Razor.Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator/Pages_Index_cshtml.g.cs
```

which do not exist on disk unless `EmitCompilerGeneratedFiles` is set, are excluded the moment anyone passes `--exclude '**/obj/**'`, and mix generated boilerplate in with the developer's code.

### What this does

1. `IndexSourceGeneratedDocuments` enumerates the generated documents per project and, for each, uses `SyntaxTree.GetLineMappings` to find which real files its `#line` directives point at. One SCIP `Document` is created per original file, and `--include` / `--exclude` are matched against that path.
2. `ScipDocumentIndexer` takes an optional `originalFilePath` and records only the occurrences whose `GetMappedLineSpan().Path` matches it, so generated boilerplate is dropped and the developer's code keeps the line and column numbers it has in the `.cshtml`. `LocationToRange` already called `GetMappedLineSpan`, so the ranges were always correct once the document was.
3. `RemoveDuplicates` collapses identical occurrences, which is needed because `_ViewImports.cshtml` and `_Imports.razor` are folded into the generated file of every view that inherits them.

Result on the same two apps: 6 `.cshtml` documents with 17 occurrences, and 11 `.razor` documents with 153 occurrences. The seventh `.cshtml`, `_ValidationScriptsPartial.cshtml`, contains no C#, so there is nothing in it to index. No measurable change in indexing time.

### Tests

A new snapshot fixture, `snapshots/input/razor`, covering a Razor Page with `@model`, `@functions` and inline expressions, a `_ViewImports.cshtml`, a Blazor component with `@code`, and an `_Imports.razor`, with expected output for net8.0, net9.0 and net10.0.

`SnapshotTests` previously only compared expected-output files ending in `.cs`, so Razor snapshots would have been written and never asserted on. `IsSnapshotFile` widens that to `.cshtml` and `.razor`.

All existing snapshots are byte-identical after the change on all three target frameworks, and `dotnet format --verify-no-changes` is clean.

### Provenance and licensing

This came out of [vela](https://github.com/dbhq-uk/vela-skill), a local code index for .NET that reached the same conclusion independently and has been running the source-generated-document approach against a 375,608-line solution with 307 Razor views. The full working notes, including the measurements above and how to reproduce them, are at [docs/upstream/scip-dotnet-razor.md](https://github.com/dbhq-uk/vela-skill/blob/main/docs/upstream/scip-dotnet-razor.md).

The approach was reimplemented for this codebase rather than copied: vela is MIT, scip-dotnet is Apache 2.0, and this contribution is offered under Apache 2.0 on the inbound-equals-outbound terms in section 5 of that licence.

### What has not been checked

Only exercised on Linux. The CI matrix also covers Windows and macOS, where the path comparison in `VisitOccurrence` uses `StringComparison.Ordinal` against a path Roslyn produced from a `#line` directive Roslyn also produced. Both sides originate from the same string, so they should match, but that is reasoning rather than a measurement.

No Razor Class Library and no MVC `Views/` layout were tested. Razor Pages and Blazor were.
